### PR TITLE
Add pytest to backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/build
 **/venv
 **/__pycache__
+**/.pytest_cache
 **/*.log
 **/firebaseServiceAccount.json
 **/.DS_Store

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ Backend test run using the `pytest` framework on a distinct test database. You m
 
 If you want to run any other pytest commands, run them manually with:
 ```
-docker exec <backend-contianer-id> /bin/bash <pytest command>
+docker exec -it planet-read_py-backend_1 /bin/bash <pytest command>
 ```
 
 # Lint
 Frontend has on-save linting. To lint the backend:
 ```
-docker exec <backend-container-id> /bin/bash -c "black . && isort --profile black ."
+docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."
 ```
 
 Follow the [getting started](https://uwblueprint.github.io/starter-code-v2/docs/getting-started) for more details, especially if you desire to use your own firebase and gcp projects.

--- a/backend/python/app/__init__.py
+++ b/backend/python/app/__init__.py
@@ -50,7 +50,9 @@ def create_app(config_name):
     ] = "mysql://{username}:{password}@{host}:3306/{db}".format(
         username=os.getenv("MYSQL_USER"),
         password=os.getenv("MYSQL_PASSWORD"),
-        host=os.getenv("TEST_DB_HOST") if config_name == "testing" else os.getenv("DB_HOST"),
+        host=os.getenv("TEST_DB_HOST")
+        if config_name == "testing"
+        else os.getenv("DB_HOST"),
         db=os.getenv("MYSQL_DATABASE"),
     )
 

--- a/backend/python/app/__init__.py
+++ b/backend/python/app/__init__.py
@@ -50,7 +50,7 @@ def create_app(config_name):
     ] = "mysql://{username}:{password}@{host}:3306/{db}".format(
         username=os.getenv("MYSQL_USER"),
         password=os.getenv("MYSQL_PASSWORD"),
-        host=os.getenv("DB_HOST"),
+        host=os.getenv("TEST_DB_HOST") if config_name == "testing" else os.getenv("DB_HOST"),
         db=os.getenv("MYSQL_DATABASE"),
     )
 

--- a/backend/python/app/config.py
+++ b/backend/python/app/config.py
@@ -24,4 +24,18 @@ class ProductionConfig(Config):
     DEBUG = False
 
 
-app_config = {"development": DevelopmentConfig, "production": ProductionConfig}
+class TestingConfig(Config):
+    """
+    Testing configurations
+    """
+
+    DEBUG = True
+    SQLALCHEMY_ECHO = True
+    TESTING = True
+
+
+app_config = {
+    "development": DevelopmentConfig,
+    "production": ProductionConfig,
+    "testing": TestingConfig,
+}

--- a/backend/python/app/conftest.py
+++ b/backend/python/app/conftest.py
@@ -1,0 +1,85 @@
+import os
+
+import pytest
+from sqlalchemy.engine import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+from graphene.test import Client
+
+from . import create_app
+
+# https://github.com/apryor6/flask_testing_examples/tree/master/fte
+
+my_app = None
+
+
+@pytest.fixture
+def app():
+    """
+    Returns app configured for testing
+    """
+    global my_app
+    if my_app is None:
+        my_app = create_app("testing")
+    return my_app
+
+
+@pytest.fixture
+def client(app):
+    """
+    Returns app test client
+    """
+    return app.test_client()
+
+
+@pytest.fixture
+def db(app):
+    """
+    Yields db instance
+    """
+    from .models import db
+
+    from .models.comment import Comment
+    from .models.entity import Entity
+    from .models.file import File
+    from .models.story import Story
+    from .models.story_content import StoryContent
+    from .models.story_translation import StoryTranslation
+    from .models.story_translation_content import StoryTranslationContent
+    from .models.user import User
+    
+    app.app_context().push()
+    db.init_app(app)
+
+    db.drop_all()
+    db.create_all()
+
+    yield db
+    
+    db.session.close()
+
+
+@pytest.fixture
+def services(app):
+    """
+    Returns model services
+    """
+    with app.app_context():
+        from .services.implementations.comment_service import CommentService
+        from .services.implementations.entity_service import EntityService
+        from .services.implementations.story_service import StoryService
+        from .services.implementations.user_service import UserService
+
+        return {
+            "comment": CommentService(),
+            "entity": EntityService(),
+            "story": StoryService(),
+            "user": UserService(),
+        }
+
+@pytest.fixture
+def client(app):
+    with app.app_context():
+        from .graphql.schema import schema
+
+        return Client(schema)

