### PR TITLE
Migrate get_users endpoint to GraphQL resolver

### DIFF
--- a/backend/python/app/graphql/queries/user_query.py
+++ b/backend/python/app/graphql/queries/user_query.py
@@ -1,11 +1,21 @@
 from ..service import services
 
-def resolve_users(root, info, **kwargs):
-    return services['user'].get_users()
 
-'''
+def resolve_users(root, info, **kwargs):
+    return services["user"].get_users()
+
+
+def resolve_user_by_id(root, info, id):
+    return services["user"].get_user_by_id(id)
+
+
+def resolve_user_by_email(root, info, email):
+    return services["user"].get_user_by_email(email)
+
+
+"""
 Required queries:
  userById(id: ID!): UserDTO!
  userByEmail(email: String!): UserDTO!
  users: [UserDTO!]!user
-'''
+"""

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -4,22 +4,33 @@ from .mutations.entity_mutation import CreateEntity
 from .mutations.user_mutation import CreateUser
 from .service import services
 from .queries.entity_query import resolve_entities
-from .queries.user_query import resolve_users
+from .queries.user_query import resolve_users, resolve_user_by_id, resolve_user_by_email
 
 import graphene
+
 
 class Mutation(graphene.ObjectType):
     create_entity = CreateEntity.Field()
     create_user = CreateUser.Field()
-     
+
+
 class Query(graphene.ObjectType):
     entities = graphene.Field(graphene.List(EntityResponseDTO))
-    users = graphene.Field(graphene.List(UserDTO))  
-    
+    users = graphene.Field(graphene.List(UserDTO))
+    user_by_id = graphene.Field(UserDTO, id=graphene.Int())
+    user_by_email = graphene.Field(UserDTO, email=graphene.String())
+
     def resolve_entities(root, info, **kwargs):
         return resolve_entities(root, info, **kwargs)
 
     def resolve_users(root, info, **kwargs):
         return resolve_users(root, info, **kwargs)
+
+    def resolve_user_by_id(root, info, id):
+        return resolve_user_by_id(root, info, id)
+
+    def resolve_user_by_email(root, info, email):
+        return resolve_user_by_email(root, info, email)
+
 
 schema = graphene.Schema(query=Query, mutation=Mutation)


### PR DESCRIPTION
## Notion ticket link
[Migrate get_users endpoint to GraphQL resolver](https://www.notion.so/uwblueprintexecs/Migrate-get_users-endpoint-to-GraphQL-resolver-460b7d7bb2b0429190163f6f7baf954d)


## Implementation description
* add `resolve_user_by_id` and `resolve_user_by_email` to `graphql/queries/user_query.py`
* add calls to `resolve_user_by_id` and `resolve_user_by_email` to `graphql/schema.py`


## Steps to test
1. Start up the backend
2. Ensure the database has existing users; otherwise seed database with users:
```
$ planet-read_db_1 psql -U postgres -d planet-read
$ \dt
```
>> if no tables present, change the `erase_db_and_sync` = `False` to `True` in `backend/python/app/models/__init__.py`
```
$ SELECT * FROM users;
```
>> if empty, insert users into the database
```
$ INSERT INTO users (first_name, last_name, auth_id, role) VALUES ('First', 'Last', 'insert-firebase-uid', 'Admin');
```
3. Go to `localhost:5000/graphql` and verify the response of the following requests returns the corresponding users that were queried:
```
{
  userById(id: <valid id of user as int>) {
    id
    firstName
    lastName
    role
    email
  }
  userByEmail(email: <valid email address of a user as string>) {
    id
    firstName
    lastName
    role
    email
  }
}
```

## What should reviewers focus on?
* `graphql/queries/user_query.py`
* `graphql/schema.py`
* files were formatted with black--is this the linter we want to use? it added a bunch of spaces+line breaks throughout the file

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
