### PR TITLE
Create updateStoryTranslationContent mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If there are no tables in the DB, go into `/backend/python/app/models/__init__.p
 # Lint
 Frontend has on-save linting. To lint the backend:
 ```
-docker exec <backend-container-id> /bin/bash -c "black . && isort --profile black ."
+docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."
 ```
 
 Follow the [getting started](https://uwblueprint.github.io/starter-code-v2/docs/getting-started) for more details, especially if you desire to use your own firebase and gcp projects.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If there are no tables in the DB, go into `/backend/python/app/models/__init__.p
 # Lint
 Frontend has on-save linting. To lint the backend:
 ```
-docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."
+docker exec <backend-container-id> /bin/bash -c "black . && isort --profile black ."
 ```
 
 Follow the [getting started](https://uwblueprint.github.io/starter-code-v2/docs/getting-started) for more details, especially if you desire to use your own firebase and gcp projects.

--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -6,6 +6,8 @@ from ..types.story_type import (
     CreateStoryTranslationResponseDTO,
     StoryRequestDTO,
     StoryResponseDTO,
+    StoryTranslationContentRequestDTO,
+    StoryTranslationContentResponseDTO,
 )
 
 
@@ -35,6 +37,25 @@ class CreateStoryTranslation(graphene.Mutation):
                 story_translation_data
             )
             return CreateStoryTranslation(story=new_story_translation)
+        except Exception as e:
+            error_message = getattr(e, "message", None)
+            raise Exception(error_message if error_message else str(e))
+
+
+class UpdateStoryTranslationContentById(graphene.Mutation):
+    class Arguments:
+        story_translation_content_data = StoryTranslationContentRequestDTO(
+            required=True
+        )
+
+    story = graphene.Field(lambda: StoryTranslationContentResponseDTO)
+
+    def mutate(root, info, story_translation_content_data):
+        try:
+            new_story_translation = services["story"].update_translation(
+                story_translation_content_data
+            )
+            return UpdateStoryTranslationContentById(new_story_translation)
         except Exception as e:
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))

--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -52,7 +52,7 @@ class UpdateStoryTranslationContentById(graphene.Mutation):
 
     def mutate(root, info, story_translation_content_data):
         try:
-            new_story_translation = services["story"].update_translation(
+            new_story_translation = services["story"].update_story_translation_content(
                 story_translation_content_data
             )
             return UpdateStoryTranslationContentById(new_story_translation)
@@ -69,9 +69,9 @@ class UpdateStoryTranslationContents(graphene.Mutation):
 
     def mutate(root, info, story_translation_contents):
         try:
-            new_story_translation_contents = services["story"].update_translations(
-                story_translation_contents
-            )
+            new_story_translation_contents = services[
+                "story"
+            ].update_story_translation_contents(story_translation_contents)
             return UpdateStoryTranslationContents(new_story_translation_contents)
         except Exception as e:
             error_message = getattr(e, "message", None)

--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -59,3 +59,20 @@ class UpdateStoryTranslationContentById(graphene.Mutation):
         except Exception as e:
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))
+
+
+class UpdateStoryTranslationContents(graphene.Mutation):
+    class Arguments:
+        story_translation_contents = graphene.List(StoryTranslationContentRequestDTO)
+
+    story = graphene.Field(lambda: graphene.List(StoryTranslationContentResponseDTO))
+
+    def mutate(root, info, story_translation_contents):
+        try:
+            new_story_translation_contents = services["story"].update_translations(
+                story_translation_contents
+            )
+            return UpdateStoryTranslationContents(new_story_translation_contents)
+        except Exception as e:
+            error_message = getattr(e, "message", None)
+            raise Exception(error_message if error_message else str(e))

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -3,7 +3,11 @@ import graphene
 from .mutations.auth_mutation import Login, Logout, Refresh, ResetPassword, SignUp
 from .mutations.entity_mutation import CreateEntity
 from .mutations.file_mutation import CreateFile
-from .mutations.story_mutation import CreateStory, CreateStoryTranslation
+from .mutations.story_mutation import (
+    CreateStory,
+    CreateStoryTranslation,
+    UpdateStoryTranslationContentById,
+)
 from .mutations.user_mutation import CreateUser, UpdateUser
 from .queries.entity_query import resolve_entities
 from .queries.file_query import resolve_file_by_id
@@ -32,6 +36,8 @@ class Mutation(graphene.ObjectType):
     logout = Logout.Field()
     signup = SignUp.Field()
     refresh = Refresh.Field()
+    create_story_translation = CreateStoryTranslation.Field()
+    update_story_translation_content_by_id = UpdateStoryTranslationContentById.Field()
 
 
 class Query(graphene.ObjectType):

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -37,7 +37,6 @@ class Mutation(graphene.ObjectType):
     logout = Logout.Field()
     signup = SignUp.Field()
     refresh = Refresh.Field()