--- a/backend/python/app/conftest.py
+++ b/backend/python/app/conftest.py
@@ -1,10 +1,10 @@
 import os
 
 import pytest
+from graphene.test import Client
 from sqlalchemy.engine import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
-from graphene.test import Client
 
 from . import create_app
 
@@ -25,20 +25,11 @@ def app():
 
 
 @pytest.fixture
-def client(app):
-    """
-    Returns app test client
-    """
-    return app.test_client()
-
-
-@pytest.fixture
 def db(app):
     """
     Yields db instance
     """
     from .models import db
-
     from .models.comment import Comment
     from .models.entity import Entity
     from .models.file import File
@@ -47,15 +38,12 @@ def db(app):
     from .models.story_translation import StoryTranslation
     from .models.story_translation_content import StoryTranslationContent
     from .models.user import User
-    
-    app.app_context().push()
-    db.init_app(app)
 
     db.drop_all()
     db.create_all()
 
     yield db
-    
+
     db.session.close()
 
 
@@ -64,22 +52,24 @@ def services(app):
     """
     Returns model services
     """
-    with app.app_context():
-        from .services.implementations.comment_service import CommentService
-        from .services.implementations.entity_service import EntityService
-        from .services.implementations.story_service import StoryService
-        from .services.implementations.user_service import UserService
+    from .services.implementations.comment_service import CommentService
+    from .services.implementations.entity_service import EntityService
+    from .services.implementations.story_service import StoryService
+    from .services.implementations.user_service import UserService
 
-        return {
-            "comment": CommentService(),
-            "entity": EntityService(),
-            "story": StoryService(),
-            "user": UserService(),
-        }
+    return {
+        "comment": CommentService(),
+        "entity": EntityService(),
+        "story": StoryService(),
+        "user": UserService(),
+    }
+
 
 @pytest.fixture
 def client(app):
-    with app.app_context():
-        from .graphql.schema import schema
+    """
+    Returns graphene client for test query/mutation
+    """
+    from .graphql.schema import schema
 
-        return Client(schema)
+    return Client(schema)

--- a/backend/python/requirements.txt
+++ b/backend/python/requirements.txt
@@ -37,7 +37,6 @@ Jinja2==2.11.2
 Mako==1.1.4
 MarkupSafe==1.1.1
 mysqlclient==2.0.3
-mongoengine==0.23.0
 msgpack==1.0.2
 mypy-extensions==0.4.3
 packaging==20.9
@@ -48,7 +47,6 @@ psycopg2==2.8.6
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.20
-pymongo==3.11.3
 pyparsing==2.4.7
 pytest==6.2.4
 python-dateutil==2.8.1

--- a/backend/python/requirements.txt
+++ b/backend/python/requirements.txt
@@ -50,6 +50,7 @@ pyasn1-modules==0.2.8
 pycparser==2.20
 pymongo==3.11.3
 pyparsing==2.4.7
+pytest==6.2.4
 python-dateutil==2.8.1
 python-dotenv==0.15.0
 python-editor==1.0.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,17 @@ services:
       - mysql_data:/var/lib/mysql/
     env_file:
       - ./.env
+  test-db:
+    image: mysql:8.0.25
+    command: --default-authentication-plugin=mysql_native_password --innodb-use-native-aio=0
+    ports:
+      - 3307:3306
+    volumes:
+      - mysql_data:/var/lib/mysql_test/
+    env_file:
+      - ./.env
 
 volumes:
   mysql_data:
+  mysql_test_data:
   file_uploads:

--- a/utils.sh
+++ b/utils.sh
@@ -4,14 +4,20 @@ then
     then
         docker exec -it planet-read_py-backend_1 pytest
     else
-        # TODO improvement - parse from backend/ path location
-        # right now, has to be from app/...
-        docker exec -it planet-read_py-backend_1 pytest $2
+        if [[ "$3" = "" ]]
+        then
+            # TODO improvement - parse from backend/ path location
+            # right now, has to be from app/...
+            docker exec -it planet-read_py-backend_1 pytest $2
+        else
+            # super detailed, match a test name pattern
+            docker exec -it planet-read_py-backend_1 pytest $2 -k "$3" -vv
+        fi
     fi
 elif [[ "$1" = "enter-db" ]]
 then
     ROOT_PASSWORD=$(grep MYSQL_ROOT_PASSWORD .env | cut -d '=' -f2)
