### PR TITLE
Add content related story models and services

### DIFF
--- a/backend/python/app/graphql/__init__.py
+++ b/backend/python/app/graphql/__init__.py
@@ -5,6 +5,7 @@ from flask_graphql import GraphQLView
 
 from ..models import db
 from ..services.implementations.entity_service import EntityService
+from ..services.implementations.story_service import StoryService
 from ..services.implementations.user_service import UserService
 from .schema import schema
 from .service import services
@@ -19,4 +20,5 @@ def init_app(app):
     )
 
     services["entity"] = EntityService(current_app.logger)
+    services["story"] = StoryService(current_app.logger)
     services["user"] = UserService(current_app.logger)

--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -1,0 +1,17 @@
+import graphene
+
+from ..service import services
+from ..types.story_type import StoryRequestDTO, StoryResponseDTO
+
+
+class CreateStory(graphene.Mutation):
+    class Arguments:
+        story_data = StoryRequestDTO(required=True)
+
+    ok = graphene.Boolean()
+    story = graphene.Field(lambda: StoryResponseDTO)
+
+    def mutate(root, info, story_data=None):
+        story_response = services["story"].create_story(story_data)
+        ok = True
+        return CreateStory(story=story_response, ok=ok)

--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -1,0 +1,9 @@
+from ..service import services
+
+
+def resolve_stories(root, info, **kwargs):
+    return services["story"].get_stories()
+
+
+def resolve_story_by_id(root, info, id):
+    return services["story"].get_story(id)

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -2,28 +2,39 @@ import graphene
 
 from .mutations.auth_mutation import ResetPassword
 from .mutations.entity_mutation import CreateEntity
+from .mutations.story_mutation import CreateStory
 from .mutations.user_mutation import CreateUser
 from .queries.entity_query import resolve_entities
-from .queries.user_query import (resolve_user_by_email, resolve_user_by_id,
-                                 resolve_users)
+from .queries.story_query import resolve_stories, resolve_story_by_id
+from .queries.user_query import resolve_user_by_email, resolve_user_by_id, resolve_users
 from .types.entity_type import EntityResponseDTO
+from .types.story_type import StoryResponseDTO
 from .types.user_type import UserDTO
 
 
 class Mutation(graphene.ObjectType):
     create_entity = CreateEntity.Field()
+    create_story = CreateStory.Field()
     create_user = CreateUser.Field()
     reset_password = ResetPassword.Field()
 
 
 class Query(graphene.ObjectType):
     entities = graphene.Field(graphene.List(EntityResponseDTO))
+    stories = graphene.Field(graphene.List(StoryResponseDTO))
+    story_by_id = graphene.Field(StoryResponseDTO, id=graphene.Int())
     users = graphene.Field(graphene.List(UserDTO))
     user_by_id = graphene.Field(UserDTO, id=graphene.Int())
     user_by_email = graphene.Field(UserDTO, email=graphene.String())
 
     def resolve_entities(root, info, **kwargs):
         return resolve_entities(root, info, **kwargs)
+
+    def resolve_stories(root, info, **kwargs):
+        return resolve_stories(root, info, **kwargs)
+
+    def resolve_story_by_id(root, info, id):
+        return resolve_story_by_id(root, info, id)
 
     def resolve_users(root, info, **kwargs):
         return resolve_users(root, info, **kwargs)

