### PR TITLE
Fix bug in content loading for story queries

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -13,7 +13,9 @@ class StoryService(IStoryService):
     def get_stories(self):
         # Entity is a SQLAlchemy model, we can use convenient methods provided
         # by SQLAlchemy like query.all() to query the data
-        return [result.to_dict() for result in Story.query.all()]
+        return [
+            story.to_dict(include_relationships=True) for story in Story.query.all()
+        ]
 
     def get_story(self, id):
         # get queries by the primary key, which is id for the Story table
@@ -21,7 +23,7 @@ class StoryService(IStoryService):
         if story is None:
             self.logger.error("Invalid id")
             raise Exception("Invalid id")
-        return story.to_dict()
+        return story.to_dict(include_relationships=True)
 
     def create_story(self, story, content):
         # create story


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Fully load content on storyByID](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=4a47edc475b34bb99b25ff1fae2a5507&p=d2730d8328e948b4be291b19c2aaf126)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* I don't know why this fixes anything I'm sorry


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Set up your DBs, make sure that you have at least one story
2. Test query:
```
{
  storyById(id: 2) {
    id
    title
    contents {
      id
      storyId
      lineIndex
      content
    }
  }
  stories {
    id
    contents {
      id
      storyId
      lineIndex
      content
    }
  }
}
```
3. Make sure `contents` field is not null on either! Either empty array `"contents": []` or something like
```
"contents": [
  {
    "id": 1,
    "storyId": "1",
    "lineIndex": 0,
    "content": "Line 1"
  },
  {
    "id": 2,
    "storyId": "1",
    "lineIndex": 1,
    "content": "Line 2"
  }
]
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* _why does this work_ 🐋 🐳 🐋 
* About lazy-loading, I chose default behaviour there are sufficient cases where I see us querying without wanting all the content details. Reference here -> https://docs-sqlalchemy.readthedocs.io/ko/latest/orm/loading_relationships.html

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
