### PR TITLE
Limit Chars Allowed in Editable 

### DIFF
--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -48,8 +48,10 @@ const GET_STORY_CONTENTS = (storyId: number, storyTranslationId: number) => gql`
 
 const TranslationPage = () => {
   const MAX_STACK_SIZE = 100;
-  const { storyIdParam, storyTranslationIdParam } =
-    useParams<TranslationPageProps>();
+  const {
+    storyIdParam,
+    storyTranslationIdParam,
+  } = useParams<TranslationPageProps>();
 
   const storyId = +storyIdParam!!;
   const storyTranslationId = +storyTranslationIdParam!!;
@@ -117,8 +119,7 @@ const TranslationPage = () => {
     lineIndex: number,
     maxChars: number,
   ) => {
-    const oldContent =
-      translatedStoryLines[arrayIndex(lineIndex)].translatedContent!;
+    const oldContent = translatedStoryLines[lineIndex].translatedContent!;
     const newUndo =
       versionHistoryStack.Undo.length === MAX_STACK_SIZE
         ? versionHistoryStack.Undo.slice(1)
@@ -141,8 +142,9 @@ const TranslationPage = () => {
 
   const undoChange = () => {
     if (versionHistoryStack.Undo.length > 0) {
-      const { lineIndex, content: newContent } =
-        versionHistoryStack.Undo[versionHistoryStack.Undo.length - 1];
+      const { lineIndex, content: newContent } = versionHistoryStack.Undo[
+        versionHistoryStack.Undo.length - 1
+      ];
       const oldContent = translatedStoryLines[lineIndex].translatedContent;
       if (oldContent !== newContent) {
         const newRedo =
@@ -167,8 +169,9 @@ const TranslationPage = () => {
 
   const redoChange = () => {
     if (versionHistoryStack.Redo.length > 0) {
-      const { lineIndex, content: newContent } =
-        versionHistoryStack.Redo[versionHistoryStack.Redo.length - 1];
+      const { lineIndex, content: newContent } = versionHistoryStack.Redo[
+        versionHistoryStack.Redo.length - 1
+      ];
       const oldContent = translatedStoryLines[lineIndex].translatedContent;
       if (oldContent !== newContent) {
         const newUndo =

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -118,7 +118,11 @@ const TranslationPage = () => {
     );
   };
 
-  const onUserInput = async (newContent: string, lineIndex: number) => {
+  const onUserInput = async (
+    newContent: string,
+    lineIndex: number,
+    maxChars: number,
+  ) => {
     const oldContent = translatedStoryLines[arrayIndex(lineIndex)]
       .translatedContent!;
     const newUndo =
@@ -129,7 +133,10 @@ const TranslationPage = () => {
       Undo: [...deepCopy(newUndo), { lineIndex, content: oldContent }],
       Redo: [],
     });
-    onChangeTranslationContent(newContent, lineIndex);
+
+    if (maxChars >= newContent.length) {
+      onChangeTranslationContent(newContent, lineIndex);
+    }
   };
 
   const undoChange = () => {
@@ -232,6 +239,7 @@ const TranslationPage = () => {
           text={storyLine.translatedContent!!}
           storyTranslationContentId={storyLine.storyTranslationContentId!!}
           lineIndex={storyLine.lineIndex}
+          maxChars={storyLine.originalContent.length * 2}
           onChange={onUserInput}
         />
         {translationStatusIcon()}

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -139,6 +139,12 @@ const TranslationPage = () => {
     }
   };
 
+  const [maxCharReached, setMaxCharReached] = useState<Number[]>([]);
+
+  const maxCharWarning = (
+    <div>a</div>
+  );
+
   const undoChange = () => {
     if (versionHistoryStack.Undo.length > 0) {
       const { lineIndex, content: newContent } = versionHistoryStack.Undo[
@@ -228,6 +234,7 @@ const TranslationPage = () => {
 
   const storyCells = translatedStoryLines.map((storyLine: StoryLine) => {
     const displayLineNumber = storyLine.lineIndex + 1;
+
     return (
       <div
         className="row-translation"

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -115,12 +115,6 @@ const TranslationPage = () => {
     }
   };
 
-  // const [maxCharReached, setMaxCharReached] = useState<Number[]>([]);
-
-  // const maxCharWarning = (
-  //   <div>a</div>
-  // );
-
   const undoChange = () => {
     if (versionHistoryStack.Undo.length > 0) {
       const { lineIndex, content: newContent } = versionHistoryStack.Undo[
@@ -225,6 +219,35 @@ const TranslationPage = () => {
     );
   });
 
+  const maxCharsExceededWarning = () => {
+    let exceededLines = ""; 
+    translatedStoryLines.map((storyLine: StoryLine) => {
+      if (
+        storyLine.translatedContent &&
+        storyLine.originalContent.length * 2 <= storyLine.translatedContent.length) 
+        {
+        exceededLines += (", " + String(storyLine.lineIndex + 1));
+      }
+    });
+
+    return (
+      <div>
+        <p>
+          You have exceeded the character limit in the following lines: 
+        </p>
+      </div>
+    );
+  };
+  //   const exceededLines = (storyLine: StoryLine) => {
+  //     return <div>{storyLine.lineIndex}</div>;
+  //   }
+  //   return (
+  //     <div>You have exceeded the character limits on the following line(s):
+  //     </div>
+  //   )
+
+  // ));
+
   return (
     <div className="translation-page">
       <h1>Story Title Here</h1>
@@ -237,6 +260,7 @@ const TranslationPage = () => {
           <button onClick={redoChange} type="button">
             Redo
           </button>
+          {maxCharsExceededWarning}
           {storyCells}
         </div>
         <div className="translation-sidebar">

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
-
+import { Box, Text } from "@chakra-ui/react";
 import "./TranslationPage.css";
 import { useParams } from "react-router-dom";
 import Cell from "../translation/Cell";
@@ -202,7 +202,6 @@ const TranslationPage = () => {
 
   const storyCells = translatedStoryLines.map((storyLine: StoryLine) => {
     const displayLineNumber = storyLine.lineIndex + 1;
-
     return (
       <div className="row-translation" key={`row-${storyLine.lineIndex}`}>
         <p className="line-index">{displayLineNumber}</p>
@@ -220,33 +219,27 @@ const TranslationPage = () => {
   });
 
   const maxCharsExceededWarning = () => {
-    let exceededLines = ""; 
-    translatedStoryLines.map((storyLine: StoryLine) => {
+    const exceededLines: number[] = [];
+    translatedStoryLines.forEach((storyLine: StoryLine) => {
       if (
         storyLine.translatedContent &&
-        storyLine.originalContent.length * 2 <= storyLine.translatedContent.length) 
-        {
-        exceededLines += (", " + String(storyLine.lineIndex + 1));
+        storyLine.originalContent.length * 2 <=
+          storyLine.translatedContent.length
+      ) {
+        exceededLines.push(storyLine.lineIndex + 1);
       }
     });
 
-    return (
-      <div>
-        <p>
-          You have exceeded the character limit in the following lines: 
-        </p>
-      </div>
-    );
+    const exceededLinesJoined = exceededLines.join(", ");
+    return exceededLines.length > 0 ? (
+      <Box>
+        <Text>
+          {"⚠ You have exceeded the character limit in the following lines: "}
+          {exceededLinesJoined}
+        </Text>
+      </Box>
+    ) : null;
   };
-  //   const exceededLines = (storyLine: StoryLine) => {
-  //     return <div>{storyLine.lineIndex}</div>;
-  //   }
-  //   return (
-  //     <div>You have exceeded the character limits on the following line(s):
-  //     </div>
-  //   )
-
-  // ));
 
   return (
     <div className="translation-page">
@@ -260,7 +253,7 @@ const TranslationPage = () => {
           <button onClick={redoChange} type="button">
             Redo
           </button>
-          {maxCharsExceededWarning}
+          {maxCharsExceededWarning()}
           {storyCells}
         </div>
         <div className="translation-sidebar">

--- a/frontend/src/components/translation/EditableCell.css
+++ b/frontend/src/components/translation/EditableCell.css
@@ -7,3 +7,13 @@
     padding: 10px;
     width: 40%;
 }
+
+.max-char-reached {
+    border:2px red solid;
+    border-radius: 3px;
+    font-size: 12px;
+    height: fit-content;
+    margin: 0px 10px 10px 10px;
+    padding: 10px;
+    width: 40%;
+}

--- a/frontend/src/components/translation/EditableCell.css
+++ b/frontend/src/components/translation/EditableCell.css
@@ -7,13 +7,3 @@
     padding: 10px;
     width: 40%;
 }
-
-.max-char-reached {
-    border:2px red solid;
-    border-radius: 3px;
-    font-size: 12px;
-    height: fit-content;
-    margin: 0px 10px 10px 10px;
-    padding: 10px;
-    width: 40%;
-}

--- a/frontend/src/components/translation/EditableCell.tsx
+++ b/frontend/src/components/translation/EditableCell.tsx
@@ -5,15 +5,21 @@ export type EditableCellProps = {
   text: string;
   storyTranslationContentId: number;
   lineIndex: number;
-  onChange: (newContent: string, lineIndex: number) => void;
+  maxChars: number;
+  onChange: (newContent: string, lineIndex: number, maxChars: number) => void;
 };
 
-const EditableCell = ({ text, lineIndex, onChange }: EditableCellProps) => {
+const EditableCell = ({
+  text,
+  lineIndex,
+  maxChars,
+  onChange,
+}: EditableCellProps) => {
   return (
     <textarea
       className="input-translation"
       value={text}
-      onChange={(event) => onChange(event.target.value, lineIndex)}
+      onChange={(event) => onChange(event.target.value, lineIndex, maxChars)}
     />
   );
 };

--- a/frontend/src/components/translation/EditableCell.tsx
+++ b/frontend/src/components/translation/EditableCell.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import "./EditableCell.css";
+// import "./EditableCell.css";
+
+import { Textarea } from "@chakra-ui/react";
 
 export type EditableCellProps = {
   text: string;
@@ -16,10 +18,11 @@ const EditableCell = ({
   onChange,
 }: EditableCellProps) => {
   return (
-    <textarea
-      className={
-        text.length === maxChars ? "max-char-reached" : "input-translation"
+    <Textarea
+      variant={
+        text.length === maxChars ? "maxCharsReached" : "translationEditable"
       }
+      isInvalid={text.length >= maxChars}
       value={text}
       onChange={(event) => onChange(event.target.value, lineIndex, maxChars)}
     />

--- a/frontend/src/components/translation/EditableCell.tsx
+++ b/frontend/src/components/translation/EditableCell.tsx
@@ -17,7 +17,9 @@ const EditableCell = ({
 }: EditableCellProps) => {
   return (
     <textarea
-      className="input-translation"
+      className={
+        text.length === maxChars ? "max-char-reached" : "input-translation"
+      }
       value={text}
       onChange={(event) => onChange(event.target.value, lineIndex, maxChars)}
     />

--- a/frontend/src/components/translation/EditableCell.tsx
+++ b/frontend/src/components/translation/EditableCell.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-// import "./EditableCell.css";
 
 import { Textarea } from "@chakra-ui/react";
 
@@ -22,7 +21,6 @@ const EditableCell = ({
       variant={
         text.length === maxChars ? "maxCharsReached" : "translationEditable"
       }
-      isInvalid={text.length >= maxChars}
       value={text}
       onChange={(event) => onChange(event.target.value, lineIndex, maxChars)}
     />

--- a/frontend/src/theme/components/Textarea.ts
+++ b/frontend/src/theme/components/Textarea.ts
@@ -1,5 +1,3 @@
-// import { theme } from "@chakra-ui/react";
-
 const Textarea = {
   variants: {
     translationEditable: {

--- a/frontend/src/theme/components/Textarea.ts
+++ b/frontend/src/theme/components/Textarea.ts
@@ -1,0 +1,25 @@
+// import { theme } from "@chakra-ui/react";
+
+const Textarea = {
+  variants: {
+    translationEditable: {
+      border: "1px solid black",
+      borderRadius: "3px",
+      fontSize: "12px",
+      height: "fit-content",
+      margin: "0px 10px 10px 10px",
+      padding: "10px",
+      width: "40%",
+    },
+    maxCharsReached: {
+      border: "2px solid red",
+      borderRadius: "3px",
+      fontSize: "12px",
+      height: "fit-content",
+      margin: "0px 10px 10px 10px",
+      padding: "10px",
+      width: "40%",
+    },
+  },
+};
+export default Textarea;

--- a/frontend/src/theme/components/Textarea.ts
+++ b/frontend/src/theme/components/Textarea.ts
@@ -12,7 +12,7 @@ const Textarea = {
       width: "40%",
     },
     maxCharsReached: {
-      border: "2px solid red",
+      border: "1px solid red",
       borderRadius: "3px",
       fontSize: "12px",
       height: "fit-content",

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -6,6 +6,7 @@ import Badge from "./components/Badge";
 import Button from "./components/Button";
 import Filter from "./components/Filter";
 import StoryCard from "./components/StoryCard";
+import Textarea from "./components/Textarea";
 
 const customTheme: Theme = extendTheme({
   fonts: {
@@ -21,6 +22,7 @@ const customTheme: Theme = extendTheme({
     Button,
     Filter,
     StoryCard,
+    Textarea,
   },
 });
 


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Ticket Name](https://www.notion.so/uwblueprintexecs/Limit-number-of-chars-in-Editable-fb93347b84824cb5adf024371430d478)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Create new ts file for Textarea to add styling for the editable box 
* Change function that updates editable to not accept new characters after a certain limit 
* Add new message that tells users which lines they are exceeding the limit on  


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Type in a characters that are double the amount of the original content 
2. Ensure that the text area has red border and there is a message at the top indicating which line is over 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* There is no unintended behaviour when user tries to input more than character limit 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
