### PR TITLE
Logout gql migration

### DIFF
--- a/backend/python/app/graphql/mutations/auth_mutation.py
+++ b/backend/python/app/graphql/mutations/auth_mutation.py
@@ -85,7 +85,6 @@ class Logout(graphene.Mutation):
             return Logout(ok=True)
         except Exception as e:
             error_message = getattr(e, "message", None)
-            print(error_message)
             return Exception(error_message if error_message else str(e))
 
 

--- a/backend/python/app/graphql/mutations/auth_mutation.py
+++ b/backend/python/app/graphql/mutations/auth_mutation.py
@@ -72,6 +72,20 @@ class Login(graphene.Mutation):
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))
 
+class Logout(graphene.Mutation):
+    class Arguments:
+        userId = graphene.ID(required=True)
+    
+    ok = graphene.Boolean()
+
+    def mutate(root, info, userId):
+        try:
+            services["auth"].revoke_tokens(userId)
+            return Logout(ok=True)
+        except Exception as e:
+            error_message = getattr(e, "message", None)
+            print(error_message)
+            return Exception(error_message if error_message else str(e))
 
 class SignUp(graphene.Mutation):
     class Arguments:

--- a/backend/python/app/graphql/mutations/auth_mutation.py
+++ b/backend/python/app/graphql/mutations/auth_mutation.py
@@ -72,10 +72,11 @@ class Login(graphene.Mutation):
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))
 
+
 class Logout(graphene.Mutation):
     class Arguments:
         userId = graphene.ID(required=True)
-    
+
     ok = graphene.Boolean()
 
     def mutate(root, info, userId):
@@ -86,6 +87,7 @@ class Logout(graphene.Mutation):
             error_message = getattr(e, "message", None)
             print(error_message)
             return Exception(error_message if error_message else str(e))
+
 
 class SignUp(graphene.Mutation):
     class Arguments:

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -1,6 +1,6 @@
 import graphene
 
-from .mutations.auth_mutation import Login, Refresh, ResetPassword, SignUp
+from .mutations.auth_mutation import Login, Logout, Refresh, ResetPassword, SignUp
 from .mutations.entity_mutation import CreateEntity
 from .mutations.story_mutation import CreateStory, CreateStoryTranslation
 from .mutations.user_mutation import CreateUser, UpdateUser
@@ -24,6 +24,7 @@ class Mutation(graphene.ObjectType):
     reset_password = ResetPassword.Field()
     update_user = UpdateUser.Field()
     login = Login.Field()
+    logout = Logout.Field()
     signup = SignUp.Field()
     refresh = Refresh.Field()
 

