### PR TITLE
Migrate reset password endpoint to GraphQL

### DIFF
--- a/backend/python/app/graphql/__init__.py
+++ b/backend/python/app/graphql/__init__.py
@@ -1,8 +1,11 @@
+import os
+
 from flask import current_app
 from flask_graphql import GraphQLView
 
 from ..models import db
 from ..services.implementations.entity_service import EntityService
+from ..services.implementations.user_service import UserService
 from .schema import schema
 from .service import services
 
@@ -16,3 +19,4 @@ def init_app(app):
     )
 
     services["entity"] = EntityService(current_app.logger)
+    services["user"] = UserService(current_app.logger)

--- a/backend/python/app/graphql/mutations/auth_mutation.py
+++ b/backend/python/app/graphql/mutations/auth_mutation.py
@@ -4,4 +4,41 @@ TODO mutations:
     refresh: String!
     logout(userId: ID!): ID
     resetPassword(email: String!): Boolean!
- """
+"""
+
+import os
+
+import graphene
+from flask import Blueprint, current_app, jsonify, request
+
+from ...services.implementations.auth_service import AuthService
+from ...services.implementations.email_service import EmailService
+from ..service import services
+
+email_service = EmailService(
+    current_app.logger,
+    {
+        "refresh_token": os.getenv("EMAIL_REFRESH_TOKEN"),
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "client_id": os.getenv("EMAIL_CLIENT_ID"),
+        "client_secret": os.getenv("EMAIL_CLIENT_SECRET"),
+    },
+    "planetread@uwblueprint.org",  # must replace
+    "Planet Read",  # must replace)
+)
+auth_service = AuthService(current_app.logger, services["user"], email_service)
+
+
+class ResetPassword(graphene.Mutation):
+    class Arguments:
+        email = graphene.String(required=True)
+
+    ok = graphene.Boolean()
+
+    def mutate(root, info, email):
+        try:
+            auth_service.reset_password(email)
+            return ResetPassword(ok=True)
+        except Exception as e:
+            error_message = getattr(e, "message", None)
+            raise Exception(error_message if error_message else str(e))

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -1,9 +1,11 @@
 import graphene
 
+from .mutations.auth_mutation import ResetPassword
 from .mutations.entity_mutation import CreateEntity
 from .mutations.user_mutation import CreateUser
 from .queries.entity_query import resolve_entities
-from .queries.user_query import resolve_user_by_email, resolve_user_by_id, resolve_users
+from .queries.user_query import (resolve_user_by_email, resolve_user_by_id,
+                                 resolve_users)
 from .types.entity_type import EntityResponseDTO
 from .types.user_type import UserDTO
 
@@ -11,6 +13,7 @@ from .types.user_type import UserDTO
 class Mutation(graphene.ObjectType):
     create_entity = CreateEntity.Field()
     create_user = CreateUser.Field()
+    reset_password = ResetPassword.Field()
 
 
 class Query(graphene.ObjectType):

--- a/backend/python/app/rest/auth_routes.py
+++ b/backend/python/app/rest/auth_routes.py
@@ -2,10 +2,8 @@ import os
 
 from flask import Blueprint, current_app, jsonify, request
 
-from ..middlewares.auth import (
-    require_authorization_by_email,
-    require_authorization_by_user_id,
-)
+from ..middlewares.auth import (require_authorization_by_email,
+                                require_authorization_by_user_id)
 from ..resources.create_user_dto import CreateUserDTO
 from ..services.implementations.auth_service import AuthService
 from ..services.implementations.email_service import EmailService

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,13 +1,85 @@
+import axios from "axios";
+import jwt from "jsonwebtoken";
 import React from "react";
 import ReactDOM from "react-dom";
+import {
+  ApolloClient,
+  ApolloProvider,
+  createHttpLink,
+  InMemoryCache,
+} from "@apollo/client";
+import { setContext } from "@apollo/client/link/context";
+
+import AUTHENTICATED_USER_KEY from "./constants/AuthConstants";
+import {
+  getLocalStorageObjProperty,
+  setLocalStorageObjProperty,
+} from "./utils/LocalStorageUtils";
 
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 
+const REFRESH_MUTATION = `
+  mutation Index_Refresh {
+    refresh
+  }
+`;
+
+const link = createHttpLink({
+  uri: `${process.env.REACT_APP_BACKEND_URL}/graphql`,
+  credentials: "include",
+});
+
+const authLink = setContext(async (_, { headers }) => {
+  // get the authentication token from local storage if it exists
+  let token: string = getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  );
+
+  if (token) {
+    const decodedToken: any = jwt.decode(token);
+
+    // refresh if decodedToken has expired
+    if (
+      decodedToken &&
+      decodedToken.exp > Math.round(new Date().getTime() / 1000)
+    ) {
+      const { data } = await axios.post(
+        `${process.env.REACT_APP_BACKEND_URL}/graphql`,
+        { query: REFRESH_MUTATION },
+        { withCredentials: true },
+      );
+
+      const accessToken: string = data.data.refresh;
+      setLocalStorageObjProperty(
+        AUTHENTICATED_USER_KEY,
+        "accessToken",
+        accessToken,
+      );
+      token = accessToken;
+    }
+  }
+  // return the headers to the context so httpLink can read them
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : "",
+    },
+  };
+});
+
+const apolloClient = new ApolloClient({
+  link: authLink.concat(link),
+  cache: new InMemoryCache(),
+});
+
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <ApolloProvider client={apolloClient}>
+      <App />
+    </ApolloProvider>
   </React.StrictMode>,
   document.getElementById("root"),
 );


### PR DESCRIPTION
## Notion ticket link
[Migrate reset_password endpoint to GraphQL](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=4a47edc475b34bb99b25ff1fae2a5507&p=b69224f1963f4ac195c62c71bff4f6da)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add mutation for `resetUser(email: String!): ResetUser`
* Migrate call in frontend from REST to GraphQL
* Change `index.tsx` to meet Apollo requirements


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. From backend, try registered email, non-registered emails in GraphQL playground
2. From frontend, try registered email, non-registered email, non-email strings in entry field and check expected message occurs


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Was it necessary to add `services["user"]` in the `__init__.py`?
* Why have other migrations not run into the apollo client issue that required changes in `index.tsx`? ✅ (just hadn't had any other front-end changes yet that were trying to import)
* Am I using Graphene incorrectly -> can we do `resetUser(email: String!): Boolean!` instead of `resetUser(email: String!): ResetUser`?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