-    docker exec -it planet-read_db_1 mysql -u $ROOT_PASSWORD -proot
+    docker exec -it planet-read_db_1 mysql -u root -p$ROOT_PASSWORD
 else
     echo "Invalid command."
 fi

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,17 @@
+if [[ "$1" = "pytest" ]]
+then
+    if [[ "$2" = "" ]]
+    then
+        docker exec -it planet-read_py-backend_1 pytest
+    else
+        # TODO improvement - parse from backend/ path location
+        # right now, has to be from app/...
+        docker exec -it planet-read_py-backend_1 pytest $2
+    fi
+elif [[ "$1" = "enter-db" ]]
+then
+    ROOT_PASSWORD=$(grep MYSQL_ROOT_PASSWORD .env | cut -d '=' -f2)
+    docker exec -it planet-read_db_1 mysql -u $ROOT_PASSWORD -proot
+else
+    echo "Invalid command."
+fi


### PR DESCRIPTION
(This is the entire description of part 1 and 2.)

## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add pytest](https://www.notion.so/uwblueprintexecs/Add-pytest-78637b82f2d9450eab9ef72dcf011290)
- This is part 1 of 2. Part 2 is available here: https://github.com/uwblueprint/planet-read/pull/69

## Usage
Test files are found by the following:
- Tests are in a `tests/` directory
- The test file is named `test_<something>.py`
- Each test is defined in a function whose prefix is `test_`:
```python
def test_<describe_the_test>():
  pass
```
The available fixtures currently are `app`, `db`, `client`, and `services`. If you pass the name of the fixture as a parameter of the test, it will execute fixture code before running your test and return or yield to you.
```python
def test_<describe_the_test>(app):
  result = app.run_something(True)
  assert(result)
```

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add testing configuration, which allows for better error log messages while testing, which is determined by the `config_name` passed to `create_app`. Normally, `create_app` is called from `server.py` which is the command that initiates the backend, but for testing it will be explicitly called if not created through the `app` fixture with `config_name = 'testing'`. This mostly just changes the db to be used.
* `conftest.py` has the fixtures we're using right now.
* Trivia: `app.app_context().push` is called same as in the development flow in the `models/__init__.py` which is called from the `create_app` flow and should therefore be available everywhere
* Trivia no. 2: ran into a ton of problems with parent packages not being found (run https://github.com/uwblueprint/planet-read/pull/53/ to observe the 😭) and restructuring made it clear where I could insert `__init__.py` files and eventually worked
* Added a `utils.sh` script because I'm lazy and like things abbreviated

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Rebuild (`docker-compose down -v`, `docker-compose up --build`) and recreate db 
2. Run the tests using `./utils.sh pytest`
3. Try out the other pytest command options: for a specific file, and for a file + name pattern match. Run it manually with `docker exec -it <backend-container-id> /bin/bash <pytest command>`
4. Verify that the tests db and general db refer to different instances: Make a change (whether via backend or frontend) to one of the tables, run the tests (which will drop and recreate everything), and check that your change has persisted. 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Test structure: I think there are two schools of thoughts here, (1) that tests should live in a distinct `app/tests` directory that mirrors the file structure of the rest of the app, or (2) that tests should live right next to the actual code. I opted for (1) because it made it easy to add `__init__.py` files that made it work and I don't think imports look too, too bad. 
* Fixture placement: all our fixtures are in a single location right now, `conftest.py`. I think we should split this up as we go. Similar thought for helpers - we'll need somewhere to put them that isn't just one long file
* The one mutation test that was implemented, `test_story_mutation.py` does a lot of verifying, checking both the expected response type and that the expected changes were made to the db for each field. This causes some problems: there are some weird type mismatches and one is snake case vs. other in camel case, which with nesting, is a pain to sort out. Is this the right approach/extensiveness at which we want to test?
* Somewhat related, Graphene offers an option for snapshot testing graphene (see [docs](https://docs.graphene-python.org/en/latest/testing/#snapshot-testing)). I'm not sold on using it, but open to feedback -- it is much more concise, but somewhat hides our result from us.
* Read through the tests cases. This PR isn't focused on extensive test coverage (so naming isn't consistent, probably missing cases, and I definitely use error vs. exception interchangeably) and will grow as we implement more, but let me know if it all makes sense.


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
