### PR TITLE
fix: send accessToken in request header

### DIFF
--- a/frontend/src/APIClients/BaseAPIClient.ts
+++ b/frontend/src/APIClients/BaseAPIClient.ts
@@ -1,3 +1,4 @@
+// TODO: delete this file
 import axios, { AxiosResponse, AxiosRequestConfig } from "axios";
 import { camelizeKeys, decamelizeKeys } from "humps";
 import jwt from "jsonwebtoken";

--- a/frontend/src/APIClients/BaseGQLClient.ts
+++ b/frontend/src/APIClients/BaseGQLClient.ts
@@ -16,16 +16,16 @@ import {
 } from "../utils/LocalStorageUtils";
 import { REFRESH } from "./mutations";
 
-const getLocalToken = () =>
-  getLocalStorageObjProperty(AUTHENTICATED_USER_KEY, "accessToken");
-
 const httpLink = createHttpLink({
   uri: `${process.env.REACT_APP_BACKEND_URL}/graphql`,
   credentials: "include",
 });
 
 const authFromLocalLink = setContext(async (_, { headers }) => {
-  const accessToken = getLocalToken();
+  const accessToken = getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  );
   return {
     headers: {
       ...headers,
@@ -35,7 +35,10 @@ const authFromLocalLink = setContext(async (_, { headers }) => {
 });
 
 const injectAccessToken = async (operation: any) => {
-  let accessToken = getLocalToken();
+  let accessToken = getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  );
   const decodedToken: any = jwt.decode(accessToken);
   if (
     decodedToken &&

--- a/frontend/src/APIClients/BaseGQLClient.ts
+++ b/frontend/src/APIClients/BaseGQLClient.ts
@@ -1,0 +1,111 @@
+import {
+  ApolloClient,
+  ApolloLink,
+  createHttpLink,
+  InMemoryCache,
+  Observable,
+} from "@apollo/client";
+import { onError } from "@apollo/client/link/error";
+import { setContext } from "@apollo/client/link/context";
+import { RetryLink } from "@apollo/client/link/retry";
+import jwt from "jsonwebtoken";
+import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
+import {
+  setLocalStorageObjProperty,
+  getLocalStorageObjProperty,
+} from "../utils/LocalStorageUtils";
+import { REFRESH } from "./mutations";
+
+const getLocalToken = () =>
+  getLocalStorageObjProperty(AUTHENTICATED_USER_KEY, "accessToken");
+
+const httpLink = createHttpLink({
+  uri: `${process.env.REACT_APP_BACKEND_URL}/graphql`,
+  credentials: "include",
+});
+
+const authFromLocalLink = setContext(async (_, { headers }) => {
+  const accessToken = getLocalToken();
+  return {
+    headers: {
+      ...headers,
+      Authorizaton: accessToken ? `Bearer ${accessToken}` : "",
+    },
+  };
+});
+
+const injectAccessToken = async (operation: any) => {
+  let accessToken = getLocalToken();
+  const decodedToken: any = jwt.decode(accessToken);
+  if (
+    operation.operationName !== "Refresh" &&
+    decodedToken &&
+    decodedToken.exp <= Math.round(new Date().getTime() / 1000)
+  ) {
+    /* eslint-disable  @typescript-eslint/no-use-before-define */
+    const results = await client.mutate({
+      mutation: REFRESH,
+    });
+    /* eslint-disable  @typescript-eslint/no-use-before-define */
+    accessToken = results?.data?.refresh.accessToken;
+    setLocalStorageObjProperty(
+      AUTHENTICATED_USER_KEY,
+      "accessToken",
+      accessToken,
+    );
+  }
+  operation.setContext({
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+};
+
+// https://www.apollographql.com/blog/apollo-client/using-apollo-link-to-handle-dependent-queries/
+const accessTokenInjectionLink = new ApolloLink(
+  (operation, forward) =>
+    new Observable((observer) => {
+      let handle: any;
+      Promise.resolve(operation)
+        .then((op) => injectAccessToken(op))
+        .then(() => {
+          handle = forward(operation).subscribe({
+            next: observer.next.bind(observer),
+            error: observer.error.bind(observer),
+            complete: observer.complete.bind(observer),
+          });
+        })
+        .catch(observer.error.bind(observer));
+      return () => {
+        if (handle) handle.unsubscribe();
+      };
+    }),
+);
+
+const refreshDirectionalLink = new RetryLink().split(
+  (operation) => ["Refresh", "Login"].includes(operation.operationName),
+  authFromLocalLink.concat(httpLink),
+  accessTokenInjectionLink.concat(httpLink),
+);
+
+// TODO: Turn off on prod
+const errorLink = onError(({ graphQLErrors, networkError }) => {
+  if (graphQLErrors)
+    graphQLErrors.forEach(({ message, locations, path }) =>
+      console.log(
+        `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
+      ),
+    );
+  if (networkError) console.log(`[Network error]: ${networkError}`);
+});
+
+/* 
+Link Tree
+errorLink -> refreshDirectionalLink
+              -> authFromLocalLink
+              -> variableInjectionLink -> authFromContextLink
+*/
+const client = new ApolloClient({
+  link: errorLink.concat(refreshDirectionalLink),
+  cache: new InMemoryCache(),
+});
+
+export default client;

--- a/frontend/src/APIClients/BaseGQLClient.ts
+++ b/frontend/src/APIClients/BaseGQLClient.ts
@@ -38,7 +38,6 @@ const injectAccessToken = async (operation: any) => {
   let accessToken = getLocalToken();
   const decodedToken: any = jwt.decode(accessToken);
   if (
-    operation.operationName !== "Refresh" &&
     decodedToken &&
     decodedToken.exp <= Math.round(new Date().getTime() / 1000)
   ) {

--- a/frontend/src/APIClients/mutations.ts
+++ b/frontend/src/APIClients/mutations.ts
@@ -1,0 +1,75 @@
+import { gql } from "@apollo/client";
+
+// Auth
+export const LOGIN = gql`
+  mutation Login($email: String!, $password: String!) {
+    login(email: $email, password: $password) {
+      id
+      firstName
+      lastName
+      email
+      role
+      approvedLanguages
+      accessToken
+      refreshToken
+    }
+  }
+`;
+
+export const LOGIN_WITH_GOOGLE = gql`
+  mutation loginWithGoogle($tokenId: String!) {
+    loginWithGoogle(tokenId: $tokenId) {
+      id
+      firstName
+      lastName
+      email
+      role
+      approvedLanguages
+      accessToken
+      refreshToken
+    }
+  }
+`;
+
+export const LOGOUT = gql`
+  mutation Logout($userId: ID!) {
+    logout(userId: $userId) {
+      ok
+    }
+  }
+`;
+
+export interface LogoutResponse {
+  ok: boolean;
+}
+
+export const REFRESH = gql`
+  mutation Refresh {
+    refresh {
+      accessToken
+      refreshToken
+      ok
+    }
+  }
+`;
+
+export interface RefreshResponse {
+  accessToken: string;
+  refreshToken: string;
+  ok: boolean;
+}
+
+export const RESET_PASSWORD = gql`
+  mutation ResetPassword($email: String!) {
+    resetPassword(email: $email) {
+      ok
+    }
+  }
+`;
+
+export interface ResetPasswordResponse {
+  ok: boolean;
+}
+
+// Stories
+// TODO: move mutation gql strings here

--- a/frontend/src/APIClients/queries.ts
+++ b/frontend/src/APIClients/queries.ts
@@ -1,0 +1,3 @@
+// TODO: move query gql strings here
+
+export {};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import React, { useState } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import { ChakraProvider } from "@chakra-ui/react";
+import { ApolloProvider } from "@apollo/client";
 
 import Login from "./components/auth/Login";
 import Signup from "./components/auth/Signup";
@@ -17,6 +18,8 @@ import customTheme from "./theme/index";
 
 import AUTHENTICATED_USER_KEY from "./constants/AuthConstants";
 import AuthContext, { AuthenticatedUser } from "./contexts/AuthContext";
+import client from "./APIClients/BaseGQLClient";
+
 import { getLocalStorageObj } from "./utils/LocalStorageUtils";
 
 const App = () => {
@@ -30,25 +33,37 @@ const App = () => {
 
   return (
     <ChakraProvider theme={customTheme}>
-      <AuthContext.Provider value={{ authenticatedUser, setAuthenticatedUser }}>
-        <Router>
-          <Switch>
-            <PrivateRoute exact path="/" component={Default} />
-            <Route exact path="/login" component={Login} />
-            <Route exact path="/signup" component={Signup} />
-            <PrivateRoute exact path="/entity/create" component={CreatePage} />
-            <PrivateRoute exact path="/entity/update" component={UpdatePage} />
-            <PrivateRoute exact path="/entity" component={DisplayPage} />
-            <PrivateRoute exact path="/stories" component={HomePage} />
-            <PrivateRoute
-              exact
-              path="/translation/:storyIdParam/:storyTranslationIdParam"
-              component={TranslationPage}
-            />
-            <Route exact path="*" component={NotFound} />
-          </Switch>
-        </Router>
-      </AuthContext.Provider>
+      <ApolloProvider client={client}>
+        <AuthContext.Provider
+          value={{ authenticatedUser, setAuthenticatedUser }}
+        >
+          <Router>
+            <Switch>
+              <PrivateRoute exact path="/" component={Default} />
+              <Route exact path="/login" component={Login} />
+              <Route exact path="/signup" component={Signup} />
+              <PrivateRoute
+                exact
+                path="/entity/create"
+                component={CreatePage}
+              />
+              <PrivateRoute
+                exact
+                path="/entity/update"
+                component={UpdatePage}
+              />
+              <PrivateRoute exact path="/entity" component={DisplayPage} />
+              <PrivateRoute exact path="/stories" component={HomePage} />
+              <PrivateRoute
+                exact
+                path="/translation/:storyIdParam/:storyTranslationIdParam"
+                component={TranslationPage}
+              />
+              <Route exact path="*" component={NotFound} />
+            </Switch>
+          </Router>
+        </AuthContext.Provider>
+      </ApolloProvider>
     </ChakraProvider>
   );
 };

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -1,4 +1,4 @@
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import React, { useContext, useState } from "react";
 import {
   GoogleLogin,
@@ -7,40 +7,11 @@ import {
 } from "react-google-login";
 import { Redirect } from "react-router-dom";
 import authAPIClient from "../../APIClients/AuthAPIClient";
+import { LOGIN, LOGIN_WITH_GOOGLE } from "../../APIClients/mutations";
 import AuthContext, { AuthenticatedUser } from "../../contexts/AuthContext";
 import ResetPassword from "./ResetPassword";
 
 type GoogleResponse = GoogleLoginResponse | GoogleLoginResponseOffline;
-
-const LOGIN = gql`
-  mutation Login($email: String!, $password: String!) {
-    login(email: $email, password: $password) {
-      id
-      firstName
-      lastName
-      email
-      role
-      approvedLanguages
-      accessToken
-      refreshToken
-    }
-  }
-`;
-
-const LOGIN_WITH_GOOGLE = gql`
-  mutation loginWithGoogle($tokenId: String!) {
-    loginWithGoogle(tokenId: $tokenId) {
-      id
-      firstName
-      lastName
-      email
-      role
-      approvedLanguages
-      accessToken
-      refreshToken
-    }
-  }
-`;
 
 const Login = () => {
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);

--- a/frontend/src/components/auth/Logout.tsx
+++ b/frontend/src/components/auth/Logout.tsx
@@ -1,32 +1,16 @@
 import React, { useContext, useEffect } from "react";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import AuthContext from "../../contexts/AuthContext";
-import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
-
-interface LogoutResponse {
-  ok: Boolean;
-}
-
-const LOGOUT = gql`
-  mutation Logout($userId: ID!) {
-    logout(userId: $userId) {
-      ok
-    }
-  }
-`;
+import { LOGOUT, LogoutResponse } from "../../APIClients/mutations";
+import authAPIClient from "../../APIClients/AuthAPIClient";
 
 const Logout = () => {
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);
   const [logout, { error }] = useMutation<{ logout: LogoutResponse }>(LOGOUT);
 
   const onLogOutClick = async () => {
-    const result = await logout({
-      variables: { userId: String(authenticatedUser?.id) },
-    });
-    if (result.data?.logout.ok === true) {
-      localStorage.removeItem(AUTHENTICATED_USER_KEY);
-      setAuthenticatedUser(null);
-    }
+    await authAPIClient.logout(String(authenticatedUser?.id), logout);
+    setAuthenticatedUser(null);
   };
 
   useEffect(() => {

--- a/frontend/src/components/auth/RefreshCredentials.tsx
+++ b/frontend/src/components/auth/RefreshCredentials.tsx
@@ -1,33 +1,17 @@
 import React, { useContext } from "react";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import AuthContext from "../../contexts/AuthContext";
-import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
-import { setLocalStorageObjProperty } from "../../utils/LocalStorageUtils";
-
-const REFRESH = gql`
-  mutation Refresh {
-    refresh {
-      accessToken
-      refreshToken
-      ok
-    }
-  }
-`;
-
-type Refresh = { refresh: { accessToken: string; ok: boolean } };
+import { REFRESH, RefreshResponse } from "../../APIClients/mutations";
+import authAPIClient from "../../APIClients/AuthAPIClient";
 
 const RefreshCredentials = () => {
   const { setAuthenticatedUser } = useContext(AuthContext);
 
-  const [refresh] = useMutation<Refresh>(REFRESH);
+  const [refresh] = useMutation<{ refresh: RefreshResponse }>(REFRESH);
 
   const onRefreshClick = async () => {
-    const result = await refresh();
-    const success = result.data?.refresh.ok;
-    const token = result.data?.refresh.accessToken;
-    if (success && token) {
-      setLocalStorageObjProperty(AUTHENTICATED_USER_KEY, "accessToken", token);
-    } else {
+    const result = await authAPIClient.refresh(refresh);
+    if (!result) {
       setAuthenticatedUser(null);
     }
   };

--- a/frontend/src/components/auth/ResetPassword.tsx
+++ b/frontend/src/components/auth/ResetPassword.tsx
@@ -1,28 +1,24 @@
 import React from "react";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
+import {
+  RESET_PASSWORD,
+  ResetPasswordResponse,
+} from "../../APIClients/mutations";
+import authAPIClient from "../../APIClients/AuthAPIClient";
 
 type ResetPasswordProps = {
   email: string;
 };
 
-const RESET_PASSWORD = gql`
-  mutation ResetPassword($email: String!) {
-    resetPassword(email: $email) {
-      ok
-    }
-  }
-`;
-
 const ResetPassword = ({ email }: ResetPasswordProps) => {
   const isRealEmailAvailable = (emailString: string): boolean => {
-    const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    const re =
+      /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(String(emailString).toLowerCase());
   };
 
-  type ResetPassword = { ok: boolean };
-  const [resetPassword] = useMutation<{ resetPassword: ResetPassword }>(
-    RESET_PASSWORD,
-  );
+  const [resetPassword] =
+    useMutation<{ resetPassword: ResetPasswordResponse }>(RESET_PASSWORD);
 
   const handleErrorOnReset = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
@@ -42,9 +38,8 @@ const ResetPassword = ({ email }: ResetPasswordProps) => {
     }
 
     try {
-      const result = await resetPassword({ variables: { email } });
-
-      if (result.data?.resetPassword.ok) {
+      const result = await authAPIClient.resetPassword(email, resetPassword);
+      if (result) {
         handleSuccessOnReset(`Reset email sent to ${email}`);
       } else {
         handleErrorOnReset("Reset password failed.");

--- a/frontend/src/components/auth/ResetPassword.tsx
+++ b/frontend/src/components/auth/ResetPassword.tsx
@@ -12,13 +12,13 @@ type ResetPasswordProps = {
 
 const ResetPassword = ({ email }: ResetPasswordProps) => {
   const isRealEmailAvailable = (emailString: string): boolean => {
-    const re =
-      /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     return re.test(String(emailString).toLowerCase());
   };
 
-  const [resetPassword] =
-    useMutation<{ resetPassword: ResetPasswordResponse }>(RESET_PASSWORD);
+  const [resetPassword] = useMutation<{ resetPassword: ResetPasswordResponse }>(
+    RESET_PASSWORD,
+  );
 
   const handleErrorOnReset = (errorMessage: string) => {
     // eslint-disable-next-line no-alert


### PR DESCRIPTION
## Implementation description
woops, this got larger than it needed to be. I should've split this into two commits but got a little code-happy.
There's two categories of changes:

1. Apollo links to make sure the Authoization header is set
- BaseGQLClient.ts
- App.tsx

2. Modularizing GQL mutations and removing frontend uses of the REST api
- everything else

Adding Apollo links to a custom Apollo client lets us intercept every request made by Apollo (i.e. all our gql requests). Implemented links inject the accessToken into the request header. The accessToken is retrieved from localstorage. If stale, we make a refresh request for a new accessToken.

I modularized GQL mutations as the apollo link needs to use the refresh mutation. Accidentally modularized all auth calls and made the respective components use the `AuthApiClient`, oops

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. login
2. open stories page
3. observe Authorization header in gql POST request
![image](https://user-images.githubusercontent.com/15113249/127955222-d18c7912-92f7-41c4-a2e7-492b84c06247.png)
4. return to main page and click refresh token
5. observe Authorization heaer changed

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* is `BaseGQLClient.ts` readable? 
* does the GQL modularlization pattern make sense to you?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits

