### PR TITLE
Integrate Translation Process Indicator

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -248,5 +248,5 @@ class StoryService(IStoryService):
 
     def _get_num_translated_lines(self, translation_contents):
         return len(translation_contents) - [
-            _.translation_content for _ in translation_contents
+            _.translation_content.strip() for _ in translation_contents
         ].count("")

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -48,7 +48,6 @@ const TranslationPage = () => {
 
   const storyId = +storyIdParam!!;
   const storyTranslationId = +storyTranslationIdParam!!;
-
   const [translatedStoryLines, setTranslatedStoryLines] = useState<StoryLine[]>(
     [],
   );
@@ -56,8 +55,6 @@ const TranslationPage = () => {
     Map<number, StoryLine>
   >(new Map());
   const [numTranslatedLines, setNumTranslatedLines] = useState(0);
-  const [numStoryLines, setNumStoryLines] = useState(0);
-  const [percentageComplete, setPercentageComplete] = useState(0);
 
   const arrayIndex = (lineIndex: number): number =>
     lineIndex - translatedStoryLines[0].lineIndex;
@@ -76,14 +73,6 @@ const TranslationPage = () => {
     }
   };
 
-  const updatePercentageComplete = (
-    translatedLines: number,
-    storyLines: number,
-  ) => {
-    setPercentageComplete((translatedLines / storyLines) * 100);
-    setNumTranslatedLines(translatedLines);
-  };
-
   const onChangeTranslationContent = async (
     newContent: string,
     lineIndex: number,
@@ -94,15 +83,15 @@ const TranslationPage = () => {
     if (
       // user deleted translation line
       !newContent.trim() &&
-      translatedStoryLines[index]?.translatedContent?.trim()
+      translatedStoryLines[index].translatedContent!!.trim()
     ) {
-      updatePercentageComplete(numTranslatedLines - 1, numStoryLines);
+      setNumTranslatedLines(numTranslatedLines - 1);
     } else if (
       // user added new translation line
       newContent.trim() &&
-      !translatedStoryLines[index]?.translatedContent?.trim()
+      !translatedStoryLines[index].translatedContent!!.trim()
     ) {
-      updatePercentageComplete(numTranslatedLines + 1, numStoryLines);
+      setNumTranslatedLines(numTranslatedLines + 1);
     }
     updatedContentArray[index].translatedContent = newContent;
     setTranslatedStoryLines(updatedContentArray);
@@ -121,11 +110,7 @@ const TranslationPage = () => {
       const storyContent = data.storyById.contents;
       const translatedContent = data.storyTranslationById.translationContents;
 
-      setNumStoryLines(data.storyTranslationById.translationContents.length);
-      updatePercentageComplete(
-        data.storyTranslationById.numTranslatedLines,
-        data.storyTranslationById.translationContents.length,
-      );
+      setNumTranslatedLines(data.storyTranslationById.numTranslatedLines);
 
       const contentArray: StoryLine[] = [];
       storyContent.forEach(({ content, lineIndex }: Content) => {
@@ -175,7 +160,11 @@ const TranslationPage = () => {
         <div className="translation-content">{storyCells}</div>
         <div className="translation-sidebar">
           <div className="translation-progress-bar">
-            <TranslationProgressBar percentageComplete={percentageComplete} />
+            <TranslationProgressBar
+              percentageComplete={
+                (numTranslatedLines / translatedStoryLines.length) * 100
+              }
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/translation/TranslationProgressBar.css
+++ b/frontend/src/components/translation/TranslationProgressBar.css
@@ -1,5 +1,5 @@
 .progress-bar-container {
-    max-width: 123px;
+    max-width: 128px;
     padding: 5px;
 }
 


### PR DESCRIPTION
## Notion ticket link
[Integrate Translation Process Indicator](https://www.notion.so/uwblueprintexecs/integrate-translation-process-indicator-9b9e877c7dce428ab45a9b70a33e0621)


## Implementation description
* Set progress bar value on first render based on return value from `storyTranslationById` query
* On user updates, determine if user is adding/removing translation lines and update progress bar accordingly 
* Branch based off of #51 

![progress bar](https://user-images.githubusercontent.com/32009013/126434225-57ea9c31-9a8a-4526-a336-b0c49feb97cd.gif)

## Steps to test
1. Seed database with stories
2. Navigate to `http://localhost:3000/stories`; select a story and click "translate book"
3. Verify that progress bar originally is at 0%
4. Enter translation: verify that progress bar increments accordingly
5. Delete translation: verify that progress bar decrements accordingly
6. Refresh the page: verify that progress bar value is accurately reflected

## What should reviewers focus on?
* Ensure whitespaces aren't counted as translated lines
* Verify that percentage is within 0%-100% at all times

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
