### PR TITLE
Add status column to story_translation_contents

### DIFF
--- a/backend/python/app/models/comment.py
+++ b/backend/python/app/models/comment.py
@@ -3,6 +3,7 @@ from sqlalchemy.dialects.mysql import DATETIME, LONGTEXT
 from sqlalchemy.orm.properties import ColumnProperty
 
 from . import db
+from .story_translation_content import StoryTranslationContent
 
 
 class Comment(db.Model):
@@ -16,9 +17,8 @@ class Comment(db.Model):
         index=True,
         nullable=False,
     )
-
+    story_translation_content = db.relationship(StoryTranslationContent)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
-
     comment_index = db.Column(db.Integer, nullable=False)
     time = db.Column(DATETIME, nullable=False)
     resolved = db.Column(db.Boolean, nullable=False)

--- a/backend/python/app/models/story_translation_content.py
+++ b/backend/python/app/models/story_translation_content.py
@@ -1,9 +1,9 @@
-from sqlalchemy import inspect
+from sqlalchemy import Enum, inspect
 from sqlalchemy.dialects.mysql import LONGTEXT
 from sqlalchemy.orm.properties import ColumnProperty
 
 from . import db
-from .comment import Comment
+from .story_translation_content_status import StoryTranslationContentStatus
 
 
 class StoryTranslationContent(db.Model):
@@ -13,6 +13,7 @@ class StoryTranslationContent(db.Model):
         db.Integer, db.ForeignKey("story_translations.id"), index=True, nullable=False
     )
     line_index = db.Column(db.Integer, nullable=False)
+    status = db.Column(Enum(StoryTranslationContentStatus))
     translation_content = db.Column(LONGTEXT, nullable=False)
 
     def to_dict(self, include_relationships=False):

--- a/backend/python/app/models/story_translation_content.py
+++ b/backend/python/app/models/story_translation_content.py
@@ -13,7 +13,11 @@ class StoryTranslationContent(db.Model):
         db.Integer, db.ForeignKey("story_translations.id"), index=True, nullable=False
     )
     line_index = db.Column(db.Integer, nullable=False)
-    status = db.Column(Enum(StoryTranslationContentStatus))
+    status = db.Column(
+        Enum(StoryTranslationContentStatus),
+        server_default=StoryTranslationContentStatus.DEFAULT.value,
+        nullable=False,
+    )
     translation_content = db.Column(LONGTEXT, nullable=False)
 
     def to_dict(self, include_relationships=False):

--- a/backend/python/app/models/story_translation_content_status.py
+++ b/backend/python/app/models/story_translation_content_status.py
@@ -3,5 +3,6 @@ import enum
 
 class StoryTranslationContentStatus(enum.Enum):
     name = "story_translation_content_status"
+    DEFAULT = "DEFAULT"
     ACTION_REQUIRED = "ACTION_REQUIRED"
     APPROVED = "APPROVED"

--- a/backend/python/app/models/story_translation_content_status.py
+++ b/backend/python/app/models/story_translation_content_status.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class StoryTranslationContentStatus(enum.Enum):
+    name = "story_translation_content_status"
+    ACTION_REQUIRED = "ACTION_REQUIRED"
+    APPROVED = "APPROVED"

--- a/backend/python/app/services/implementations/comment_service.py
+++ b/backend/python/app/services/implementations/comment_service.py
@@ -5,6 +5,7 @@ from sqlalchemy import func
 
 from ...models import db
 from ...models.comment import Comment
+from ...models.story_translation_content_status import StoryTranslationContentStatus
 from ..interfaces.comment_service import ICommentService
 
 
@@ -38,6 +39,10 @@ class CommentService(ICommentService):
             raise error
 
         db.session.add(new_comment)
+        db.session.commit()
+
+        story_translation_content = new_comment.story_translation_content
+        story_translation_content.status = StoryTranslationContentStatus.ACTION_REQUIRED
         db.session.commit()
 
         return new_comment

