### PR TITLE
Eliminate arrayIndex method and usages

### DIFF
--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -68,9 +68,6 @@ const TranslationPage = () => {
     Redo: [],
   });
 
-  const arrayIndex = (lineIndex: number): number =>
-    lineIndex - translatedStoryLines[0].lineIndex;
-
   const deepCopy = (lines: Object) => {
     // This is a funky method to make deep copies on objects with primative values
     // https://javascript.plainenglish.io/how-to-deep-copy-objects-and-arrays-in-javascript-7c911359b089
@@ -97,30 +94,28 @@ const TranslationPage = () => {
     lineIndex: number,
   ) => {
     const updatedContentArray = [...translatedStoryLines];
-    const index = arrayIndex(lineIndex);
     if (
       // user deleted translation line
       !newContent.trim() &&
-      translatedStoryLines[index].translatedContent!!.trim()
+      translatedStoryLines[lineIndex].translatedContent!!.trim()
     ) {
       setNumTranslatedLines(numTranslatedLines - 1);
     } else if (
       // user added new translation line
       newContent.trim() &&
-      !translatedStoryLines[index].translatedContent!!.trim()
+      !translatedStoryLines[lineIndex].translatedContent!!.trim()
     ) {
       setNumTranslatedLines(numTranslatedLines + 1);
     }
-    updatedContentArray[index].translatedContent = newContent;
+    updatedContentArray[lineIndex].translatedContent = newContent;
     setTranslatedStoryLines(updatedContentArray);
     setChangedStoryLines(
-      changedStoryLines.set(lineIndex, updatedContentArray[index]),
+      changedStoryLines.set(lineIndex, updatedContentArray[lineIndex]),
     );
   };
 
   const onUserInput = async (newContent: string, lineIndex: number) => {
-    const oldContent = translatedStoryLines[arrayIndex(lineIndex)]
-      .translatedContent!;
+    const oldContent = translatedStoryLines[lineIndex].translatedContent!;
     const newUndo =
       versionHistoryStack.Undo.length === MAX_STACK_SIZE
         ? versionHistoryStack.Undo.slice(1)
@@ -137,8 +132,7 @@ const TranslationPage = () => {
       const { lineIndex, content: newContent } = versionHistoryStack.Undo[
         versionHistoryStack.Undo.length - 1
       ];
-      const oldContent =
-        translatedStoryLines[arrayIndex(lineIndex)].translatedContent;
+      const oldContent = translatedStoryLines[lineIndex].translatedContent;
       if (oldContent !== newContent) {
         const newRedo =
           versionHistoryStack.Redo.length === MAX_STACK_SIZE
@@ -165,8 +159,7 @@ const TranslationPage = () => {
       const { lineIndex, content: newContent } = versionHistoryStack.Redo[
         versionHistoryStack.Redo.length - 1
       ];
-      const oldContent =
-        translatedStoryLines[arrayIndex(lineIndex)].translatedContent;
+      const oldContent = translatedStoryLines[lineIndex].translatedContent;
       if (oldContent !== newContent) {
         const newUndo =
           versionHistoryStack.Undo.length === MAX_STACK_SIZE
@@ -222,10 +215,7 @@ const TranslationPage = () => {
   const storyCells = translatedStoryLines.map((storyLine: StoryLine) => {
     const displayLineNumber = storyLine.lineIndex + 1;
     return (
-      <div
-        className="row-translation"
-        key={`row-${arrayIndex(storyLine.lineIndex)}`}
-      >
+      <div className="row-translation" key={`row-${storyLine.lineIndex}`}>
         <p className="line-index">{displayLineNumber}</p>
         <Cell text={storyLine.originalContent} />
         <EditableCell


### PR DESCRIPTION
## Notion ticket link
https://github.com/uwblueprint/planet-read/pull/55#discussion_r680615460

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Comment should explain why this makes sense - replaced all `arrayIndex(lineIndex)` calls with just `lineIndex` since the `arrayIndex(lineIndex) == lineIndex` always


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run locally, open up translation page. Did I break anything?


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Does eliminating this method make sense given how design wants the page to be?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
