### PR TITLE
Implemented Undo/Redo Functionality

### DIFF
--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -20,6 +20,12 @@ type Content = {
   lineIndex: number;
   content: string;
 };
+
+interface HistoryStack {
+  Undo: Array<{ lineIndex: number; content: string }>;
+  Redo: Array<{ lineIndex: number; content: string }>;
+}
+
 const GET_STORY_CONTENTS = (storyId: number, storyTranslationId: number) => gql`
   query {
     storyById(id: ${storyId}) {
@@ -56,8 +62,20 @@ const TranslationPage = () => {
   >(new Map());
   const [numTranslatedLines, setNumTranslatedLines] = useState(0);
 
+  const [
+    versionHistoryStack,
+    updateVersionHistoryStack,
+  ] = useState<HistoryStack>({ Undo: [], Redo: [] });
+
   const arrayIndex = (lineIndex: number): number =>
     lineIndex - translatedStoryLines[0].lineIndex;
+
+  const deepCopy = (lines: Object) => {
+    // This is a funky method to make deep copies on objects with primative values
+    // https://javascript.plainenglish.io/how-to-deep-copy-objects-and-arrays-in-javascript-7c911359b089
+    // Should probably go under some util
+    return JSON.parse(JSON.stringify(lines));
+  };
 
   // TODO replace with real logic
   const translationStatusIcon = (): JSX.Element | null => {
@@ -73,13 +91,19 @@ const TranslationPage = () => {
     }
   };
 
+  const updateVersionHistory = (content: string, lineIndex: number) => {
+    updateVersionHistoryStack({
+      Undo: [...deepCopy(versionHistoryStack.Undo), { lineIndex, content }],
+      Redo: [],
+    });
+  };
+
   const onChangeTranslationContent = async (
     newContent: string,
     lineIndex: number,
   ) => {
     const updatedContentArray = [...translatedStoryLines];
     const index = arrayIndex(lineIndex);
-
     if (
       // user deleted translation line
       !newContent.trim() &&
@@ -98,6 +122,65 @@ const TranslationPage = () => {
     setChangedStoryLines(
       changedStoryLines.set(lineIndex, updatedContentArray[index]),
     );
+  };
+
+  const onUserInput = async (newContent: string, lineIndex: number) => {
+    const oldContent =
+      translatedStoryLines[arrayIndex(lineIndex)].translatedContent;
+    if (oldContent !== undefined) {
+      updateVersionHistory(oldContent, lineIndex);
+    }
+    onChangeTranslationContent(newContent, lineIndex);
+  };
+
+  console.log(versionHistoryStack);
+
+  const undoChange = () => {
+    if (versionHistoryStack.Undo.length > 0) {
+      const { lineIndex, content: newContent } = versionHistoryStack.Undo[
+        versionHistoryStack.Undo.length - 1
+      ];
+      const oldContent =
+        translatedStoryLines[arrayIndex(lineIndex)].translatedContent;
+      if (oldContent !== newContent) {
+        const newHistory = {
+          Undo: deepCopy(versionHistoryStack.Undo.slice(0, -1)),
+          Redo: [
+            ...deepCopy(versionHistoryStack.Redo),
+            {
+              lineIndex,
+              content: oldContent,
+            },
+          ],
+        };
+        updateVersionHistoryStack(newHistory);
+        onChangeTranslationContent(newContent, lineIndex);
+      }
+    }
+  };
+
+  const redoChange = () => {
+    if (versionHistoryStack.Redo.length > 0) {
+      const { lineIndex, content: newContent } = versionHistoryStack.Redo[
+        versionHistoryStack.Redo.length - 1
+      ];
+      const oldContent =
+        translatedStoryLines[arrayIndex(lineIndex)].translatedContent;
+      if (oldContent !== newContent) {
+        const newHistory = {
+          Undo: [
+            ...deepCopy(versionHistoryStack.Undo),
+            {
+              lineIndex,
+              content: oldContent,
+            },
+          ],
+          Redo: deepCopy(versionHistoryStack.Redo.slice(0, -1)),
+        };
+        updateVersionHistoryStack(newHistory);
+        onChangeTranslationContent(newContent, lineIndex);
+      }
+    }
   };
 
   const clearUnsavedChangesMap = () => {
@@ -133,7 +216,6 @@ const TranslationPage = () => {
 
   const storyCells = translatedStoryLines.map((storyLine: StoryLine) => {
     const displayLineNumber = storyLine.lineIndex + 1;
-
     return (
       <div
         className="row-translation"
@@ -145,7 +227,7 @@ const TranslationPage = () => {
           text={storyLine.translatedContent!!}
           storyTranslationContentId={storyLine.storyTranslationContentId!!}
           lineIndex={storyLine.lineIndex}
-          onChange={onChangeTranslationContent}
+          onChange={onUserInput}
         />
         {translationStatusIcon()}
       </div>
@@ -157,7 +239,15 @@ const TranslationPage = () => {
       <h1>Story Title Here</h1>
       <h4>View story details</h4>
       <div className="translation-container">
-        <div className="translation-content">{storyCells}</div>
+        <div className="translation-content">
+          <button onClick={undoChange} type="button">
+            Undo
+          </button>
+          <button onClick={redoChange} type="button">
+            Redo
+          </button>
+          {storyCells}
+        </div>
         <div className="translation-sidebar">
           <div className="translation-progress-bar">
             <TranslationProgressBar

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -137,9 +137,6 @@ const TranslationPage = () => {
       const { lineIndex, content: newContent } = versionHistoryStack.Undo[
         versionHistoryStack.Undo.length - 1
       ];
-      console.log(
-        versionHistoryStack.Undo[versionHistoryStack.Undo.length - 1],
-      );
       const oldContent =
         translatedStoryLines[arrayIndex(lineIndex)].translatedContent;
       if (oldContent !== newContent) {

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -133,8 +133,6 @@ const TranslationPage = () => {
     onChangeTranslationContent(newContent, lineIndex);
   };
 
-  console.log(versionHistoryStack);
-
   const undoChange = () => {
     if (versionHistoryStack.Undo.length > 0) {
       const { lineIndex, content: newContent } = versionHistoryStack.Undo[


### PR DESCRIPTION
## Notion ticket link
[Allow translation undo and redo](https://www.notion.so/uwblueprintexecs/Allow-translation-undo-and-redo-7f36573f90a040748c6cb81f870a7dd1)

## Implementation description
* When a user enters a character, takes a snapshot of the current state and pushes it onto a stack.
* Undo -> Pop from undo stack and add current state to redo
* Redo -> Pop from  redo stack and add current state to undo
* Not debounced since figuring out exactly when to snapshot can be tricky esp in conjunction with autosave, this is more MVP for undo/redo.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Launch the app and go to the translation page for some story
2. Type some stuff into the translation area, perhaps multiple text areas
3. Press the undo button (not using ctrl + z, that's built into textarea so that would always work), this should undo the last press you've made
4. Try redoing
6. Send a photo of the most derelict/broken bike you can find to @andrewyguo on slack to make him suffer. 

https://user-images.githubusercontent.com/53587708/127574770-9105506b-9888-4b92-abb6-08223b4523dd.mp4

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Note: The buttons are not styled yet since I think they would need to be re-implemented once [Add Chakra UI #49](https://github.com/uwblueprint/planet-read/pull/49) is merged in.
* Make sure the edge cases work (i.e when you undo/redo all the work you've done in a session) I've had some weird finicky stuff with it and I'm pretty sure it no longer breaks but just saying that I wouldn't be the most surprised.
* When the user starts typing after a ton of undos, they wipe all the redo screenshots, does this make sense?

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR


<p align="center">
  <img src="https://user-images.githubusercontent.com/53587708/127574565-1071262b-5a0f-4d95-b4eb-4c6478f57446.png" />
</p>

