### PR TITLE
Fix line index bug and MySQL migration errors in seed_db script

### DIFF
--- a/seed_db.sh
+++ b/seed_db.sh
@@ -135,36 +135,38 @@ else
 
     for STORY_ID in 1 2 3 4 5 6 7
     do 
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 1, '“Every two weeks I went to a meeting with them, and in my room here I covered pages with writing. 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 0, '“Every two weeks I went to a meeting with them, and in my room here I covered pages with writing. 
             I bought every known Hebrew dictionary. But the old gentlemen were always ahead of me. 
             It wasn’t long before they were ahead of our rabbi; he brought a colleague in. ');"
 
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 2, 'Mr. Hamilton, you should have sat through some of those nights of argument and discussion. 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 1, 'Mr. Hamilton, you should have sat through some of those nights of argument and discussion. 
             The questions, the inspection, oh, the lovely thinking—the beautiful thinking.');"
                                                                                                                                                         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 3, 'After two years we felt that we could approach your sixteen verses of the fourth chapter of Genesis. ');"
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 2, 'After two years we felt that we could approach your sixteen verses of the fourth chapter of Genesis. ');"
 
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 4, 'My old gentlemen felt that these words were very important too—’Thou shalt’ and ‘Do thou.’ 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 3, 'My old gentlemen felt that these words were very important too—’Thou shalt’ and ‘Do thou.’ 
             And this was the gold from our mining: ‘Thou mayest.’ ‘Thou mayest rule over sin.’ ');"
 
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 5, 'The old gentlemen smiled and nodded and felt the years were well spent. It brought them out of their
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 4, 'The old gentlemen smiled and nodded and felt the years were well spent. It brought them out of their
             Chinese shells too, and right now they are studying Greek.” ');"
         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 6, 'Samuel said, “It’s a fantastic story. And I’ve tried to follow and maybe I’ve missed somewhere. 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 5, 'Samuel said, “It’s a fantastic story. And I’ve tried to follow and maybe I’ve missed somewhere. 
             Why is this word so important?”');"
         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 7, 'Lee’s hand shook as he filled the delicate cups. 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 6, 'Lee’s hand shook as he filled the delicate cups. 
             He drank his down in one gulp. “Don’t you see?” he cried. ');"
         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 8, '“The American Standard translation orders men to triumph over sin, and you can call sin ignorance. ');"
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 7, '“The American Standard translation orders men to triumph over sin, and you can call sin ignorance. ');"
         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 9, 'The King James translation makes a promise in ‘Thou shalt,’ 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 8, 'The King James translation makes a promise in ‘Thou shalt,’ 
             meaning that men will surely triumph over sin. ');"
         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 10, 'But the Hebrew word, the word timshel—‘Thou mayest’—that gives a choice. 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_ID', 9, 'But the Hebrew word, the word timshel—‘Thou mayest’—that gives a choice. 
             It might be the most important word in the world. 
             That says the way is open. That throws it right back on a man.
             For if ‘Thou mayest’—it is also true that ‘Thou mayest not.’ Don’t you see?”');"
+        
+        docker exec -it planet-read_db_1 psql -U postgres -d planet-read -c "INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_TRANSLATION_ID', 10, 'Well this line is probably a disappointment.');"
     done 
 
     
