### PR TITLE
Change ResetPassword props declaration from type to interface

### DIFF
--- a/frontend/src/components/auth/ResetPassword.tsx
+++ b/frontend/src/components/auth/ResetPassword.tsx
@@ -2,9 +2,9 @@ import React, { useContext } from "react";
 import { gql, useMutation } from "@apollo/client";
 import AuthContext from "../../contexts/AuthContext";
 
-interface ResetPasswordProps {
+type ResetPasswordProps = {
   email?: string;
-}
+};
 
 const RESET_PASSWORD = gql`
   mutation ResetPassword($email: String!) {

--- a/frontend/src/components/auth/ResetPassword.tsx
+++ b/frontend/src/components/auth/ResetPassword.tsx
@@ -1,9 +1,8 @@
-import React, { useContext } from "react";
+import React from "react";
 import { gql, useMutation } from "@apollo/client";
-import AuthContext from "../../contexts/AuthContext";
 
 type ResetPasswordProps = {
-  email?: string;
+  email: string;
 };
 
 const RESET_PASSWORD = gql`
@@ -15,8 +14,6 @@ const RESET_PASSWORD = gql`
 `;
 
 const ResetPassword = ({ email }: ResetPasswordProps) => {
-  const { authenticatedUser } = useContext(AuthContext);
-
   const isRealEmailAvailable = (emailString: string): boolean => {
     const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(String(emailString).toLowerCase());
@@ -36,17 +33,16 @@ const ResetPassword = ({ email }: ResetPasswordProps) => {
   };
 
   const onResetPasswordClick = async () => {
-    if (authenticatedUser == null && !isRealEmailAvailable(email!)) {
+    if (!isRealEmailAvailable(email!)) {
       alert("Invalid email");
       return;
     }
 
-    const resetEmail = authenticatedUser?.email ?? email;
     try {
-      const result = await resetPassword({ variables: { email: resetEmail } });
+      const result = await resetPassword({ variables: { email } });
 
       if (result.data?.resetPassword.ok) {
-        handleSuccessOnReset(`Reset email sent to ${resetEmail}`);
+        handleSuccessOnReset(`Reset email sent to ${email}`);
       } else {
         handleErrorOnReset("Reset password failed.");
       }
@@ -64,10 +60,6 @@ const ResetPassword = ({ email }: ResetPasswordProps) => {
       Reset Password
     </button>
   );
-};
-
-ResetPassword.defaultProps = {
-  email: "",
 };
 
 export default ResetPassword;

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useContext } from "react";
 import { useHistory } from "react-router-dom";
 
 import Logout from "../auth/Logout";
 import RefreshCredentials from "../auth/RefreshCredentials";
 import ResetPassword from "../auth/ResetPassword";
+import AuthContext from "../../contexts/AuthContext";
 
 const CreateButton = () => {
   const history = useHistory();
@@ -48,13 +49,15 @@ const HomePageButton = () => {
 };
 
 const Default = () => {
+  const { authenticatedUser } = useContext(AuthContext);
+
   return (
     <div style={{ textAlign: "center", paddingTop: "20px" }}>
       <h1>Default Page</h1>
       <div className="btn-group" style={{ paddingRight: "10px" }}>
         <Logout />
         <RefreshCredentials />
-        <ResetPassword />
+        <ResetPassword email={authenticatedUser!!.email} />
         <CreateButton />
         <UpdateButton />
         <GetButton />


### PR DESCRIPTION
## Notion ticket link
Dev health thing


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Change from interface to type declaration


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Start localhost and try reset password when logged in and logged out (with real / not real input)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* More of me being unsure about Typescript conventions. This seems to imply that default props that I'm relying on will be deprecated (https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/default_props/, https://github.com/reactjs/rfcs/pull/107). To be replaced by object default values but we're using functional components everywhere?
* Otherwise, we could declare the type as `string | null` and throw some nullchecks in?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
