### PR TITLE
Create and Assign User to Story Translation

### DIFF
--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -2,8 +2,8 @@ import graphene
 
 from ..service import services
 from ..types.story_type import (
-    NewStoryTranslationRequestDTO,
-    NewStoryTranslationResponseDTO,
+    CreateStoryTranslationRequestDTO,
+    CreateStoryTranslationResponseDTO,
     StoryRequestDTO,
     StoryResponseDTO,
 )
@@ -25,9 +25,9 @@ class CreateStory(graphene.Mutation):
 
 class CreateStoryTranslation(graphene.Mutation):
     class Arguments:
-        story_translation_data = NewStoryTranslationRequestDTO(required=True)
+        story_translation_data = CreateStoryTranslationRequestDTO(required=True)
 
-    story = graphene.Field(lambda: NewStoryTranslationResponseDTO)
+    story = graphene.Field(lambda: CreateStoryTranslationResponseDTO)
 
     def mutate(root, info, story_translation_data):
         try:

--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -1,7 +1,12 @@
 import graphene
 
 from ..service import services
-from ..types.story_type import StoryRequestDTO, StoryResponseDTO
+from ..types.story_type import (
+    NewStoryTranslationRequestDTO,
+    NewStoryTranslationResponseDTO,
+    StoryRequestDTO,
+    StoryResponseDTO,
+)
 
 
 class CreateStory(graphene.Mutation):
@@ -16,3 +21,20 @@ class CreateStory(graphene.Mutation):
         story_response = services["story"].create_story(story_data, contents)
         ok = True
         return CreateStory(story=story_response, ok=ok)
+
+
+class CreateStoryTranslation(graphene.Mutation):
+    class Arguments:
+        story_translation_data = NewStoryTranslationRequestDTO(required=True)
+
+    story = graphene.Field(lambda: NewStoryTranslationResponseDTO)
+
+    def mutate(root, info, story_translation_data):
+        try:
+            new_story_translation = services["story"].create_translation(
+                story_translation_data
+            )
+            return CreateStoryTranslation(story=new_story_translation)
+        except Exception as e:
+            error_message = getattr(e, "message", None)
+            raise Exception(error_message if error_message else str(e))

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -2,7 +2,7 @@ import graphene
 
 from .mutations.auth_mutation import Login, ResetPassword, SignUp
 from .mutations.entity_mutation import CreateEntity
-from .mutations.story_mutation import CreateStory
+from .mutations.story_mutation import CreateStory, CreateStoryTranslation
 from .mutations.user_mutation import CreateUser, UpdateUser
 from .queries.entity_query import resolve_entities
 from .queries.story_query import resolve_stories, resolve_story_by_id
@@ -20,6 +20,7 @@ class Mutation(graphene.ObjectType):
     update_user = UpdateUser.Field()
     login = Login.Field()
     signup = SignUp.Field()
+    create_story_translation = CreateStoryTranslation.Field()
 
 
 class Query(graphene.ObjectType):

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -33,3 +33,18 @@ class StoryRequestDTO(graphene.InputObjectType):
     youtube_link = graphene.String(required=True)
     level = graphene.Int(required=True)
     translated_languages = graphene.List(LanguageEnum)
+
+
+class NewStoryTranslationResponseDTO(graphene.ObjectType):
+    id = graphene.Int(required=True)
+    translator_id = graphene.Int(required=True)
+    story_id = graphene.String(required=True)
+    language = graphene.String(required=True)
+    stage = graphene.Field(StageEnum)
+
+
+class NewStoryTranslationRequestDTO(graphene.InputObjectType):
+    translator_id = graphene.Int(required=True)
+    story_id = graphene.Int(required=True)
+    language = graphene.String(required=True)
+    stage = graphene.Field(StageEnum, default_value=StageEnum.START)

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -35,7 +35,7 @@ class StoryRequestDTO(graphene.InputObjectType):
     translated_languages = graphene.List(LanguageEnum)
 
 
-class NewStoryTranslationResponseDTO(graphene.ObjectType):
+class CreateStoryTranslationResponseDTO(graphene.ObjectType):
     id = graphene.Int(required=True)
     translator_id = graphene.Int(required=True)
     story_id = graphene.String(required=True)
@@ -43,8 +43,8 @@ class NewStoryTranslationResponseDTO(graphene.ObjectType):
     stage = graphene.Field(StageEnum)
 
 
-class NewStoryTranslationRequestDTO(graphene.InputObjectType):
+class CreateStoryTranslationRequestDTO(graphene.InputObjectType):
     translator_id = graphene.Int(required=True)
     story_id = graphene.Int(required=True)
     language = graphene.String(required=True)
-    stage = graphene.Field(StageEnum, default_value=StageEnum.START)
+    stage = graphene.Field(StageEnum, default_value="TRANSLATE")

--- a/backend/python/app/models/story_translation.py
+++ b/backend/python/app/models/story_translation.py
@@ -10,10 +10,11 @@ stages_enum = db.Enum("START", "TRANSLATE", "REVIEW", "PUBLISH", name="stages")
 
 
 class StoryTranslation(db.Model):
+
     __tablename__ = "story_translations"
     id = db.Column(db.Integer, primary_key=True, nullable=False)
     story_id = db.Column(db.Integer, db.ForeignKey("stories.id"), nullable=False)