--- a/seed_db.sh
+++ b/seed_db.sh
@@ -43,11 +43,15 @@ then
     echo "Erasing the database..."
 
 
-    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; DELETE FROM story_translation_contents;"
-    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; DELETE FROM story_contents;"
-    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; DELETE FROM story_translations;"
-    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; DELETE FROM users;"
-    docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; DELETE FROM stories;"
+    docker exec -it planet-read_db_1 mysql -u root -proot -e "
+        USE planet-read;
+        DELETE FROM comments;
+        DELETE FROM story_translation_contents;
+        DELETE FROM story_contents;
+        DELETE FROM story_translations;
+        DELETE FROM users;
+        DELETE FROM stories;
+    "
 
 
     echo "Erased the database 💥💥💥"
@@ -78,7 +82,7 @@ else
             ('Carl', 'Sagan', '$AUTH_ID_1', 'User', '{\"ENGLISH_US\":4}'),
             ('Miroslav', 'Klose', '$AUTH_ID_2', 'User', '{\"POLISH\":4, \"GERMAN\":4}'),
             ('Kevin', 'De Bryune', '$AUTH_ID_3', 'User', '{\"DUTCH\":4, \"FRENCH\":4}'),
-            ('Dwight', 'D. Eisenhower', '$AUTH_ID_4', 'User', '{\"ENGLISH_UK\":4}'), 
+            ('Dwight', 'D. Eisenhower', '$AUTH_ID_4', 'User', '{\"ENGLISH_UK\":4, \"ENGLISH_US\":4}'), 
             ('Alexander', 'Hamilton', '$AUTH_ID_5', 'User', '{\"MANDARIN\":4}'), 
             ('Angela', 'Merkel', '$AUTH_ID_6', 'Admin', '{\"GERMAN\":4}'), 
             ('Richard', 'Feynman', '$AUTH_ID_7', 'User', '{\"PORTUGESE\":4}');
@@ -86,9 +90,9 @@ else
 
     echo "Finished generating users..." 
 
+    # stories 
     if  [[ "$1" = "kevin" ]] 
     then 
-        # stories 
         docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER TABLE stories AUTO_INCREMENT = 1;"
         
         docker exec -it planet-read_db_1 mysql -u root -proot -e "
@@ -105,8 +109,7 @@ else
                 ('Kevin Lobbies Against Expansion of Social Safety Net', 'He complains higher taxes will prevent him from getting a new Gulfstream G650ER for Christmas', 'https://www.youtube.com/watch?v=t8IK0ZqfxNI&t=27s', 2, '[]');
         "
 
-    else 
-        # stories 
+    else
         docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER TABLE stories AUTO_INCREMENT = 1;"
         
         docker exec -it planet-read_db_1 mysql -u root -proot -e "
@@ -151,7 +154,7 @@ else
     "
     echo "Finished generating story translations..." 
     
-    # Story content 
+    # story_contents
     docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER TABLE story_contents AUTO_INCREMENT = 1;"
 
     for STORY_ID in 1 2 3 4 5 6 7
@@ -176,7 +179,7 @@ else
     
     echo "Finished generating story contents..." 
 
-    # Story translation content 
+    # story_translation_contents
     docker exec -it planet-read_db_1 mysql -u root -proot -e "USE planet-read; ALTER TABLE story_translation_contents AUTO_INCREMENT = 1;"
 
     for STORY_TRANSLATION_ID in 2 3 5 7 11 13 
@@ -239,6 +242,26 @@ else
                 ('$STORY_TRANSLATION_ID', 9, 'But the Hebrew word, the word timshel-\'Thou mayest\'-that gives a choice. It might be the most important word in the world. That says the way is open. That throws it right back on a man. For if \'Thou mayest\'-it is also true that \'Thou mayest not.\' Don\'t you see?\"');
         "
     done 
