### PR TITLE
List StoryTranslations currently being translated or reviewed by User

### DIFF
--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -7,3 +7,7 @@ def resolve_stories(root, info, **kwargs):
 
 def resolve_story_by_id(root, info, id):
     return services["story"].get_story(id)
+
+
+def resolve_story_translations_by_user(root, info, user_id, translator):
+    return services["story"].get_story_translations(user_id, translator)

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -5,10 +5,14 @@ from .mutations.entity_mutation import CreateEntity
 from .mutations.story_mutation import CreateStory
 from .mutations.user_mutation import CreateUser, UpdateUser
 from .queries.entity_query import resolve_entities
-from .queries.story_query import resolve_stories, resolve_story_by_id
+from .queries.story_query import (
+    resolve_stories,
+    resolve_story_by_id,
+    resolve_story_translations_by_user,
+)
 from .queries.user_query import resolve_user_by_email, resolve_user_by_id, resolve_users
 from .types.entity_type import EntityResponseDTO
-from .types.story_type import StoryResponseDTO
+from .types.story_type import StoryResponseDTO, StoryTranslationResponseDTO
 from .types.user_type import UserDTO
 
 
@@ -26,6 +30,11 @@ class Query(graphene.ObjectType):
     entities = graphene.Field(graphene.List(EntityResponseDTO))
     stories = graphene.Field(graphene.List(StoryResponseDTO))
     story_by_id = graphene.Field(StoryResponseDTO, id=graphene.Int())
+    story_translations_by_user = graphene.Field(
+        graphene.List(StoryTranslationResponseDTO),
+        user_id=graphene.Int(),
+        translator=graphene.Boolean(),
+    )
     users = graphene.Field(graphene.List(UserDTO))
     user_by_id = graphene.Field(UserDTO, id=graphene.Int())
     user_by_email = graphene.Field(UserDTO, email=graphene.String())
@@ -47,6 +56,9 @@ class Query(graphene.ObjectType):
 
     def resolve_user_by_email(root, info, email):
         return resolve_user_by_email(root, info, email)
+
+    def resolve_story_translations_by_user(root, info, user_id, translator):
+        return resolve_story_translations_by_user(root, info, user_id, translator)
 
 
 schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -33,3 +33,16 @@ class StoryRequestDTO(graphene.InputObjectType):
     youtube_link = graphene.String(required=True)
     level = graphene.Int(required=True)
     translated_languages = graphene.List(LanguageEnum)
+
+
+class StoryTranslationResponseDTO(graphene.ObjectType):
+    story_id = graphene.Int(required=True)
+    title = graphene.String(required=True)
+    description = graphene.String(required=True)
+    youtube_link = graphene.String(required=True)
+    level = graphene.Int(required=True)
+    story_translation_id = graphene.Int(required=True)
+    language = graphene.String(required=True)
+    stage = graphene.Field(StageEnum, required=True)
+    translator_id = graphene.Int()
+    reviewer_id = graphene.Int()

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -38,3 +38,15 @@ class IStoryService(ABC):
         :raises Exception: if entity fields are invalid
         """
         pass
+
+    @abstractmethod
+    def get_story_translations(self, user_id, translate):
+        """Return a list of stories currently being translated/reviewed
+
+        :param user_id: id of the user
+        :param translator: boolean; if True will return a list of stories
+        being translated by the user, else a list of stories being reviewed
+        :return: list of StoryTranslationResponseDTO's
+        :rtype: list of StoryTranslationResponseDTO's
+        """
+        pass


### PR DESCRIPTION
## Notion ticket link
[List StoryTranslations currently being translated or reviewed by User](https://www.notion.so/uwblueprintexecs/List-StoryTranslations-currently-being-translated-or-reviewed-by-User-6d4c73c43a5741979392feb916a475f9)

## Implementation description
* added query to return list of StoryTranslations by User based on whether they are a translator (translator=True) or reviewer (translator=False)

## Steps to test
1. Seed database with at least 2 users
```
$ docker exec -it <db container id> psql -U postgres -d planet-read
$ INSERT INTO users (first_name, last_name, auth_id, role, approved_languages) VALUES ('First', 'Last', 'insert-firebase-uid', 'Admin', '{"english":3}');
```
2. Seed database with stories/story translation entries
```
$ INSERT INTO stories (title, description, youtube_link, level) VALUES ('my story title', 'story description', 'link', 1);
$ INSERT INTO story_translations (story_id, language, stage, translator_id, reviewer_id) VALUES (<id of inserted story>, 'ARABIC', 'START', 1, 2);
```
3. Run query and verify the correct values from Story/StoryTranslation are retrieved (in this case a list of stories where user is the translator should be returned)
```
{
  storyTranslationsByUser(userId: 2, translator: true) {
    storyId
    title
    description
    youtube_link
    level
    storyTranslationId
    language
    stage
    translatorId
    reviewerId
  }
}
```
4. Change translate to `false` as well to verify only stories where the user is a reviewer are returned
```
{
  storyTranslationsByUser(userId: 2, translator: false) {
    storyId
    title
    description
    youtube_link
    level
    storyTranslationId
    language
    stage
    translatorId
    reviewerId
  }
}
```

## What should reviewers focus on?
* query in `app/services/implementations/story_service.py`
*  `StoryTranslationResponseDTO` in `backend/python/app/graphql/types/story_type.py` 
     * right now the query returns the id, title, description and level from the Story table and id, language, stage, translator_id, reviewer_id from the StoryTranslation table--are these the fields we want returned/more/less?

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