-    language = db.Column(pgEnum(LanguageEnum), nullable=False)
+    language = db.Column(db.String, nullable=False)
     stage = db.Column(stages_enum, nullable=False)
     translator_id = db.Column(db.Integer, db.ForeignKey("users.id"), index=True)
     reviewer_id = db.Column(db.Integer, db.ForeignKey("users.id"), index=True)

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -60,26 +60,26 @@ class StoryService(IStoryService):
             new_story_translation = StoryTranslation(**entity.__dict__)
             db.session.add(new_story_translation)
             db.session.commit()
+        except Exception as error:
+            self.logger.error(str(error))
+            raise error
+        try:
             translation_id = new_story_translation.id
             story_id = new_story_translation.story_id
-            try:
-                story_lines = len(StoryContent.query.filter_by(story_id=story_id).all())
-                new_story_translation_content_cache = [
-                    StoryTranslationContent(
-                        story_translation_id=translation_id,
-                        line_index=line,
-                        translation_content="",
-                    )
-                    for line in range(story_lines)
-                ]
-                db.session.bulk_save_objects(new_story_translation_content_cache)
-                db.session.commit()
-            except Exception as error:
-                db.session.delete(new_story_translation)
-                db.session.commit()
-                self.logger.error(str(error))
-                raise error
+            story_lines = len(StoryContent.query.filter_by(story_id=story_id).all())
+            new_story_translation_content_cache = [
+                StoryTranslationContent(
+                    story_translation_id=translation_id,
+                    line_index=line,
+                    translation_content="",
+                )
+                for line in range(story_lines)
+            ]
+            db.session.bulk_save_objects(new_story_translation_content_cache)
+            db.session.commit()
         except Exception as error:
+            db.session.delete(new_story_translation)
+            db.session.commit()
             self.logger.error(str(error))
             raise error
 

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -3,6 +3,8 @@ from flask import current_app
 from ...models import db
 from ...models.story import Story
 from ...models.story_content import StoryContent
+from ...models.story_translation import StoryTranslation
+from ...models.story_translation_content import StoryTranslationContent
 from ..interfaces.story_service import IStoryService
 
 
@@ -35,6 +37,7 @@ class StoryService(IStoryService):
         db.session.commit()
 
         # insert contents into story_contents
+        # TODO use batch inserts here instead of iterating over the for loop?
         try:
             for i, line in enumerate(content):
                 new_content = {
@@ -51,3 +54,33 @@ class StoryService(IStoryService):
         db.session.refresh(new_story)
 
         return new_story
+
+    def create_translation(self, entity):
+        try:
+            new_story_translation = StoryTranslation(**entity.__dict__)
+            db.session.add(new_story_translation)
+            db.session.commit()
+            translation_id = new_story_translation.id
+            story_id = new_story_translation.story_id
+            try:
+                story_lines = len(StoryContent.query.filter_by(story_id=story_id).all())
+                new_story_translation_content_cache = [
+                    StoryTranslationContent(
+                        story_translation_id=translation_id,
+                        line_index=line,
+                        translation_content="",
+                    )
+                    for line in range(story_lines)
+                ]
+                db.session.bulk_save_objects(new_story_translation_content_cache)
+                db.session.commit()
+            except Exception as error:
+                db.session.delete(new_story_translation)
+                db.session.commit()
+                self.logger.error(str(error))
+                raise error
+        except Exception as error:
+            self.logger.error(str(error))
+            raise error
+
+        return new_story_translation


### PR DESCRIPTION
## Notion ticket link
[Assign a User as translator to a story](https://www.notion.so/uwblueprintexecs/Assign-a-User-as-translator-to-a-story-5dbab72c1a53461c96dcf39a7ea24a64)

## Implementation description
* Created a new DTO for request & response for creating a story translation
* Creates a new entry for the story translation
* Fetches all the lines associated with the story that's being translated and makes empty lines for those
* Returns the initial story translation entry

## Steps to test
1. Build the backend container & go to the [GQL playground](http://localhost:5000/graphql)
2. Ensure you have a story and a user.
3. Query for a random user_id and story_id `stories{user_id}` and `users{user_id}` should do it, fetch any random numbers from those lists
4. Run the following mutation
```
mutation($storyTranslationData: NewStoryTranslationRequestDTO!){
              createStoryTranslation(storyTranslationData: {
                "translatorId": ${INSERT USER_ID  HERE},
                "storyId": ${INSERT STORY_ID  HERE},
                "language": "English"
            }){
                story{
                  id
                  translatorId
                  storyId
                  language
                  stage
		}
	}
}
```
5. Profit
6. Now to test error states, try any of the following: Invalid story_id/user_id/language/stage

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* I don't like the code pattern because of the repeated db.commit but according to [this helpful article I only found after debugging for like 30 minutes](https://flask-sqlalchemy.palletsprojects.com/en/2.x/queries/) you only get the primary key of the object after you commit. So if anyone has a workaround to this lmk 👍
* Also, this means I used like double try except loops so we don't ever have a case where a query fails when making the StoryTranslationContents entries and then just leaves the instantiated StoryTranslation entry existing so, lmk if there's a workaround to this as well.

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