+
+    # comments
+    echo "Adding comments to The Great Gatsby (id: 6) Story Translation (id: 13) With Carl (id: 1) and Dwight (id: 4)"  
+
+    docker exec -it planet-read_db_1 mysql -u root -proot -e "
+        USE planet-read; 
+        UPDATE story_translations SET reviewer_id=4 WHERE id=13;
+        UPDATE story_translation_contents SET status='APPROVED' WHERE id IN(51, 52, 55, 56, 60);
+        UPDATE story_translation_contents SET status='ACTION_REQUIRED' WHERE id IN(53, 54, 59);
+        INSERT INTO comments 
+            (story_translation_content_id, user_id, comment_index, time, resolved, content) 
+        VALUES 
+            (51, 1, 0, NOW(), True, 'Not sure if this grammar makes sense'),
+            (51, 4, 1, NOW(), True, 'It\'s fine, go back to grammar school man'),
+            (51, 1, 2, NOW(), True, 'uwu dont need to be so mean man'),
+            (53, 1, 0, NOW(), False, 'this comment is lonely uwu '),
+            (54, 4, 0, NOW(), False, 'this comment is likes to be alone uwu '),
+            (59, 4, 0, NOW(), False, 'this comment is disagreeable'),
+            (59, 1, 1, NOW(), False, 'I agree!');
+    "
 
     echo "Finished generating story translation contents..." 
 

--- a/seed_db.sh
+++ b/seed_db.sh
@@ -254,13 +254,13 @@ else
         INSERT INTO comments 
             (story_translation_content_id, user_id, comment_index, time, resolved, content) 
         VALUES 
-            (51, 1, 0, NOW(), True, 'Not sure if this grammar makes sense'),
-            (51, 4, 1, NOW(), True, 'It\'s fine, go back to grammar school man'),
-            (51, 1, 2, NOW(), True, 'uwu dont need to be so mean man'),
-            (53, 1, 0, NOW(), False, 'this comment is lonely uwu '),
-            (54, 4, 0, NOW(), False, 'this comment is likes to be alone uwu '),
-            (59, 4, 0, NOW(), False, 'this comment is disagreeable'),
-            (59, 1, 1, NOW(), False, 'I agree!');
+            (51, 1, 0, '2021-07-31 01:48:42', True, 'Not sure if this grammar makes sense'),
+            (51, 4, 1, '2021-08-09 12:28:42', True, 'It\'s fine, go back to grammar school man'),
+            (51, 1, 2, '2021-08-10 21:55:42', True, 'uwu dont need to be so mean man'),
+            (53, 1, 0, '2021-07-31 13:22:42', False, 'this comment is lonely uwu '),
+            (54, 4, 0, '2021-08-09 01:38:12', True, 'this comment is likes to be alone uwu '),
+            (59, 4, 0, '2021-08-09 18:23:32', False, 'this comment is disagreeable'),
+            (59, 1, 1, '2021-08-10 21:58:42', False, 'I agree!');
     "
 
     echo "Finished generating story translation contents..." 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add status column to story translation content](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=4a47edc475b34bb99b25ff1fae2a5507&p=c0be1a8a0e9c46679f332fd68f98e021)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* create enum for status and add to story_translation_contents
* lazy load story_translation_content on comment
* create_comment sets story_translation_content status to ACTION_REQUIRED
* insert comments in seed_db

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. flip boolean in models/init
2. run `./seed_db.sh` 
3. double check that the database is in a sensible state 
4. test out createcomment mutation ([example query](http://localhost:5000/graphql?variables=null&operationName=createComment&query=mutation%20createComment%7B%0A%20createComment(commentData%3A%7BuserId%3A%201%2C%20content%3A%22hello%22%2C%20storyTranslationContentId%3A%203%7D)%20%7B%0A%20%20ok%0A%20%20comment%7B%0A%20%20%20%20content%0A%20%20%20%20time%0A%20%20%20%20userId%0A%20%20%20%20id%0A%20%20%20%20storyTranslationContentId%20%0A%20%20%20%20commentIndex%0A%20%20%7D%0A%7D%0A%7D))
5. observe that the related story_translation_content row has status == ACTION_REQUIRED


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* make sure it works!


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
