### PR TITLE
Add Story Pill to Story Cards 

### DIFF
--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -155,7 +155,13 @@ const StoryCard = ({
           <div className="story-card-tags">
             {/* TODO: make tags that reflect actual state */}
             <Tag displayText={`Level ${level}`} />
-            {storyTranslationId && <Tag displayText={`${language}`} />}
+            {!storyTranslationId && storyId && (
+              <Tag
+                displayText={`${
+                  language[0] + language.substring(1).toLowerCase()
+                }`}
+              />
+            )}
           </div>
         </div>
         <p className="story-card-description">{description}</p>

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -6,6 +6,7 @@ import Tag from "./Tag";
 import PrimaryButton from "./PrimaryButton";
 import SecondaryButton from "./SecondaryButton";
 import "./StoryCard.css";
+import changeLanguageToTitleCase from "../../utils/StoryCardUtils";
 
 type AssignReviewer = { ok: boolean };
 const ASSIGN_REVIEWER = gql`
@@ -155,13 +156,7 @@ const StoryCard = ({
           <div className="story-card-tags">
             {/* TODO: make tags that reflect actual state */}
             <Tag displayText={`Level ${level}`} />
-            {!storyTranslationId && storyId && (
-              <Tag
-                displayText={`${
-                  language[0] + language.substring(1).toLowerCase()
-                }`}
-              />
-            )}
+            <Tag displayText={`${changeLanguageToTitleCase(language)}`} />
           </div>
         </div>
         <p className="story-card-description">{description}</p>

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -6,7 +6,7 @@ import Tag from "./Tag";
 import PrimaryButton from "./PrimaryButton";
 import SecondaryButton from "./SecondaryButton";
 import "./StoryCard.css";
-import changeLanguageToTitleCase from "../../utils/StoryCardUtils";
+import convertLanguageTitleCase from "../../utils/LanguageUtils";
 
 type AssignReviewer = { ok: boolean };
 const ASSIGN_REVIEWER = gql`
@@ -154,9 +154,8 @@ const StoryCard = ({
         <div className="story-card-top">
           <p className="story-card-title">{title}</p>
           <div className="story-card-tags">
-            {/* TODO: make tags that reflect actual state */}
             <Tag displayText={`Level ${level}`} />
-            <Tag displayText={`${changeLanguageToTitleCase(language)}`} />
+            <Tag displayText={`${convertLanguageTitleCase(language)}`} />
           </div>
         </div>
         <p className="story-card-description">{description}</p>

--- a/frontend/src/utils/LanguageUtils.ts
+++ b/frontend/src/utils/LanguageUtils.ts
@@ -1,5 +1,5 @@
 // Change language string to title case
-function changeLanguageToTitleCase(language: string) {
+function convertLanguageTitleCase(language: string) {
   // Handles 4 edge cases: ENGLISH_US, ENGLISH_UK, ENGLISH_INDIA, ASANTE_TWI
   switch (language) {
     case "ENGLISH_US":
@@ -17,6 +17,6 @@ function changeLanguageToTitleCase(language: string) {
     default:
       return language[0] + language.substring(1).toLowerCase();
   }
-};
+}
 
-export { changeLanguageToTitleCase as default };
+export { convertLanguageTitleCase as default };

--- a/frontend/src/utils/StoryCardUtils.ts
+++ b/frontend/src/utils/StoryCardUtils.ts
@@ -1,0 +1,22 @@
+// Change language string to title case
+function changeLanguageToTitleCase(language: string) {
+  // Handles 4 edge cases: ENGLISH_US, ENGLISH_UK, ENGLISH_INDIA, ASANTE_TWI
+  switch (language) {
+    case "ENGLISH_US":
+      return "English (US)";
+
+    case "ENGLISH_UK":
+      return "English (UK)";
+
+    case "ENGLISH_INDIA":
+      return "English (India)";
+
+    case "ASANTE_TWI":
+      return "Asante Twi";
+
+    default:
+      return language[0] + language.substring(1).toLowerCase();
+  }
+}
+
+export { changeLanguageToTitleCase as default };

--- a/frontend/src/utils/StoryCardUtils.ts
+++ b/frontend/src/utils/StoryCardUtils.ts
@@ -17,6 +17,6 @@ function changeLanguageToTitleCase(language: string) {
     default:
       return language[0] + language.substring(1).toLowerCase();
   }
-}
+};
 
 export { changeLanguageToTitleCase as default };


### PR DESCRIPTION
## Notion ticket link
[Add Story Pill](https://www.notion.so/uwblueprintexecs/Add-language-pill-to-all-story-cards-ce7044a46e8944a1891aa613f9b83b0c)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add a file in /frontend/src/utils to convert language string to Title Case 
* Remove conditional that storyTranslationId needs to be defined before showing story language pill 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Log in as a user and see if story language pill is displayed 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Ensure that the 4 edge cases are displayed properly (ENGLISH_US, ENGLISH_UK, ENGLISH_INDIA, ASANTE_TWI) 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
