### PR TITLE
Add authorization for user GraphQL endpoints

### DIFF
--- a/backend/python/app/graphql/mutations/entity_mutation.py
+++ b/backend/python/app/graphql/mutations/entity_mutation.py
@@ -1,5 +1,6 @@
 import graphene
 
+from ...middlewares.auth import require_authorization_by_role_gql
 from ..service import services
 from ..types.entity_type import EntityRequestDTO, EntityResponseDTO
 
@@ -11,6 +12,7 @@ class CreateEntity(graphene.Mutation):
     ok = graphene.Boolean()
     entity = graphene.Field(lambda: EntityResponseDTO)
 
+    @require_authorization_by_role_gql({"User", "Admin"})
     def mutate(root, info, entity_data=None):
         entity_response = services["entity"].create_entity(entity_data)
         ok = True

--- a/backend/python/app/graphql/mutations/user_mutation.py
+++ b/backend/python/app/graphql/mutations/user_mutation.py
@@ -1,5 +1,6 @@
 import graphene
 
+from ...middlewares.auth import require_authorization_by_role_gql
 from ..service import services
 from ..types.user_type import CreateUserDTO, UserDTO
 
@@ -11,6 +12,7 @@ class CreateUser(graphene.Mutation):
     ok = graphene.Boolean()
     user = graphene.Field(lambda: UserDTO)
 
+    @require_authorization_by_role_gql({"User", "Admin"})
     def mutate(root, info, user_data=None):
         user_response = services["user"].create_user(user_data).__dict__
         ok = True

--- a/backend/python/app/graphql/queries/entity_query.py
+++ b/backend/python/app/graphql/queries/entity_query.py
@@ -1,5 +1,7 @@
+from ...middlewares.auth import require_authorization_by_role_gql
 from ..service import services
 
 
+@require_authorization_by_role_gql({"User", "Admin"})
 def resolve_entities(root, info, **kwargs):
     return services["entity"].get_entities()

--- a/backend/python/app/graphql/queries/user_query.py
+++ b/backend/python/app/graphql/queries/user_query.py
@@ -1,14 +1,18 @@
+from ...middlewares.auth import require_authorization_by_role_gql
 from ..service import services
 
 
+@require_authorization_by_role_gql({"User", "Admin"})
 def resolve_users(root, info, **kwargs):
     return services["user"].get_users()
 
 
+@require_authorization_by_role_gql({"User", "Admin"})
 def resolve_user_by_id(root, info, id):
     return services["user"].get_user_by_id(id)
 
 
+@require_authorization_by_role_gql({"User", "Admin"})
 def resolve_user_by_email(root, info, email):
     return services["user"].get_user_by_email(email)
 

--- a/backend/python/app/middlewares/auth.py
+++ b/backend/python/app/middlewares/auth.py
@@ -113,3 +113,25 @@ def require_authorization_by_email(email_field):
         return wrapper
 
     return require_authorization
+
+
+def require_authorization_by_role_gql(roles):
+    """
+    Determine if request is authorized based on access_token validity and role of client
+
+    :param roles: the set of authorized roles to check for
+    :type roles: {str}
+    """
+
+    def require_authorization(api_func):
+        @wraps(api_func)
+        def wrapper(root, info, *args, **kwargs):
+            access_token = get_access_token(info.context)
+            authorized = auth_service.is_authorized_by_role(access_token, roles)
+            if not authorized:
+                raise Exception("You are not authorized to make this request.")
+            return api_func(root, info, *args, **kwargs)
+
+        return wrapper
+
+    return require_authorization

--- a/backend/python/app/rest/auth_routes.py
+++ b/backend/python/app/rest/auth_routes.py
@@ -2,10 +2,7 @@ import os
 
 from flask import Blueprint, current_app, jsonify, request
 
-from ..middlewares.auth import (
-    require_authorization_by_email,
-    require_authorization_by_user_id,
-)
+from ..middlewares.auth import require_authorization_by_user_id
 from ..resources.create_user_dto import CreateUserDTO
 from ..services.implementations.auth_service import AuthService
 from ..services.implementations.email_service import EmailService


### PR DESCRIPTION
## Notion ticket link
[Add authorization checks to Graphql resolvers](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=4a47edc475b34bb99b25ff1fae2a5507&p=da8927857a284356b83d10053b9ff230)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Added new middleware method `require_authorization_by_role_gql` that performs the same checks as its non-GraphQL equivalent. Needed to change the arguments and how it accessed headers (request object is in `info.context` rather than just `request`)
* Added the decorator to the appropriate mutations and queries. Justification for adding it on the business logic layer rather than the GraphQL layer (in `schema.py`) based on https://graphql.org/learn/authorization/ 

Also, I added the method into the existing `auth.py` instead of creating a new file because when we eliminate the REST code, the file name still makes sense and now requires a single method name refactor.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test

Setup -> I added users manually (see https://github.com/uwblueprint/planet-read/pull/11). Not really necessary, but makes for slightly more interesting testing 🤷 

1. NOT AUTHORIZED case: Open `localhost:5000/graphql` and mess around with any of the queries and any of the mutations except for `resetPassword`. Should respond that "You are not authorized to make this request.", eg. below. Can also produce this in Postman if you have no/an incorrect `Authorization` header.
```
{
  "errors": [
    {
      "message": "You are not authorized to make this request.",
      "locations": [
        {
          "line": 2,
          "column": 2
        }
      ],
      "path": [
        "entities"
      ]
    }
  ],
  "data": {
    "entities": null
  }
}
```
2. AUTHORIZED case: Find access token with `console.log(window.localStorage.getItem("localhost:AUTHENTICATED_USER"));` in front-end console. Use this (formatted as `Bearer <access-token>`) as the `Authorization` header and try making any of the above failing requests. Should return as expected, no errors. I used Postman for this.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Should this ticket include a GraphQL verison of `require_authorization_by_user_id`? No way to test without logout GraphQL endpoint being established
* I don't know how to accomplish the headers in GraphiQL so I used Postman instead. I know Postman can hide CORS errors -- is this a flawed way of testing?

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