--- a/frontend/src/components/auth/Logout.tsx
+++ b/frontend/src/components/auth/Logout.tsx
@@ -20,7 +20,6 @@ const Logout = () => {
   const [logout, { error }] = useMutation<{ logout: LogoutResponse }>(LOGOUT);
 
   const onLogOutClick = async () => {
-    console.log("Test");
     const result = await logout({
       variables: { userId: String(authenticatedUser?.id) },
     });
@@ -28,8 +27,6 @@ const Logout = () => {
     if (result.data?.logout.ok === true) {
       success = true;
       localStorage.removeItem(AUTHENTICATED_USER_KEY);
-    }
-    if (success) {
       setAuthenticatedUser(null);
     }
   };

--- a/frontend/src/components/auth/Logout.tsx
+++ b/frontend/src/components/auth/Logout.tsx
@@ -1,19 +1,50 @@
-import React, { useContext } from "react";
-import authAPIClient from "../../APIClients/AuthAPIClient";
+import React, { useContext, useEffect } from "react";
+import { gql, useMutation } from "@apollo/client";
 import AuthContext from "../../contexts/AuthContext";
+import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
+
+interface LogoutResponse {
+  ok: Boolean;
+}
+
+const LOGOUT = gql`
+  mutation Logout($userId: ID!) {
+    logout(userId: $userId) {
+      ok
+    }
+  }
+`;
 
 const Logout = () => {
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);
+  const [logout, { data, error }] = useMutation<{ logout: LogoutResponse }>(
+    LOGOUT,
+  );
 
-  const onLogOutClick = async () => {
-    const success = await authAPIClient.logout(authenticatedUser?.id);
-    if (success) {
+  useEffect(() => {
+    if (data?.logout?.ok) {
       setAuthenticatedUser(null);
+      localStorage.removeItem(AUTHENTICATED_USER_KEY);
     }
-  };
+  }, [data]);
+
+  useEffect(() => {
+    if (error) {
+      // TODO: Implement Error State
+      console.log(error);
+    }
+  }, [error]);
 
   return (
-    <button type="button" className="btn btn-primary" onClick={onLogOutClick}>
+    <button
+      type="button"
+      className="btn btn-primary"
+      onClick={() => {
+        logout({
+          variables: { userId: authenticatedUser?.id },
+        });
+      }}
+    >
       Log Out
     </button>
   );

--- a/frontend/src/components/auth/Logout.tsx
+++ b/frontend/src/components/auth/Logout.tsx
@@ -23,9 +23,7 @@ const Logout = () => {
     const result = await logout({
       variables: { userId: String(authenticatedUser?.id) },
     });
-    let success: boolean = false;
     if (result.data?.logout.ok === true) {
-      success = true;
       localStorage.removeItem(AUTHENTICATED_USER_KEY);
       setAuthenticatedUser(null);
     }

--- a/frontend/src/components/auth/Logout.tsx
+++ b/frontend/src/components/auth/Logout.tsx
@@ -17,16 +17,22 @@ const LOGOUT = gql`
 
 const Logout = () => {
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);
-  const [logout, { data, error }] = useMutation<{ logout: LogoutResponse }>(
-    LOGOUT,
-  );
+  const [logout, { error }] = useMutation<{ logout: LogoutResponse }>(LOGOUT);
 
-  useEffect(() => {
-    if (data?.logout?.ok) {
-      setAuthenticatedUser(null);
+  const onLogOutClick = async () => {
+    console.log("Test");
+    const result = await logout({
+      variables: { userId: String(authenticatedUser?.id) },
+    });
+    let success: boolean = false;
+    if (result.data?.logout.ok === true) {
+      success = true;
       localStorage.removeItem(AUTHENTICATED_USER_KEY);
     }
-  }, [data]);
+    if (success) {
+      setAuthenticatedUser(null);
+    }
+  };
 
   useEffect(() => {
     if (error) {
@@ -36,15 +42,7 @@ const Logout = () => {
   }, [error]);
 
   return (
-    <button
-      type="button"
-      className="btn btn-primary"
-      onClick={() => {
-        logout({
-          variables: { userId: authenticatedUser?.id },
-        });
-      }}
-    >
+    <button type="button" className="btn btn-primary" onClick={onLogOutClick}>
       Log Out
     </button>
   );


### PR DESCRIPTION
## Notion ticket link
[Migrate logout endpoint to GraphQL](https://www.notion.so/uwblueprintexecs/Migrate-logout-endpoint-to-GraphQL-e9bc15fed00e4dc9b4bb0f8811e08521)


## Implementation description
* Copied & pasted code from the rest endpoint for backend 👍
* Refactored frontend to use some hooks
* Good vibes 😎


## Steps to test
1. Start the container & go to the web app
2. Login
3. Logout
4. yes


## What should reviewers focus on?
* Nothing much, I think this should be a fairly standard migration, _might_ be subject to the same issues as the [refresh ticket](https://github.com/uwblueprint/planet-read/pull/22) but I doubt it since it seems to work and I don't think that's how auth is implemented.
* Some of the type stuff might be finnicky in the frontend, I've never use Typescript so lmk if I'm violating any best practices


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
