### PR TITLE
Fix translation content returned as null bug for story translations queries

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -97,18 +97,13 @@ class StoryService(IStoryService):
 
     def get_story_translations(self, user_id, translator, language, level):
         try:
-            return (
+            story_translations = (
                 db.session.query(
                     Story.id.label("story_id"),
                     Story.title.label("title"),
                     Story.description.label("description"),
                     Story.youtube_link.label("youtube_link"),
                     Story.level.label("level"),
-                    StoryTranslation.id.label("id"),
-                    StoryTranslation.language.label("language"),
-                    StoryTranslation.stage.label("stage"),
-                    StoryTranslation.translator_id.label("translator_id"),
-                    StoryTranslation.reviewer_id.label("reviewer_id"),
                 )
                 .join(StoryTranslation, Story.id == StoryTranslation.story_id)
                 .filter(
@@ -118,7 +113,16 @@ class StoryService(IStoryService):
                 )
                 .filter(StoryTranslation.language == language if language else True)
                 .filter(Story.level <= level if level else True)
+                .all()
             )
+            translationsList = []
+            for story_translation in story_translations:
+                story_translation_dict = story_translation._asdict()
+                translationsList.append({
+                    **StoryTranslation.query.get(story_translation_dict["story_id"]).to_dict(include_relationships=True),
+                    **story_translation._asdict(),
+                })
+            return translationsList
         except Exception as error:
             self.logger.error(str(error))
             raise error
@@ -222,18 +226,13 @@ class StoryService(IStoryService):
 
     def get_story_translations_available_for_review(self, language, level):
         try:
-            return (
+            story_translations = (
                 db.session.query(
                     Story.id.label("story_id"),
                     Story.title.label("title"),
                     Story.description.label("description"),
                     Story.youtube_link.label("youtube_link"),
                     Story.level.label("level"),
-                    StoryTranslation.id.label("id"),
-                    StoryTranslation.language.label("language"),
-                    StoryTranslation.stage.label("stage"),
-                    StoryTranslation.translator_id.label("translator_id"),
-                    StoryTranslation.reviewer_id.label("reviewer_id"),
                 )
                 .join(StoryTranslation, Story.id == StoryTranslation.story_id)
                 .filter(Story.level <= level)
@@ -241,6 +240,14 @@ class StoryService(IStoryService):
                 .filter(StoryTranslation.reviewer_id == None)
                 .all()
             )
+            translationsList = []
+            for story_translation in story_translations:
+                story_translation_dict = story_translation._asdict()
+                translationsList.append({
+                    **StoryTranslation.query.get(story_translation_dict["story_id"]).to_dict(include_relationships=True),
+                    **story_translation._asdict(),
+                })
+            return translationsList
 
         except Exception as error:
             self.logger.error(str(error))

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -118,10 +118,14 @@ class StoryService(IStoryService):
             translationsList = []
             for story_translation in story_translations:
                 story_translation_dict = story_translation._asdict()
-                translationsList.append({
-                    **StoryTranslation.query.get(story_translation_dict["story_id"]).to_dict(include_relationships=True),
-                    **story_translation._asdict(),
-                })
+                translationsList.append(
+                    {
+                        **StoryTranslation.query.get(
+                            story_translation_dict["story_id"]
+                        ).to_dict(include_relationships=True),
+                        **story_translation._asdict(),
+                    }
+                )
             return translationsList
         except Exception as error:
             self.logger.error(str(error))
@@ -243,10 +247,14 @@ class StoryService(IStoryService):
             translationsList = []
             for story_translation in story_translations:
                 story_translation_dict = story_translation._asdict()
-                translationsList.append({
-                    **StoryTranslation.query.get(story_translation_dict["story_id"]).to_dict(include_relationships=True),
-                    **story_translation._asdict(),
-                })
+                translationsList.append(
+                    {
+                        **StoryTranslation.query.get(
+                            story_translation_dict["story_id"]
+                        ).to_dict(include_relationships=True),
+                        **story_translation._asdict(),
+                    }
+                )
             return translationsList
 
         except Exception as error:

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -98,7 +98,9 @@ class StoryService(IStoryService):
     def get_story_translations(self, user_id, translator, language, level):
         try:
             stories = (
-                Story.query.join(StoryTranslation, Story.id == StoryTranslation.story_id)
+                Story.query.join(
+                    StoryTranslation, Story.id == StoryTranslation.story_id
+                )
                 .filter(
                     StoryTranslation.translator_id == user_id
                     if translator
@@ -111,7 +113,9 @@ class StoryService(IStoryService):
             )
 
             story_translations = (
-                StoryTranslation.query.join(Story, Story.id == StoryTranslation.story_id)
+                StoryTranslation.query.join(
+                    Story, Story.id == StoryTranslation.story_id
+                )
                 .filter(
                     StoryTranslation.translator_id == user_id
                     if translator
@@ -124,17 +128,19 @@ class StoryService(IStoryService):
             )
 
             for i in range(len(stories)):
-                stories[i] = {**stories[i].to_dict(), **story_translations[i].to_dict(include_relationships=True)}
+                stories[i] = {
+                    **stories[i].to_dict(),
+                    **story_translations[i].to_dict(include_relationships=True),
+                }
 
             return stories
-            
+
         except Exception as error:
             self.logger.error(str(error))
             raise error
 
     def get_story_translation(self, id):
         try:
-
             story_details = (
                 db.session.query(
                     Story.id.label("story_id"),
@@ -149,10 +155,15 @@ class StoryService(IStoryService):
                     StoryTranslation.reviewer_id.label("reviewer_id"),
                     StoryTranslationContent.id.label("content_id"),
                     StoryTranslationContent.line_index.label("line_index"),
-                    StoryTranslationContent.translation_content.label("translation_content"),
+                    StoryTranslationContent.translation_content.label(
+                        "translation_content"
+                    ),
                 )
                 .join(StoryTranslation, Story.id == StoryTranslation.story_id)
-                .join(StoryTranslationContent, StoryTranslationContent.story_translation_id == StoryTranslation.id)
+                .join(
+                    StoryTranslationContent,
+                    StoryTranslationContent.story_translation_id == StoryTranslation.id,
+                )
                 .filter(StoryTranslation.id == id)
                 .all()
             )
@@ -165,7 +176,13 @@ class StoryService(IStoryService):
 
             for story_detail in story_details:
                 story_detail_dict = story_detail._asdict()
-                response["translation_contents"].append({"id" : story_detail_dict["content_id"], "line_index" : story_detail_dict["line_index"], "translation_content" : story_detail_dict["translation_content"]})
+                response["translation_contents"].append(
+                    {
+                        "id": story_detail_dict["content_id"],
+                        "line_index": story_detail_dict["line_index"],
+                        "translation_content": story_detail_dict["translation_content"],
+                    }
+                )
 
             response["num_translated_lines"] = self._get_num_translated_lines(
                 response["translation_contents"]
@@ -245,7 +262,9 @@ class StoryService(IStoryService):
     def get_story_translations_available_for_review(self, language, level):
         try:
             stories = (
-                Story.query.join(StoryTranslation, Story.id == StoryTranslation.story_id)
+                Story.query.join(
+                    StoryTranslation, Story.id == StoryTranslation.story_id
+                )
                 .filter(Story.level <= level)
                 .filter(StoryTranslation.language == language)
                 .filter(StoryTranslation.reviewer_id == None)
@@ -254,7 +273,9 @@ class StoryService(IStoryService):
             )
 
             story_translations = (
-                StoryTranslation.query.join(Story, Story.id == StoryTranslation.story_id)
+                StoryTranslation.query.join(
+                    Story, Story.id == StoryTranslation.story_id
+                )
                 .filter(Story.level <= level)
                 .filter(StoryTranslation.language == language)
                 .filter(StoryTranslation.reviewer_id == None)
@@ -263,7 +284,10 @@ class StoryService(IStoryService):
             )
 
             for i in range(len(stories)):
-                stories[i] = {**stories[i].to_dict(), **story_translations[i].to_dict(include_relationships=True)}
+                stories[i] = {
+                    **stories[i].to_dict(),
+                    **story_translations[i].to_dict(include_relationships=True),
+                }
 
             return stories
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Return translation content on storyTranslationsByUser and storyTranslationsAvailableForReview](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=4a47edc475b34bb99b25ff1fae2a5507&p=6a0636cf217e423685acc3909a348d91)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Use two separate queries, one for the stories based on desired criteria and the other for the story translations with translation content
* Join the the two queries together in a dict and return a list of these dicts


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the `storyTranslationsByUser` and `storyTranslationsAvailableForReview` queries and observe that the `translationContents` field is not null


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Whether this is the best way to get the translation contents as it requires an additional query per row of the main one


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
