### PR TITLE
Migrate UpdateUser Mutation to GQL

### DIFF
--- a/backend/python/app/graphql/mutations/user_mutation.py
+++ b/backend/python/app/graphql/mutations/user_mutation.py
@@ -22,7 +22,7 @@ class UpdateUser(graphene.Mutation):
         id = graphene.ID(required=True)
         user = UpdateUserDTO(required=True)
 
-    updated_user = graphene.Field(lambda: UserDTO)
+    user = graphene.Field(lambda: UserDTO)
 
     def mutate(root, info, id, user):
         """
@@ -30,7 +30,7 @@ class UpdateUser(graphene.Mutation):
         """
         try:
             updated_user = services["user"].update_user_by_id(id, user)
-            return UpdateUser(updated_user=updated_user)
+            return UpdateUser(user=updated_user)
         except Exception as e:
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))

--- a/backend/python/app/graphql/mutations/user_mutation.py
+++ b/backend/python/app/graphql/mutations/user_mutation.py
@@ -1,7 +1,7 @@
 import graphene
 
 from ..service import services
-from ..types.user_type import CreateUserDTO, UserDTO
+from ..types.user_type import CreateUserDTO, UserDTO, UpdateUserDTO
 
 
 class CreateUser(graphene.Mutation):
@@ -16,6 +16,23 @@ class CreateUser(graphene.Mutation):
         ok = True
         return CreateUser(user=user_response, ok=ok)
 
+class UpdateUser(graphene.Mutation):
+    class Arguments:
+        id  = graphene.ID(required=True)
+        user = UpdateUserDTO(required=True)
+    
+    updated_user = graphene.Field(lambda: UserDTO)
+
+    def mutate(root, info, id, user):
+        """
+        Update the user with the specified user_id
+        """
+        try:
+            updated_user = services["user"].update_user_by_id(id, user)
+            return UpdateUser(updated_user=updated_user)
+        except Exception as e:
+            error_message = getattr(e, "message", None)
+            raise Exception(error_message if error_message else str(e))
 
 """
 TODO mutations:

--- a/backend/python/app/graphql/mutations/user_mutation.py
+++ b/backend/python/app/graphql/mutations/user_mutation.py
@@ -1,7 +1,7 @@
 import graphene
 
 from ..service import services
-from ..types.user_type import CreateUserDTO, UserDTO, UpdateUserDTO
+from ..types.user_type import CreateUserDTO, UpdateUserDTO, UserDTO
 
 
 class CreateUser(graphene.Mutation):
@@ -16,11 +16,12 @@ class CreateUser(graphene.Mutation):
         ok = True
         return CreateUser(user=user_response, ok=ok)
 
+
 class UpdateUser(graphene.Mutation):
     class Arguments:
-        id  = graphene.ID(required=True)
+        id = graphene.ID(required=True)
         user = UpdateUserDTO(required=True)
-    
+
     updated_user = graphene.Field(lambda: UserDTO)
 
     def mutate(root, info, id, user):
@@ -33,6 +34,7 @@ class UpdateUser(graphene.Mutation):
         except Exception as e:
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))
+
 
 """
 TODO mutations:

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -3,7 +3,7 @@ import graphene
 from .mutations.auth_mutation import ResetPassword
 from .mutations.entity_mutation import CreateEntity
 from .mutations.story_mutation import CreateStory
-from .mutations.user_mutation import CreateUser
+from .mutations.user_mutation import CreateUser, UpdateUser
 from .queries.entity_query import resolve_entities
 from .queries.story_query import resolve_stories, resolve_story_by_id
 from .queries.user_query import resolve_user_by_email, resolve_user_by_id, resolve_users
@@ -17,6 +17,7 @@ class Mutation(graphene.ObjectType):
     create_story = CreateStory.Field()
     create_user = CreateUser.Field()
     reset_password = ResetPassword.Field()
+    update_user = UpdateUser.Field()
 
 
 class Query(graphene.ObjectType):

--- a/backend/python/app/graphql/types/user_type.py
+++ b/backend/python/app/graphql/types/user_type.py
@@ -26,3 +26,13 @@ class CreateUserDTO(graphene.InputObjectType):
     resume = graphene.Int(required=False, default=None)
     profile_pic = graphene.Int(required=False, default=None)
     approved_languages = graphene.JSONString(required=False, default=None)
+
+
+class UpdateUserDTO(graphene.InputObjectType):
+    first_name = graphene.String(required=True)
+    last_name = graphene.String(required=True)
+    role = graphene.Argument(RoleEnum, required=True)
+    email = graphene.String(required=True)
+    resume = graphene.Int(required=False, default=None)
+    profile_pic = graphene.Int(required=False, default=None)
+    approved_languages = graphene.JSONString(required=False, default=None)

--- a/backend/python/app/models/story.py
+++ b/backend/python/app/models/story.py
@@ -5,7 +5,6 @@ from . import db
 from .story_content import StoryContent
 
 
-
 class Story(db.Model):
     __tablename__ = "stories"
     id = db.Column(db.Integer, primary_key=True, nullable=False)

--- a/backend/python/app/resources/create_user_dto.py
+++ b/backend/python/app/resources/create_user_dto.py
@@ -1,5 +1,15 @@
 class CreateUserDTO:
-    def __init__(self, first_name, last_name, email, role, password, resume=None, profile_pic=None, approved_languages=None):
+    def __init__(
+        self,
+        first_name,
+        last_name,
+        email,
+        role,
+        password,
+        resume=None,
+        profile_pic=None,
+        approved_languages=None,
+    ):
         self.first_name = first_name
         self.last_name = last_name
         self.email = email

--- a/backend/python/app/resources/create_user_dto.py
+++ b/backend/python/app/resources/create_user_dto.py
@@ -1,7 +1,10 @@
 class CreateUserDTO:
-    def __init__(self, first_name, last_name, email, role, password):
+    def __init__(self, first_name, last_name, email, role, password, resume=None, profile_pic=None, approved_languages=None):
         self.first_name = first_name
         self.last_name = last_name
         self.email = email
         self.role = role
         self.password = password
+        self.resume = resume
+        self.profile_pic = profile_pic
+        self.approved_languages = approved_languages

--- a/backend/python/app/resources/user_dto.py
+++ b/backend/python/app/resources/user_dto.py
@@ -6,9 +6,9 @@ class UserDTO:
         last_name,
         email,
         role,
-        resume,
-        profile_pic,
-        approved_languages,
+        resume=None,
+        profile_pic=None,
+        approved_languages=None,
     ):
         self.id = id
         self.first_name = first_name


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Migrate update_user endpoint to GraphQL ](https://www.notion.so/uwblueprintexecs/Migrate-update_user-endpoint-to-GraphQL-8ade7c5d1a444caea7bb0a478435dbde)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Migrated the updateUser mutation with the same format that all the other mutations/queries are being migrated to gql.
* Altered/Updated some DTOs to work with https://github.com/uwblueprint/planet-read/pull/17


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Build the containers and go to [The GQL Interactive Interface](localhost:5000/graphql)
2. Make sure you have a user in the db, if you need to just go to the homepage and create a new one
3. Craft a mutation under UpdateUser and ensure that your response isn't an error.
4. Profit


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Not sure which DTOs are legacy-isms from REST implementation and removed since there are multiple files named relatively similarly

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