-    create_story_translation = CreateStoryTranslation.Field()
     update_story_translation_content_by_id = UpdateStoryTranslationContentById.Field()
     update_story_translation_contents = UpdateStoryTranslationContents.Field()
 

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -7,6 +7,7 @@ from .mutations.story_mutation import (
     CreateStory,
     CreateStoryTranslation,
     UpdateStoryTranslationContentById,
+    UpdateStoryTranslationContents,
 )
 from .mutations.user_mutation import CreateUser, UpdateUser
 from .queries.entity_query import resolve_entities
@@ -38,6 +39,7 @@ class Mutation(graphene.ObjectType):
     refresh = Refresh.Field()
     create_story_translation = CreateStoryTranslation.Field()
     update_story_translation_content_by_id = UpdateStoryTranslationContentById.Field()
+    update_story_translation_contents = UpdateStoryTranslationContents.Field()
 
 
 class Query(graphene.ObjectType):

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -65,9 +65,9 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
 
 class StoryTranslationContentRequestDTO(graphene.InputObjectType):
     id = graphene.Int(required=True)
-    content = graphene.String(required=True)
+    translation_content = graphene.String(required=True)
 
 
 class StoryTranslationContentResponseDTO(graphene.ObjectType):
     id = graphene.Int(required=True)
-    content = graphene.String(required=True)
+    translation_content = graphene.String(required=True)

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -49,6 +49,7 @@ class CreateStoryTranslationRequestDTO(graphene.InputObjectType):
     language = graphene.String(required=True)
     stage = graphene.Field(StageEnum, default_value="TRANSLATE")
 
+
 class StoryTranslationResponseDTO(graphene.ObjectType):
     story_id = graphene.Int(required=True)
     title = graphene.String(required=True)
@@ -60,3 +61,13 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
     stage = graphene.Field(StageEnum, required=True)
     translator_id = graphene.Int()
     reviewer_id = graphene.Int()
+
+
+class StoryTranslationContentRequestDTO(graphene.InputObjectType):
+    id = graphene.Int(required=True)
+    content = graphene.String(required=True)
+
+
+class StoryTranslationContentResponseDTO(graphene.ObjectType):
+    id = graphene.Int(required=True)
+    content = graphene.String(required=True)

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -122,47 +122,53 @@ class StoryService(IStoryService):
             self.logger.error(str(error))
             raise error
 
-    def update_translation(self, entity):
+    def update_story_translation_content(self, story_translation_content):
         try:
-            old_translation_content = StoryTranslationContent.query.get(entity.id)
+            old_translation_content = StoryTranslationContent.query.get(
+                story_translation_content.id
+            )
 
             if not old_translation_content:
                 raise Exception(
-                    "story_translation_content_id {id} not found".format(id=entity.id)
+                    "story_translation_content_id {id} not found".format(
+                        id=story_translation_content.id
+                    )
                 )
 
