### PR TITLE
Modularlize GQL request strings

### DIFF
--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -9,7 +9,7 @@ import {
   LogoutResponse,
   ResetPasswordResponse,
   RefreshResponse,
-} from "./mutations";
+} from "./mutations/AuthMutations";
 import { setLocalStorageObjProperty } from "../utils/LocalStorageUtils";
 
 type LoginFunction = (

--- a/frontend/src/APIClients/BaseGQLClient.ts
+++ b/frontend/src/APIClients/BaseGQLClient.ts
@@ -14,7 +14,7 @@ import {
   setLocalStorageObjProperty,
   getLocalStorageObjProperty,
 } from "../utils/LocalStorageUtils";
-import { REFRESH } from "./mutations";
+import { REFRESH } from "./mutations/AuthMutations";
 
 const httpLink = createHttpLink({
   uri: `${process.env.REACT_APP_BACKEND_URL}/graphql`,

--- a/frontend/src/APIClients/mutations.ts
+++ b/frontend/src/APIClients/mutations.ts
@@ -17,7 +17,7 @@ export const LOGIN = gql`
 `;
 
 export const LOGIN_WITH_GOOGLE = gql`
-  mutation loginWithGoogle($tokenId: String!) {
+  mutation LoginWithGoogle($tokenId: String!) {
     loginWithGoogle(tokenId: $tokenId) {
       id
       firstName
@@ -71,5 +71,70 @@ export interface ResetPasswordResponse {
   ok: boolean;
 }
 
+export const SIGNUP = gql`
+  mutation SignUp(
+    $firstName: String!
+    $lastName: String!
+    $email: String!
+    $password: String!
+  ) {
+    signup(
+      firstName: $firstName
+      lastName: $lastName
+      email: $email
+      password: $password
+    ) {
+      id
+      firstName
+      lastName
+      email
+      role
+      accessToken
+      refreshToken
+    }
+  }
+`;
+
 // Stories
-// TODO: move mutation gql strings here
+export const UPDATE_STORY_TRANSLATION_CONTENTS = gql`
+  mutation UpdateStoryTranslationContents(
+    $storyTranslationContents: [StoryTranslationContentRequestDTO]
+  ) {
+    updateStoryTranslationContents(
+      storyTranslationContents: $storyTranslationContents
+    ) {
+      story {
+        id
+      }
+    }
+  }
+`;
+
+export const CREATE_TRANSLATION = gql`
+  mutation CreateStoryTranslation(
+    $storyTranslationData: CreateStoryTranslationRequestDTO!
+  ) {
+    createStoryTranslation(storyTranslationData: $storyTranslationData) {
+      story {
+        id
+      }
+    }
+  }
+`;
+export type CreateTranslation = {
+  story: {
+    id: number;
+  };
+};
+
+export const ASSIGN_REVIEWER = gql`
+  mutation AssignUserAsReviewer($storyTranslationId: ID!, $userId: ID!) {
+    assignUserAsReviewer(
+      storyTranslationId: $storyTranslationId
+      userId: $userId
+    ) {
+      ok
+    }
+  }
+`;
+export type AssignReviewer = { ok: boolean };

--- a/frontend/src/APIClients/mutations/AuthMutations.ts
+++ b/frontend/src/APIClients/mutations/AuthMutations.ts
@@ -1,6 +1,5 @@
 import { gql } from "@apollo/client";
 
-// Auth
 export const LOGIN = gql`
   mutation Login($email: String!, $password: String!) {
     login(email: $email, password: $password) {
@@ -94,47 +93,3 @@ export const SIGNUP = gql`
     }
   }
 `;
-
-// Stories
-export const UPDATE_STORY_TRANSLATION_CONTENTS = gql`
-  mutation UpdateStoryTranslationContents(
-    $storyTranslationContents: [StoryTranslationContentRequestDTO]
-  ) {
-    updateStoryTranslationContents(
-      storyTranslationContents: $storyTranslationContents
-    ) {
-      story {
-        id
-      }
-    }
-  }
-`;
-
-export const CREATE_TRANSLATION = gql`
-  mutation CreateStoryTranslation(
-    $storyTranslationData: CreateStoryTranslationRequestDTO!
-  ) {
-    createStoryTranslation(storyTranslationData: $storyTranslationData) {
-      story {
-        id
-      }
-    }
-  }
-`;
-export type CreateTranslation = {
-  story: {
-    id: number;
-  };
-};
-
-export const ASSIGN_REVIEWER = gql`
-  mutation AssignUserAsReviewer($storyTranslationId: ID!, $userId: ID!) {
-    assignUserAsReviewer(
-      storyTranslationId: $storyTranslationId
-      userId: $userId
-    ) {
-      ok
-    }
-  }
-`;
-export type AssignReviewer = { ok: boolean };

--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -1,0 +1,44 @@
+import { gql } from "@apollo/client";
+
+export const UPDATE_STORY_TRANSLATION_CONTENTS = gql`
+  mutation UpdateStoryTranslationContents(
+    $storyTranslationContents: [StoryTranslationContentRequestDTO]
+  ) {
+    updateStoryTranslationContents(
+      storyTranslationContents: $storyTranslationContents
+    ) {
+      story {
+        id
+      }
+    }
+  }
+`;
+
+export const CREATE_TRANSLATION = gql`
+  mutation CreateStoryTranslation(
+    $storyTranslationData: CreateStoryTranslationRequestDTO!
+  ) {
+    createStoryTranslation(storyTranslationData: $storyTranslationData) {
+      story {
+        id
+      }
+    }
+  }
+`;
+export type CreateTranslationResponse = {
+  story: {
+    id: number;
+  };
+};
+
+export const ASSIGN_REVIEWER = gql`
+  mutation AssignUserAsReviewer($storyTranslationId: ID!, $userId: ID!) {
+    assignUserAsReviewer(
+      storyTranslationId: $storyTranslationId
+      userId: $userId
+    ) {
+      ok
+    }
+  }
+`;
+export type AssignReviewerResponse = { ok: boolean };

--- a/frontend/src/APIClients/queries.ts
+++ b/frontend/src/APIClients/queries.ts
@@ -1,3 +1,115 @@
-// TODO: move query gql strings here
+import { DocumentNode, gql } from "@apollo/client";
 
-export {};
+// Stories
+export const GET_STORY_CONTENTS = (id: number) =>
+  gql`
+      query {
+        storyById(
+          id: ${id}
+        ) {
+          contents {
+            id
+            lineIndex
+            content
+          }
+        }
+      }
+    `;
+
+export const GET_STORY_AND_TRANSLATION_CONTENTS = (
+  storyId: number,
+  storyTranslationId: number,
+) => gql`
+  query GetStoryAndTranslationContents{
+    storyById(id: ${storyId}) {
+      contents {
+        id
+        lineIndex
+        content
+      }
+    }
+    storyTranslationById(id: ${storyTranslationId}) {
+      translationContents {
+        id
+        lineIndex
+        content: translationContent
+      },
+      numTranslatedLines
+    }
+  }
+`;
+
+export type QueryInformation = {
+  fieldName: string;
+  string: DocumentNode;
+};
+
+const STORY_FIELDS = `
+    title
+    description
+    youtubeLink
+    level
+    `;
+
+export const buildHomePageStoriesQuery = (
+  displayMyStories: boolean,
+  language: string,
+  isTranslator: boolean,
+  level: number,
+  userId: number,
+): QueryInformation => {
+  let result = {};
+
+  if (isTranslator && !displayMyStories) {
+    result = {
+      fieldName: "storiesAvailableForTranslation",
+      string: gql`
+            query {
+              storiesAvailableForTranslation(
+                language: "${language}",
+                level: ${level}
+              ) {
+                storyId: id
+                ${STORY_FIELDS}
+              }
+            }
+          `,
+    };
+  } else if (!isTranslator && !displayMyStories) {
+    result = {
+      fieldName: "storyTranslationsAvailableForReview",
+      string: gql`
+            query {
+              storyTranslationsAvailableForReview(
+                language: "${language}",
+                level: ${level}
+              ) {
+                storyId
+                storyTranslationId: id
+                ${STORY_FIELDS}
+              }
+            }
+          `,
+    };
+  } else if (displayMyStories) {
+    result = {
+      fieldName: "storyTranslationsByUser",
+      string: gql`
+            query {
+              storyTranslationsByUser(
+                userId: ${userId},
+                translator: ${isTranslator},
+                language: "${language}",
+                level: ${level}
+              ) {
+                storyId
+                storyTranslationId: id
+                ${STORY_FIELDS}
+              }
+            }
+          `,
+    };
+  }
+
+  return result as QueryInformation;
+};

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -1,9 +1,8 @@
 import { DocumentNode, gql } from "@apollo/client";
 
-// Stories
 export const GET_STORY_CONTENTS = (id: number) =>
   gql`
-      query {
+      query GetStoryContents {
         storyById(
           id: ${id}
         ) {
@@ -64,7 +63,7 @@ export const buildHomePageStoriesQuery = (
     result = {
       fieldName: "storiesAvailableForTranslation",
       string: gql`
-            query {
+            query StoriesAvailableForTranslation {
               storiesAvailableForTranslation(
                 language: "${language}",
                 level: ${level}
@@ -79,7 +78,7 @@ export const buildHomePageStoriesQuery = (
     result = {
       fieldName: "storyTranslationsAvailableForReview",
       string: gql`
-            query {
+            query StoriesAvailableForTranslation {
               storyTranslationsAvailableForReview(
                 language: "${language}",
                 level: ${level}
@@ -95,7 +94,7 @@ export const buildHomePageStoriesQuery = (
     result = {
       fieldName: "storyTranslationsByUser",
       string: gql`
-            query {
+            query StoriesAvailableForTranslation {
               storyTranslationsByUser(
                 userId: ${userId},
                 translator: ${isTranslator},

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -7,7 +7,10 @@ import {
 } from "react-google-login";
 import { Redirect } from "react-router-dom";
 import authAPIClient from "../../APIClients/AuthAPIClient";
-import { LOGIN, LOGIN_WITH_GOOGLE } from "../../APIClients/mutations";
+import {
+  LOGIN,
+  LOGIN_WITH_GOOGLE,
+} from "../../APIClients/mutations/AuthMutations";
 import AuthContext, { AuthenticatedUser } from "../../contexts/AuthContext";
 import ResetPassword from "./ResetPassword";
 

--- a/frontend/src/components/auth/Logout.tsx
+++ b/frontend/src/components/auth/Logout.tsx
@@ -1,7 +1,10 @@
 import React, { useContext, useEffect } from "react";
 import { useMutation } from "@apollo/client";
 import AuthContext from "../../contexts/AuthContext";
-import { LOGOUT, LogoutResponse } from "../../APIClients/mutations";
+import {
+  LOGOUT,
+  LogoutResponse,
+} from "../../APIClients/mutations/AuthMutations";
 import authAPIClient from "../../APIClients/AuthAPIClient";
 
 const Logout = () => {

--- a/frontend/src/components/auth/RefreshCredentials.tsx
+++ b/frontend/src/components/auth/RefreshCredentials.tsx
@@ -1,7 +1,10 @@
 import React, { useContext } from "react";
 import { useMutation } from "@apollo/client";
 import AuthContext from "../../contexts/AuthContext";
-import { REFRESH, RefreshResponse } from "../../APIClients/mutations";
+import {
+  REFRESH,
+  RefreshResponse,
+} from "../../APIClients/mutations/AuthMutations";
 import authAPIClient from "../../APIClients/AuthAPIClient";
 
 const RefreshCredentials = () => {

--- a/frontend/src/components/auth/ResetPassword.tsx
+++ b/frontend/src/components/auth/ResetPassword.tsx
@@ -3,7 +3,7 @@ import { useMutation } from "@apollo/client";
 import {
   RESET_PASSWORD,
   ResetPasswordResponse,
-} from "../../APIClients/mutations";
+} from "../../APIClients/mutations/AuthMutations";
 import authAPIClient from "../../APIClients/AuthAPIClient";
 
 type ResetPasswordProps = {

--- a/frontend/src/components/auth/Signup.tsx
+++ b/frontend/src/components/auth/Signup.tsx
@@ -3,7 +3,7 @@ import { Redirect } from "react-router-dom";
 import { useMutation } from "@apollo/client";
 import authAPIClient from "../../APIClients/AuthAPIClient";
 import AuthContext, { AuthenticatedUser } from "../../contexts/AuthContext";
-import { SIGNUP } from "../../APIClients/mutations";
+import { SIGNUP } from "../../APIClients/mutations/AuthMutations";
 
 const Signup = () => {
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);

--- a/frontend/src/components/auth/Signup.tsx
+++ b/frontend/src/components/auth/Signup.tsx
@@ -1,32 +1,9 @@
 import React, { useContext, useState } from "react";
 import { Redirect } from "react-router-dom";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import authAPIClient from "../../APIClients/AuthAPIClient";
 import AuthContext, { AuthenticatedUser } from "../../contexts/AuthContext";
-
-const SIGNUP = gql`
-  mutation SignUp(
-    $firstName: String!
-    $lastName: String!
-    $email: String!
-    $password: String!
-  ) {
-    signup(
-      firstName: $firstName
-      lastName: $lastName
-      email: $email
-      password: $password
-    ) {
-      id
-      firstName
-      lastName
-      email
-      role
-      accessToken
-      refreshToken
-    }
-  }
-`;
+import { SIGNUP } from "../../APIClients/mutations";
 
 const Signup = () => {
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);

--- a/frontend/src/components/homepage/PreviewModal.tsx
+++ b/frontend/src/components/homepage/PreviewModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { gql, useQuery } from "@apollo/client";
+import { useQuery } from "@apollo/client";
 import {
   Badge,
   Box,
@@ -16,6 +16,7 @@ import {
   Text,
 } from "@chakra-ui/react";
 import convertLanguageTitleCase from "../../utils/LanguageUtils";
+import { GET_STORY_CONTENTS } from "../../APIClients/queries";
 
 export type PreviewModalProps = {
   storyId: number;
@@ -41,21 +42,6 @@ const PreviewModal = ({
   primaryBtnOnClick,
 }: PreviewModalProps) => {
   const [content, setContent] = useState<string[]>([]);
-
-  const GET_STORY_CONTENTS = (id: number) =>
-    gql`
-      query {
-        storyById(
-          id: ${id}
-        ) {
-          contents {
-            id
-            lineIndex
-            content
-          }
-        }
-      }
-    `;
 
   useQuery(GET_STORY_CONTENTS(storyId), {
     fetchPolicy: "cache-and-network",

--- a/frontend/src/components/homepage/PreviewModal.tsx
+++ b/frontend/src/components/homepage/PreviewModal.tsx
@@ -16,7 +16,7 @@ import {
   Text,
 } from "@chakra-ui/react";
 import convertLanguageTitleCase from "../../utils/LanguageUtils";
-import { GET_STORY_CONTENTS } from "../../APIClients/queries";
+import { GET_STORY_CONTENTS } from "../../APIClients/queries/StoryQueries";
 
 export type PreviewModalProps = {
   storyId: number;

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -16,10 +16,10 @@ import "./StoryCard.css";
 import convertLanguageTitleCase from "../../utils/LanguageUtils";
 import {
   ASSIGN_REVIEWER,
-  AssignReviewer,
+  AssignReviewerResponse,
   CREATE_TRANSLATION,
-  CreateTranslation,
-} from "../../APIClients/mutations";
+  CreateTranslationResponse,
+} from "../../APIClients/mutations/StoryMutations";
 
 export type StoryCardProps = {
   storyId: number;
@@ -62,7 +62,7 @@ const StoryCard = ({
   };
 
   const [assignUserAsReviewer] = useMutation<{
-    assignUserAsReviewer: AssignReviewer;
+    assignUserAsReviewer: AssignReviewerResponse;
   }>(ASSIGN_REVIEWER);
   const assignReviewer = async () => {
     try {
@@ -80,7 +80,7 @@ const StoryCard = ({
   };
 
   const [createTranslation] = useMutation<{
-    createStoryTranslation: CreateTranslation;
+    createStoryTranslation: CreateTranslationResponse;
   }>(CREATE_TRANSLATION);
   const assignTranslator = async () => {
     try {

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import { useHistory } from "react-router-dom";
 import {
   Badge,
@@ -14,35 +14,12 @@ import AuthContext from "../../contexts/AuthContext";
 import PreviewModal from "./PreviewModal";
 import "./StoryCard.css";
 import convertLanguageTitleCase from "../../utils/LanguageUtils";
-
-type AssignReviewer = { ok: boolean };
-const ASSIGN_REVIEWER = gql`
-  mutation assignUserAsReviewer($storyTranslationId: ID!, $userId: ID!) {
-    assignUserAsReviewer(
-      storyTranslationId: $storyTranslationId
-      userId: $userId
-    ) {
-      ok
-    }
-  }
-`;
-
-type CreateTranslation = {
-  story: {
-    id: number;
-  };
-};
-const CREATE_TRANSLATION = gql`
-  mutation createStoryTranslation(
-    $storyTranslationData: CreateStoryTranslationRequestDTO!
-  ) {
-    createStoryTranslation(storyTranslationData: $storyTranslationData) {
-      story {
-        id
-      }
-    }
-  }
-`;
+import {
+  ASSIGN_REVIEWER,
+  AssignReviewer,
+  CREATE_TRANSLATION,
+  CreateTranslation,
+} from "../../APIClients/mutations";
 
 export type StoryCardProps = {
   storyId: number;

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -1,89 +1,15 @@
 import React, { useContext, useState } from "react";
-import { DocumentNode, gql, useQuery } from "@apollo/client";
+import { useQuery } from "@apollo/client";
 import Filter from "../homepage/Filter";
 import StoryList from "../homepage/StoryList";
 import { StoryCardProps } from "../homepage/StoryCard";
 import AuthContext from "../../contexts/AuthContext";
 import ToggleButton from "../utils/ToggleButton";
 import Header from "../navigation/Header";
+import { buildHomePageStoriesQuery } from "../../APIClients/queries";
 import "./HomePage.css";
 
-type QueryInformation = {
-  fieldName: string;
-  string: DocumentNode;
-};
-
 const HomePage = () => {
-  const STORY_FIELDS = `
-  title
-  description
-  youtubeLink
-  level
-  `;
-
-  const buildHomePageStoriesQuery = (
-    displayMyStories: boolean,
-    language: string,
-    isTranslator: boolean,
-    level: number,
-    userId: number,
-  ): QueryInformation => {
-    let result = {};
-
-    if (isTranslator && !displayMyStories) {
-      result = {
-        fieldName: "storiesAvailableForTranslation",
-        string: gql`
-          query {
-            storiesAvailableForTranslation(
-              language: "${language}",
-              level: ${level}
-            ) {
-              storyId: id
-              ${STORY_FIELDS}
-            }
-          }
-        `,
-      };
-    } else if (!isTranslator && !displayMyStories) {
-      result = {
-        fieldName: "storyTranslationsAvailableForReview",
-        string: gql`
-          query {
-            storyTranslationsAvailableForReview(
-              language: "${language}",
-              level: ${level}
-            ) {
-              storyId
-              storyTranslationId: id
-              ${STORY_FIELDS}
-            }
-          }
-        `,
-      };
-    } else if (displayMyStories) {
-      result = {
-        fieldName: "storyTranslationsByUser",
-        string: gql`
-          query {
-            storyTranslationsByUser(
-              userId: ${userId},
-              translator: ${isTranslator},
-              language: "${language}",
-              level: ${level}
-            ) {
-              storyId
-              storyTranslationId: id
-              ${STORY_FIELDS}
-            }
-          }
-        `,
-      };
-    }
-
-    return result as QueryInformation;
-  };
-
   const { authenticatedUser } = useContext(AuthContext);
 
   const approvedLanguages = JSON.parse(

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -6,7 +6,7 @@ import { StoryCardProps } from "../homepage/StoryCard";
 import AuthContext from "../../contexts/AuthContext";
 import ToggleButton from "../utils/ToggleButton";
 import Header from "../navigation/Header";
-import { buildHomePageStoriesQuery } from "../../APIClients/queries";
+import { buildHomePageStoriesQuery } from "../../APIClients/queries/StoryQueries";
 import "./HomePage.css";
 
 const HomePage = () => {

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { gql, useQuery } from "@apollo/client";
+import { useQuery } from "@apollo/client";
 
 import "./TranslationPage.css";
 import { useParams } from "react-router-dom";
@@ -9,6 +9,7 @@ import TranslationProgressBar from "../translation/TranslationProgressBar";
 import CheckmarkIcon from "../../assets/checkmark.svg";
 import CommentIcon from "../../assets/comment_no_number.svg";
 import Autosave, { StoryLine } from "../translation/Autosave";
+import { GET_STORY_AND_TRANSLATION_CONTENTS } from "../../APIClients/queries";
 
 type TranslationPageProps = {
   storyIdParam: string | undefined;
@@ -25,26 +26,6 @@ type HistoryStack = {
   Undo: Array<{ lineIndex: number; content: string }>;
   Redo: Array<{ lineIndex: number; content: string }>;
 };
-
-const GET_STORY_CONTENTS = (storyId: number, storyTranslationId: number) => gql`
-  query {
-    storyById(id: ${storyId}) {
-      contents {
-        id
-        lineIndex
-        content
-      }
-    }
-    storyTranslationById(id: ${storyTranslationId}) {
-      translationContents {
-        id
-        lineIndex
-        content: translationContent
-      },
-      numTranslatedLines
-    }
-  }
-`;
 
 const TranslationPage = () => {
   const MAX_STACK_SIZE = 100;
@@ -185,7 +166,7 @@ const TranslationPage = () => {
     setChangedStoryLines(new Map());
   };
 
-  useQuery(GET_STORY_CONTENTS(storyId, storyTranslationId), {
+  useQuery(GET_STORY_AND_TRANSLATION_CONTENTS(storyId, storyTranslationId), {
     fetchPolicy: "cache-and-network",
     onCompleted: (data) => {
       const storyContent = data.storyById.contents;

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -9,7 +9,7 @@ import TranslationProgressBar from "../translation/TranslationProgressBar";
 import CheckmarkIcon from "../../assets/checkmark.svg";
 import CommentIcon from "../../assets/comment_no_number.svg";
 import Autosave, { StoryLine } from "../translation/Autosave";
-import { GET_STORY_AND_TRANSLATION_CONTENTS } from "../../APIClients/queries";
+import { GET_STORY_AND_TRANSLATION_CONTENTS } from "../../APIClients/queries/StoryQueries";
 
 type TranslationPageProps = {
   storyIdParam: string | undefined;

--- a/frontend/src/components/translation/Autosave.tsx
+++ b/frontend/src/components/translation/Autosave.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from "react";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
+import { UPDATE_STORY_TRANSLATION_CONTENTS } from "../../APIClients/mutations";
 
 import debounce from "../../utils/DebounceUtils";
 
@@ -9,20 +10,6 @@ export type StoryLine = {
   translatedContent?: string;
   storyTranslationContentId?: number;
 };
-
-const UPDATE_TRANSLATION = gql`
-  mutation updateStoryTranslationContents(
-    $storyTranslationContents: [StoryTranslationContentRequestDTO]
-  ) {
-    updateStoryTranslationContents(
-      storyTranslationContents: $storyTranslationContents
-    ) {
-      story {
-        id
-      }
-    }
-  }
-`;
 
 type AutosaveProps = {
   storylines: StoryLine[];
@@ -35,7 +22,9 @@ const Autosave = ({ storylines, onSuccess }: AutosaveProps) => {
     alert(errorMessage);
   };
 
-  const [updateTranslation] = useMutation<{}>(UPDATE_TRANSLATION);
+  const [updateTranslation] = useMutation<{}>(
+    UPDATE_STORY_TRANSLATION_CONTENTS,
+  );
 
   const debouncedSave = useCallback(
     debounce(async (linesToUpdate: StoryLine[]) => {

--- a/frontend/src/components/translation/Autosave.tsx
+++ b/frontend/src/components/translation/Autosave.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from "react";
 import { useMutation } from "@apollo/client";
-import { UPDATE_STORY_TRANSLATION_CONTENTS } from "../../APIClients/mutations";
+import { UPDATE_STORY_TRANSLATION_CONTENTS } from "../../APIClients/mutations/StoryMutations";
 
 import debounce from "../../utils/DebounceUtils";
 


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description 
* move all gql request strings to `src/APIClients/mutations.ts` and `src/APIClients/queries.ts`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. poke around frontend and make sure nothing is broke 💀 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* thoughts on the organization of the files? open to splitting it into 
  * `auth_mutations.ts` and `story_queries.ts` (etc)
  * eliminating mutation/query distinction and just going with `auth_requests.ts` and `story_requests.ts`


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
