### PR TITLE
Build user model

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Don't forget to seed your database with a firebase user:
 docker ps
 docker exec -it <db-container-id> /bin/bash
 psql -U postgres -d planet-read
-INSERT INTO users (first_name, last_name, auth_id, role) VALUES ('First', 'Last', 'insert-firebase-uid', 'Admin');
+INSERT INTO users (first_name, last_name, auth_id, role, approved_languages) VALUES ('First', 'Last', 'insert-firebase-uid', 'Admin', '{"english":3}');
 ```
 
 If there are no tables in the DB, go into `/backend/python/app/models/__init__.py` and change the `erase_db_and_sync = False` to True, allow the hot reload to build, and change it back to `False`. Try to seed the database with a user again.

--- a/backend/python/app/graphql/types/user_type.py
+++ b/backend/python/app/graphql/types/user_type.py
@@ -12,6 +12,9 @@ class UserDTO(graphene.ObjectType):
     last_name = graphene.String(required=True)
     role = graphene.Field(RoleEnum, required=True)
     email = graphene.String(required=True)
+    resume = graphene.Int()
+    profile_pic = graphene.Int()
+    approved_languages = graphene.JSONString()
 
 
 class CreateUserDTO(graphene.InputObjectType):
@@ -20,3 +23,6 @@ class CreateUserDTO(graphene.InputObjectType):
     role = graphene.Argument(RoleEnum, required=True)
     email = graphene.String(required=True)
     password = graphene.String(required=True)
+    resume = graphene.Int(required=False, default=None)
+    profile_pic = graphene.Int(required=False, default=None)
+    approved_languages = graphene.JSONString(required=False, default=None)

--- a/backend/python/app/models/user.py
+++ b/backend/python/app/models/user.py
@@ -14,6 +14,10 @@ class User(db.Model):
     last_name = db.Column(db.String, nullable=False)
     auth_id = db.Column(db.String, nullable=False)
     role = db.Column(roles_enum)
+    resume = db.Column(db.Integer, db.ForeignKey("files.id"))
+    profile_pic = db.Column(db.Integer, db.ForeignKey("files.id"))
+    # format for approved_languages should be language: highest approved level
+    approved_languages = db.Column(db.JSON)
 
     def to_dict(self, include_relationships=False):
         # define the entities table

--- a/backend/python/app/resources/auth_dto.py
+++ b/backend/python/app/resources/auth_dto.py
@@ -4,7 +4,27 @@ from .user_dto import UserDTO
 
 class AuthDTO(Token, UserDTO):
     def __init__(
-        self, access_token, refresh_token, id, first_name, last_name, email, role
+        self,
+        access_token,
+        refresh_token,
+        id,
+        first_name,
+        last_name,
+        email,
+        role,
+        resume,
+        profile_pic,
+        approved_languages,
     ):
         Token.__init__(self, access_token, refresh_token)
-        UserDTO.__init__(self, id, first_name, last_name, email, role)
+        UserDTO.__init__(
+            self,
+            id,
+            first_name,
+            last_name,
+            email,
+            role,
+            resume,
+            profile_pic,
+            approved_languages,
+        )

--- a/backend/python/app/resources/user_dto.py
+++ b/backend/python/app/resources/user_dto.py
@@ -1,7 +1,20 @@
 class UserDTO:
-    def __init__(self, id, first_name, last_name, email, role):
+    def __init__(
+        self,
+        id,
+        first_name,
+        last_name,
+        email,
+        role,
+        resume,
+        profile_pic,
+        approved_languages,
+    ):
         self.id = id
         self.first_name = first_name
         self.last_name = last_name
         self.email = email
         self.role = role
+        self.resume = resume
+        self.profile_pic = profile_pic
+        self.approved_languages = approved_languages

--- a/backend/python/app/services/implementations/user_service.py
+++ b/backend/python/app/services/implementations/user_service.py
@@ -30,7 +30,6 @@ class UserService(IUserService):
                 raise Exception("user_id {user_id} not found".format(user_id))
 
             firebase_user = firebase_admin.auth.get_user(user.auth_id)
-
             user_dict = UserService.__user_to_dict_and_remove_auth_id(user)
             user_dict["email"] = firebase_user.email
 
@@ -145,6 +144,9 @@ class UserService(IUserService):
                 "last_name": user.last_name,
                 "auth_id": firebase_user.uid,
                 "role": user.role,
+                "resume": user.resume,
+                "profile_pic": user.profile_pic,
+                "approved_languages": user.approved_languages,
             }
 
             try:
@@ -194,6 +196,9 @@ class UserService(IUserService):
                     User.first_name: user.first_name,
                     User.last_name: user.last_name,
                     User.role: user.role,
+                    User.resume: user.resume,
+                    User.profile_pic: user.profile_pic,
+                    User.approved_languages: user.approved_languages,
                 }
             )
 


### PR DESCRIPTION
## Notion ticket link
[Build User model](https://www.notion.so/uwblueprintexecs/Build-User-model-1030f0330d934282893011ae9249f9bd)


## Implementation description
* added profile_pic and resume fields to User model that correspond to an ID in the files table
* added approved_languages field as an object where the key is the language, and the value is the highest level the user is approved for


## Steps to test
1. Start up the backend
2. Ensure the database has existing users; otherwise seed database with users:
```
$ planet-read_db_1 psql -U postgres -d planet-read
$ \dt
```
> if no tables present, change the `erase_db_and_sync` = `False` to `True` in `backend/python/app/models/__init__.py`
```
$ SELECT * FROM users;
```
> if empty, insert users into the database
```
$ INSERT INTO users (first_name, last_name, auth_id, role, approved_languages) VALUES ('First', 'Last', 'insert-firebase-uid', 'Admin', '{"english":3}');
```

3. Get the access token for the user and upload some files; store the id of the file that was added
```
curl --location --request POST 'http://localhost:5000/files' \
--header 'Authorization: Bearer  <ACCESS_TOKEN>' \
--form 'file=@"<PATH_TO_FILE>"'
```
4. Go to `localhost:5000/graphql` and verify that you are able to create a new user:
```
mutation {
  createUser(userData: {firstName: "First", lastName: "Last", email: "test@abc.com", password: "aabfddlad", role: User, resume: <id of file you uploaded>, profilePic: <id of file you uploaded>, approvedLanguages: "{\"english\":3}"}) {
    user {
      id
    }
  }
}
```

## What should reviewers focus on?
* Verify that the new fields were added correctly, and that appropriate field types were used
* Currently no validation is in place to check if the given file id was already used for the profile_pic/resume
* Additionally, no validation is in place for checking that the approved_languages object keys/values are valid


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