@@ -174,42 +176,44 @@ else
 
     for STORY_TRANSLATION_ID in 2 3 5 7 11 13 
     do 
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 1, '“Every two weeks I went to a meeting with them, and in my room here I covered pages with writing. 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 0, '“Every two weeks I went to a meeting with them, and in my room here I covered pages with writing. 
             I bought every known Hebrew dictionary. But the old gentlemen were always ahead of me. 
             It wasn’t long before they were ahead of our rabbi; he brought a colleague in. ');"
 
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 2, 'Mr. Hamilton, you should have sat through some of those nights of argument and discussion. 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 1, 'Mr. Hamilton, you should have sat through some of those nights of argument and discussion. 
             The questions, the inspection, oh, the lovely thinking—the beautiful thinking.');"
                                                                                                                                                         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 3, 'After two years we felt that we could approach your sixteen verses of the fourth chapter of Genesis. ');"
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 2, 'After two years we felt that we could approach your sixteen verses of the fourth chapter of Genesis. ');"
 
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 4, 'My old gentlemen felt that these words were very important too—’Thou shalt’ and ‘Do thou.’ 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 3, 'My old gentlemen felt that these words were very important too—’Thou shalt’ and ‘Do thou.’ 
             And this was the gold from our mining: ‘Thou mayest.’ ‘Thou mayest rule over sin.’ ');"
 
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 5, 'The old gentlemen smiled and nodded and felt the years were well spent. It brought them out of their
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 4, 'The old gentlemen smiled and nodded and felt the years were well spent. It brought them out of their
             Chinese shells too, and right now they are studying Greek.” ');"
         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 6, 'Samuel said, “It’s a fantastic story. And I’ve tried to follow and maybe I’ve missed somewhere. 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 5, 'Samuel said, “It’s a fantastic story. And I’ve tried to follow and maybe I’ve missed somewhere. 
             Why is this word so important?”');"
         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 7, 'Lee’s hand shook as he filled the delicate cups. 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 6, 'Lee’s hand shook as he filled the delicate cups. 
             He drank his down in one gulp. “Don’t you see?” he cried. ');"
         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 8, '“The American Standard translation orders men to triumph over sin, 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 7, '“The American Standard translation orders men to triumph over sin, 
             and you can call sin ignorance. ');"
         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 9, 'The King James translation makes a promise in ‘Thou shalt,’ 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 8, 'The King James translation makes a promise in ‘Thou shalt,’ 
             meaning that men will surely triumph over sin. ');"
         
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 10, 'But the Hebrew word, the word timshel—‘Thou mayest’—that gives a choice. 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 9, 'But the Hebrew word, the word timshel—‘Thou mayest’—that gives a choice. 
             It might be the most important word in the world. 
             That says the way is open. That throws it right back on a man.
             For if ‘Thou mayest’—it is also true that ‘Thou mayest not.’ Don’t you see?”');"
+        
+        docker exec -it planet-read_db_1 psql -U postgres -d planet-read -c "INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 10, 'Another disappointing line.');"
     done 
 
     for STORY_TRANSLATION_ID in 1 4 6 8 9 10  
     do 
-        for i in 1 2 3 4 5 6 7 8 9 10
+        for i in 0 1 2 3 4 5 6 7 8 9 10
         do
             docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', $i, '');"
         done 
@@ -217,7 +221,7 @@ else
 
     for STORY_TRANSLATION_ID in 12 
     do 
-        for i in 1 2 3 4 5 6 7 8 9 
+        for i in 0 1 2 3 4 5 6 7 8 9 
         do
             docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', $i, '');"
         done 

--- a/seed_db.sh
+++ b/seed_db.sh
@@ -68,7 +68,7 @@ else
     
 
     # users 
-    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER SEQUENCE users_id_seq RESTART WITH 1;"
+    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER TABLE users AUTO_INCREMENT = 1;"
 
     docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO users (first_name, last_name, auth_id, role, approved_languages) VALUES ('Carl', 'Sagan', '$AUTH_ID_1', 'User', '{\"ENGLISH_US\":4}');"
     docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO users (first_name, last_name, auth_id, role, approved_languages) VALUES ('Miroslav', 'Klose', '$AUTH_ID_2', 'User', '{\"POLISH\":4, \"GERMAN\":4}');"
@@ -82,7 +82,7 @@ else
     if  [[ "$1" = "kevin" ]] 
     then 
         # stories 
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER SEQUENCE stories_id_seq RESTART WITH 1;"
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER TABLE stories AUTO_INCREMENT = 1;"
         
         docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO stories (title, description, youtube_link, level, translated_languages) VALUES ('Kevin Burns Coal to Create Smog', 'He wants to test out the HEPA filter in the new Tesla he got for his birthday', 'https://www.youtube.com/watch?v=pP44EPBMb8A', 4, '[\"GERMAN\", \"ENGLISH_UK\"]');"
         docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO stories (title, description, youtube_link, level, translated_languages) VALUES ('Kevin Drives Dolphin Species to Extinction', 'He said dolphin looked at him funny', 'https://www.youtube.com/watch?v=ouAccsTzlGU', 2, '[\"GERMAN\", \"POLISH\"]');"
@@ -94,7 +94,7 @@ else
     
     else 
         # stories 
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER SEQUENCE stories_id_seq RESTART WITH 1;"
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER TABLE stories AUTO_INCREMENT = 1;"
         
         docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO stories (title, description, youtube_link, level, translated_languages) VALUES ('East of Eden', 'John Steinbeck', 'https://www.youtube.com/watch?v=DHyUYg8X31c', 4, '[\"GERMAN\", \"ENGLISH_UK\"]');"
         docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO stories (title, description, youtube_link, level, translated_languages) VALUES ('War and Peace', 'Leo Tolstoy', 'https://www.youtube.com/watch?v=Da-2h2B4faU&t=4s', 1, '[\"GERMAN\", \"POLISH\"]');"
