### PR TITLE
Add Reset button to login screen 

### DIFF
--- a/backend/python/app/rest/auth_routes.py
+++ b/backend/python/app/rest/auth_routes.py
@@ -95,7 +95,6 @@ def logout(user_id):
 @blueprint.route(
     "/resetPassword/<string:email>", methods=["POST"], strict_slashes=False
 )
-@require_authorization_by_email("email")
 def reset_password(email):
     """
     Triggers password reset for user with specified email (reset link will be emailed)

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useState } from "react";
 import { Redirect } from "react-router-dom";
 import authAPIClient from "../../APIClients/AuthAPIClient";
 import AuthContext, { AuthenticatedUser } from "../../contexts/AuthContext";
+import ResetPassword from "./ResetPassword";
 
 const Login = () => {
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);
@@ -45,6 +46,7 @@ const Login = () => {
           >
             Log In
           </button>
+          <ResetPassword email={email} />
         </div>
       </form>
     </div>

--- a/frontend/src/components/auth/ResetPassword.tsx
+++ b/frontend/src/components/auth/ResetPassword.tsx
@@ -2,11 +2,30 @@ import React, { useContext } from "react";
 import authAPIClient from "../../APIClients/AuthAPIClient";
 import AuthContext from "../../contexts/AuthContext";
 
-const ResetPassword = () => {
+interface ResetPasswordProps {
+  email?: string;
+}
+
+const ResetPassword = ({ email }: ResetPasswordProps) => {
   const { authenticatedUser } = useContext(AuthContext);
 
+  const isRealEmailAvailable = (emailString: string): boolean => {
+    const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return re.test(String(emailString).toLowerCase());
+  };
+
   const onResetPasswordClick = async () => {
-    await authAPIClient.resetPassword(authenticatedUser?.email);
+    if (authenticatedUser == null && !isRealEmailAvailable(email!)) {
+      alert("invalid email");
+      return;
+    }
+    const resetEmail = authenticatedUser?.email ?? email;
+    if (await authAPIClient.resetPassword(resetEmail)) {
+      alert(`Reset email sent to ${resetEmail}`);
+    } else {
+      alert(`Unsuccessful attempt to send reset email. 
+        Check that email is correct.`);
+    }
   };
 
   return (
@@ -18,6 +37,10 @@ const ResetPassword = () => {
       Reset Password
     </button>
   );
+};
+
+ResetPassword.defaultProps = {
+  email: "",
 };
 
 export default ResetPassword;


### PR DESCRIPTION
## Notion ticket link
[Allow users to reset their password](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=4a47edc475b34bb99b25ff1fae2a5507&p=92887fb5e64845e882c4c79a97a18ff6)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add reset button to home screen
* Implement basic logic for parsing email string
* Create alerts based on whether the reset email was successfully sent
* Remove authentication requirement that was needed to send reset email

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Try to reset password from login page with legitimate email form (eg. `test@gmail.com`), random string (eg. `potato`), and real email (eg. `planetread+user@uwblueprint.org`). Should receive email for the latter
2. Login fully and try to reset password, make sure it still works 
![3407185f-bcbc-4c57-bc7d-cc75201615f5](https://user-images.githubusercontent.com/40974372/118602747-0eafd280-b781-11eb-9524-094ebc1bbb71.gif)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* What UI cue are we expecting? This is super, super minimal
* Test coverage suggestions please :)) 

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