-            StoryTranslationContent.query.filter_by(id=entity.id).update(
+            StoryTranslationContent.query.filter_by(
+                id=story_translation_content.id
+            ).update(
                 {
-                    StoryTranslationContent.translation_content: entity.translation_content
+                    StoryTranslationContent.translation_content: story_translation_content.translation_content
                 }
             )
             db.session.commit()
-        except Exception as e:
-            reason = getattr(e, "message", None)
+        except Exception as error:
+            reason = getattr(error, "message", None)
             self.logger.error(
                 "Failed to update story translation content. Reason = {reason}".format(
-                    reason=(reason if reason else str(e))
+                    reason=(reason if reason else str(error))
                 )
             )
-            raise e
+            raise error
 
         return StoryTranslationContentResponseDTO(
-            entity.id,
-            entity.translation_content,
+            story_translation_content.id,
+            story_translation_content.translation_content,
         )
 
-    def update_translations(self, story_translation_contents):
+    def update_story_translation_contents(self, story_translation_contents):
         try:
             db.session.bulk_update_mappings(
                 StoryTranslationContent, story_translation_contents
             )
             db.session.commit()
             return story_translation_contents
-        except Exception as e:
-            reason = getattr(e, "message", None)
+        except Exception as error:
+            reason = getattr(error, "message", None)
             self.logger.error(
                 "Failed to update story translation content. Reason = {reason}".format(
-                    reason=(reason if reason else str(e))
+                    reason=(reason if reason else str(error))
                 )
             )
-            raise e
+            raise error

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -6,6 +6,7 @@ from ...models.story_content import StoryContent
 from ...models.story_translation import StoryTranslation
 from ...models.story_translation_content import StoryTranslationContent
 from ..interfaces.story_service import IStoryService
+from ...graphql.types.story_type import StoryTranslationContentResponseDTO
 
 
 class StoryService(IStoryService):
@@ -120,3 +121,30 @@ class StoryService(IStoryService):
         except Exception as error:
             self.logger.error(str(error))
             raise error
+
+    def update_translation(self, entity):
+        try:
+            old_translation_content = StoryTranslationContent.query.get(entity.id)
+
+            if not old_translation_content:
+                raise Exception(
+                    "story_translation_content_id {id} not found".format(id=entity.id)
+                )
+
+            StoryTranslationContent.query.filter_by(id=entity.id).update(
+                {StoryTranslationContent.translation_content: entity.content}
+            )
+            db.session.commit()
+        except Exception as e:
+            reason = getattr(e, "message", None)
+            self.logger.error(
+                "Failed to update story translation content. Reason = {reason}".format(
+                    reason=(reason if reason else str(e))
+                )
+            )
+            raise e
+
+        return StoryTranslationContentResponseDTO(
+            entity.id,
+            entity.content,
+        )

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -52,10 +52,10 @@ class IStoryService(ABC):
         pass
 
     @abstractmethod
-    def update_translation(self, entity):
+    def update_story_translation_content(self, story_translation_content):
         """Update a single story translation content entry
 
-        :param entity: StoryTranslationContentRequestDTO id and updated
+        :param story_translation_content: StoryTranslationContentRequestDTO id and updated
         translation for story translation
         :return: StoryTranslationContentResponseDTO
         :rtype: StoryTranslationContentResponseDTO
@@ -63,10 +63,10 @@ class IStoryService(ABC):
         pass
 
     @abstractmethod
-    def update_translations(self, story_translations):
-        """Batch update story translation content entry
+    def update_story_translation_contents(self, story_translations):
+        """Batch update story translation content entries
 
-        :param entity: list of StoryTranslationContentRequestDTO objects
+        :param story_translations: list of StoryTranslationContentRequestDTO objects
         :return: list of StoryTranslationContentResponseDTO objects
         :rtype: [StoryTranslationContentResponseDTO]
         """

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -55,8 +55,19 @@ class IStoryService(ABC):
     def update_translation(self, entity):
         """Update a single story translation content entry
 
-        :param entity: id and updated translation for story translation
+        :param entity: StoryTranslationContentRequestDTO id and updated
+        translation for story translation
         :return: StoryTranslationContentResponseDTO
         :rtype: StoryTranslationContentResponseDTO
+        """
+        pass
+
+    @abstractmethod
+    def update_translations(self, story_translations):
+        """Batch update story translation content entry
+
+        :param entity: list of StoryTranslationContentRequestDTO objects
+        :return: list of StoryTranslationContentResponseDTO objects
+        :rtype: [StoryTranslationContentResponseDTO]
         """
         pass

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -50,3 +50,13 @@ class IStoryService(ABC):
         :rtype: list of StoryTranslationResponseDTO's
         """
         pass
+
+    @abstractmethod
+    def update_translation(self, entity):
+        """Update a single story translation content entry
+
+        :param entity: id and updated translation for story translation
+        :return: StoryTranslationContentResponseDTO
+        :rtype: StoryTranslationContentResponseDTO
+        """
+        pass


### PR DESCRIPTION
## Notion ticket link
[Create updateStoryTranslationContent and updateStoryTranslationContentById mutations](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=4a47edc475b34bb99b25ff1fae2a5507&p=4dd2a92fda8f4d6788c6a55a41e3dc14)


## Implementation description
* Added mutation to update story translation content by id: accepts id and new content string
* Added mutation to update story translation content in bulk: accepts list of StoryTranslationContentRequestDTOs (i.e. id and translation_content) and updates all


## Steps to test
1. Seed database with values for users, stories, story_contents, story_translations and story_translation_contents (at least 2 for story_translation_contents)
2. Test updating by id:
```
mutation{
  updateStoryTranslationContentById(storyTranslationContentData:{
    id: 1
    translationContent:"updated"
  }) {
    story {
      id
      translationContent
    }
  }
}
```
3. Verify that the entry was updated
```
$ docker exec -it <db docker id> psql -U postgres -d planet-read
$ select * from story_translation_contents;
```
4. Test updating in bulk:
```
mutation {
  updateStoryTranslationContents(storyTranslationContents: [{id: 1, translationContent: "update 1"}, {id: 2, translationContent: "update 2"}]) {
    story {
      id
      translationContent
    }
  }
}
```
5. Verify that the entries were updated:
```
$ docker exec -it <db docker id> psql -U postgres -d planet-read
$ select * from story_translation_contents;
```

## What should reviewers focus on?
* `/app/services/implementations/story_service.py`
* What should the return be for both of the updates? Right now it just returns the id and the translation_content but should it be returning the entire updated entry?
* Does changing the translation change the stage of the translation?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