--- a/backend/python/app/graphql/service.py
+++ b/backend/python/app/graphql/service.py
@@ -4,9 +4,11 @@ flask app has started. Create dummy services here that will be
 updated with live app loggers during __init__.py
 """
 from ..services.implementations.entity_service import EntityService
+from ..services.implementations.story_service import StoryService
 from ..services.implementations.user_service import UserService
 
 services = {
     "entity": EntityService(),
+    "story": StoryService(),
     "user": UserService(),
 }

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -1,0 +1,25 @@
+import graphene
+
+
+class StageEnum(graphene.Enum):
+    START = "START"
+    TRANSLATE = "TRANSLATE"
+    REVIEW = "REVIEW"
+    PUBLISH = "PUBLISH"
+
+
+class StoryResponseDTO(graphene.ObjectType):
+    id = graphene.Int()
+    stage = graphene.Field(StageEnum, required=True)
+    description = graphene.String(required=True)
+    youtube_link = graphene.String(required=True)
+    level = graphene.Int(required=True)
+    translated_languages = graphene.List(graphene.String)  # TODO replace with Enum
+
+
+class StoryRequestDTO(graphene.InputObjectType):
+    stage = graphene.Argument(StageEnum, required=True)
+    description = graphene.String(required=True)
+    youtube_link = graphene.String(required=True)
+    level = graphene.Int(required=True)
+    translated_languages = graphene.List(graphene.String)  # TODO replace with Enum

--- a/backend/python/app/models/__init__.py
+++ b/backend/python/app/models/__init__.py
@@ -8,6 +8,9 @@ def init_app(app):
     from .entity import Entity
     from .file import File
     from .story import Story
+    from .story_content import StoryContent
+    from .story_translation import StoryTranslation
+    from .story_translation_content import StoryTranslationContent
     from .user import User
 
     app.app_context().push()

--- a/backend/python/app/models/story_content.py
+++ b/backend/python/app/models/story_content.py
@@ -2,20 +2,16 @@ from sqlalchemy import inspect
 from sqlalchemy.orm.properties import ColumnProperty
 
 from . import db
-from .story_content import StoryContent
-
-stages_enum = db.Enum("START", "TRANSLATE", "REVIEW", "PUBLISH", name="stages")
 
 
-class Story(db.Model):
-    __tablename__ = "stories"
+class StoryContent(db.Model):
+    __tablename__ = "story_contents"
     id = db.Column(db.Integer, primary_key=True, nullable=False)
-    stage = db.Column(stages_enum, nullable=False)
-    description = db.Column(db.String, nullable=False)
-    youtube_link = db.Column(db.String, nullable=False)
-    level = db.Column(db.Integer, nullable=False)
-    translated_languages = db.Column(db.ARRAY(db.String))
-    contents = db.relationship(StoryContent)
+    story_id = db.Column(
+        db.Integer, db.ForeignKey("stories.id"), index=True, nullable=False
+    )
+    line_index = db.Column(db.Integer, nullable=False)
+    content = db.Column(db.String, nullable=False)
 
     def to_dict(self, include_relationships=False):
         cls = type(self)

--- a/backend/python/app/models/story_translation.py
+++ b/backend/python/app/models/story_translation.py
@@ -2,20 +2,17 @@ from sqlalchemy import inspect
 from sqlalchemy.orm.properties import ColumnProperty
 
 from . import db
-from .story_content import StoryContent
-
-stages_enum = db.Enum("START", "TRANSLATE", "REVIEW", "PUBLISH", name="stages")
+from .story_translation_content import StoryTranslationContent
 
 
-class Story(db.Model):
-    __tablename__ = "stories"
+class StoryTranslation(db.Model):
+    __tablename__ = "story_translations"
     id = db.Column(db.Integer, primary_key=True, nullable=False)
-    stage = db.Column(stages_enum, nullable=False)
-    description = db.Column(db.String, nullable=False)
-    youtube_link = db.Column(db.String, nullable=False)
-    level = db.Column(db.Integer, nullable=False)
-    translated_languages = db.Column(db.ARRAY(db.String))
-    contents = db.relationship(StoryContent)
+    story_id = db.Column(db.Integer, db.ForeignKey("stories.id"), nullable=False)
+    language = db.Column(db.String, nullable=False)  # TODO replace with Enum
+    translator_id = db.Column(db.Integer, db.ForeignKey("users.id"), index=True)
+    reviewer_id = db.Column(db.Integer, db.ForeignKey("users.id"), index=True)
+    translation_contents = db.relationship(StoryTranslationContent)
 
     def to_dict(self, include_relationships=False):
         cls = type(self)

--- a/backend/python/app/models/story_translation_content.py
+++ b/backend/python/app/models/story_translation_content.py
@@ -2,20 +2,16 @@ from sqlalchemy import inspect
 from sqlalchemy.orm.properties import ColumnProperty
 
 from . import db
-from .story_content import StoryContent
-
-stages_enum = db.Enum("START", "TRANSLATE", "REVIEW", "PUBLISH", name="stages")
 
 
-class Story(db.Model):
-    __tablename__ = "stories"
+class StoryTranslationContent(db.Model):
+    __tablename__ = "story_translation_contents"
     id = db.Column(db.Integer, primary_key=True, nullable=False)
-    stage = db.Column(stages_enum, nullable=False)
-    description = db.Column(db.String, nullable=False)
-    youtube_link = db.Column(db.String, nullable=False)
-    level = db.Column(db.Integer, nullable=False)
-    translated_languages = db.Column(db.ARRAY(db.String))
-    contents = db.relationship(StoryContent)
+    story_translation_id = db.Column(
+        db.Integer, db.ForeignKey("story_translations.id"), index=True, nullable=False
+    )
+    line_index = db.Column(db.Integer, nullable=False)
+    translation_content = db.Column(db.String, nullable=False)
 
     def to_dict(self, include_relationships=False):
         cls = type(self)

--- a/backend/python/app/rest/auth_routes.py
+++ b/backend/python/app/rest/auth_routes.py
@@ -2,8 +2,10 @@ import os
 
 from flask import Blueprint, current_app, jsonify, request
 
-from ..middlewares.auth import (require_authorization_by_email,
-                                require_authorization_by_user_id)
+from ..middlewares.auth import (
+    require_authorization_by_email,
+    require_authorization_by_user_id,
+)
 from ..resources.create_user_dto import CreateUserDTO
 from ..services.implementations.auth_service import AuthService
 from ..services.implementations.email_service import EmailService

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -1,0 +1,37 @@
+from flask import current_app
+
+from ...models import db
+from ...models.story import Story
+from ..interfaces.story_service import IStoryService
+
+
+class StoryService(IStoryService):
+    def __init__(self, logger=current_app.logger):
+        self.logger = logger
+
+    def get_stories(self):
+        # Entity is a SQLAlchemy model, we can use convenient methods provided
+        # by SQLAlchemy like query.all() to query the data
+        return [result.to_dict() for result in Story.query.all()]
+
+    def get_story(self, id):
+        # get queries by the primary key, which is id for the Story table
+        story = Story.query.get(id)
+        if story is None:
+            self.logger.error("Invalid id")
+            raise Exception("Invalid id")
+        return story.to_dict()
+
+    def create_story(self, entity):
+        # TODO: Require all story content when creating story
+        # and insert into story_contents
+        try:
+            new_story = Story(**entity.__dict__)
+        except Exception as error:
+            self.logger.error(str(error))
+            raise error
+
+        db.session.add(new_story)
+        db.session.commit()
+
+        return new_story

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -1,0 +1,39 @@
+from abc import ABC, abstractmethod
+
+
+class IStoryService(ABC):
+    """
+    A class to handle CRUD functionality for stories, story_contents,
+    story_translations, and story_translation_contents
+    """
+
+    @abstractmethod
+    def get_stories(self):
+        """Return a list of all stories
+
+        :return: A list of dictionaries from Story objects
+        :rtype: list of dictionaries
+        """
+        pass
+
+    @abstractmethod
+    def get_story(self, id):
+        """Return a dictionary from the Story object based on id
+
+        :param id: Story id
+        :return: dictionary of Story object
+        :rtype: dictionary
+        :raises Exception: id retrieval fails
+        """
+        pass
+
+    @abstractmethod
+    def create_story(self, story):
+        """Create a new Story object
+
+        :param story: dictionary of story fields
+        :return: dictionary of Story object
+        :rtype: dictionary
+        :raises Exception: if entity fields are invalid
+        """
+        pass


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Build stories and related models](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=4a47edc475b34bb99b25ff1fae2a5507&p=bc046588cdf24872a208ecf2e1ebfc58)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* add models for stories, story content, and their translations
* see [architecture doc](https://www.notion.so/uwblueprintexecs/Architecture-Brainstorm-44de9f6c559f48f58694164d3aaaf688)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## New API
```
mutation {
  createStory(storyData: {stage: START, description: "heres my story", youtubeLink: "no!", level: 1, translatedLanguages: []}) {
    story {
      id
    }
  }
}

```
```
{
  storyById(id:1){
    youtubeLink
    translatedLanguages
  }
}
```
```
{
  stories {
    youtubeLink
  }
}
```


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## Tentative Queries
Column index decisions were made based on these queries. Each query uses the indexes to some degree.
```
// Load Homepage
// Show all stories I am translating or reviewing 
SELECT * FROM stories INNER JOIN story_translations ON stories.id = story_translations.id WHERE story_translations.translator_id = ? OR story_translations.reviewer_id = ?;
// Show all stories available for translation or reviewing to me
SELECT * FROM stories WHERE NOT (translated_languages @> ARRAY['mylanguage']::varchar[]);

// Load Translation Platform
SELECT * FROM story_contents WHERE story_id = ?;
SELECT * FROM story_translations INNER JOIN story_translation_contents ON story_translations.id = story_translation_contents.id  WHERE story_translations.id = ?;

// Save Translation
UPDATE story_translation_contents SET translation_content = ? WHERE story_translation_id = ? AND line_index = ?;
```
#### Note about showing available stories
`translated_languages` could've been a json dictionary for looking up if a language was translated or not. I tried testing the query in both conditions and there's a marginal improvement with the array. I predict the array will still perform better, but this is not too challenging to change in the future. 
```
planet-read=# EXPLAIN SELECT * FROM stories WHERE NOT (translated_languages @> ARRAY['hi']::varchar[]);
                              QUERY PLAN
-----------------------------------------------------------------------
 Seq Scan on stories  (cost=0.00..17.50 rows=597 width=108)
   Filter: (NOT (translated_languages @> '{hi}'::character varying[]))
(2 rows)


planet-read=# EXPLAIN SELECT * FROM stories WHERE translated_languages->>'field' = 'hi';
                            QUERY PLAN
-------------------------------------------------------------------
 Seq Scan on stories  (cost=0.00..19.00 rows=3 width=108)
   Filter: ((translated_languages ->> 'field'::text) = 'hi'::text)
(2 rows)
```

## Caution
* `stories.translatedLanguages` could technically fall out of sync from what is actually translated. We will need to keep it in sync with `story_translations` via api


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