@@ -107,7 +107,7 @@ else
     
 
     # story_translations
-    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER SEQUENCE story_translations_id_seq RESTART WITH 1;"
+    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER TABLE story_translations AUTO_INCREMENT = 1;"
 
 
     docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translations (story_id, language, stage, translator_id) VALUES (1, 'GERMAN', 'TRANSLATE', 6);"
@@ -123,7 +123,7 @@ else
     docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translations (story_id, language, stage, translator_id) VALUES (4, 'ENGLISH_UK', 'TRANSLATE', 4);"
 
     docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translations (story_id, language, stage, translator_id) VALUES (5, 'GERMAN', 'TRANSLATE', 2);"
-    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translations (story_id, language, stage, translator_id) VALUES (5, 'ENGLISH_US', 'TRANSLATE', 1);"
+    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translations (story_id, language, stage, translator_id) VALUES (4, 'ENGLISH_UK', 'TRANSLATE', 1);"
     docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translations (story_id, language, stage, translator_id) VALUES (5, 'PORTUGUESE', 'TRANSLATE', 7);"
     docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translations (story_id, language, stage, translator_id) VALUES (5, 'DUTCH', 'TRANSLATE', 3);"
 
@@ -131,7 +131,7 @@ else
 
 
     # Story content 
-    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER SEQUENCE story_contents_id_seq RESTART WITH 1;"
+    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER TABLE story_contents AUTO_INCREMENT = 1;"
 
     for STORY_ID in 1 2 3 4 5 6 7
     do 
@@ -165,13 +165,11 @@ else
             It might be the most important word in the world. 
             That says the way is open. That throws it right back on a man.
             For if ‘Thou mayest’—it is also true that ‘Thou mayest not.’ Don’t you see?”');"
-        
-        docker exec -it planet-read_db_1 psql -U postgres -d planet-read -c "INSERT INTO story_contents (story_id, line_index, content) VALUES ('$STORY_TRANSLATION_ID', 10, 'Well this line is probably a disappointment.');"
     done 
 
     
     # Story translation content 
-    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER SEQUENCE story_translation_contents_id_seq RESTART WITH 1;"
+    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER TABLE story_translation_contents AUTO_INCREMENT = 1;"
 
 
     for STORY_TRANSLATION_ID in 2 3 5 7 11 13 
@@ -207,13 +205,11 @@ else
             It might be the most important word in the world. 
             That says the way is open. That throws it right back on a man.
             For if ‘Thou mayest’—it is also true that ‘Thou mayest not.’ Don’t you see?”');"
-        
-        docker exec -it planet-read_db_1 psql -U postgres -d planet-read -c "INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 10, 'Another disappointing line.');"
     done 
 
     for STORY_TRANSLATION_ID in 1 4 6 8 9 10  
     do 
-        for i in 0 1 2 3 4 5 6 7 8 9 10
+        for i in 0 1 2 3 4 5 6 7 8 9
         do
             docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', $i, '');"
         done 
@@ -221,12 +217,12 @@ else
 
     for STORY_TRANSLATION_ID in 12 
     do 
-        for i in 0 1 2 3 4 5 6 7 8 9 
+        for i in 0 1 2 3 4 5 6 7 8
         do
             docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', $i, '');"
         done 
 
-        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 10, 'But the Hebrew word, the word timshel—‘Thou mayest’—that gives a choice. 
+        docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; INSERT INTO story_translation_contents (story_translation_id, line_index, translation_content) VALUES ('$STORY_TRANSLATION_ID', 9, 'But the Hebrew word, the word timshel—‘Thou mayest’—that gives a choice. 
             It might be the most important word in the world. 
             That says the way is open. That throws it right back on a man.
             For if ‘Thou mayest’—it is also true that ‘Thou mayest not.’ Don’t you see?”');"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
Bug fix

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Noticed some inconsistency around line indexes. Using mutations/UI for insertion, this should never come up but direct insertion with script commands hides the problem. Think this should solve it
* Made based on https://github.com/uwblueprint/planet-read/pull/39#discussion_r667439779


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run script


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Does this fix the issue?

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
