### PR TITLE
Change font size slider

### DIFF
--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -10,6 +10,7 @@ import CheckmarkIcon from "../../assets/checkmark.svg";
 import CommentIcon from "../../assets/comment_no_number.svg";
 import Autosave, { StoryLine } from "../translation/Autosave";
 import { GET_STORY_AND_TRANSLATION_CONTENTS } from "../../APIClients/queries/StoryQueries";
+import FontSizeSlider from "../translation/FontSizeSlider";
 
 type TranslationPageProps = {
   storyIdParam: string | undefined;
@@ -48,6 +49,12 @@ const TranslationPage = () => {
     Undo: [],
     Redo: [],
   });
+
+  const [fontSize, setFontSize] = useState<string>("12px");
+
+  const handleFontSizeChange = (val: string) => {
+    setFontSize(val);
+  };
 
   const deepCopy = (lines: Object) => {
     // This is a funky method to make deep copies on objects with primative values
@@ -198,12 +205,13 @@ const TranslationPage = () => {
     return (
       <div className="row-translation" key={`row-${storyLine.lineIndex}`}>
         <p className="line-index">{displayLineNumber}</p>
-        <Cell text={storyLine.originalContent} />
+        <Cell text={storyLine.originalContent} fontSize={fontSize} />
         <EditableCell
           text={storyLine.translatedContent!!}
           storyTranslationContentId={storyLine.storyTranslationContentId!!}
           lineIndex={storyLine.lineIndex}
           onChange={onUserInput}
+          fontSize={fontSize}
         />
         {translationStatusIcon()}
       </div>
@@ -214,6 +222,7 @@ const TranslationPage = () => {
     <div className="translation-page">
       <h1>Story Title Here</h1>
       <h4>View story details</h4>
+      <FontSizeSlider setFontSize={handleFontSizeChange} />
       <div className="translation-container">
         <div className="translation-content">
           <button onClick={undoChange} type="button">

--- a/frontend/src/components/translation/Cell.tsx
+++ b/frontend/src/components/translation/Cell.tsx
@@ -3,10 +3,15 @@ import "./Cell.css";
 
 export type CellProps = {
   text: string;
+  fontSize: string;
 };
 
-const Cell = ({ text }: CellProps) => {
-  return <p className="cell">{text}</p>;
+const Cell = ({ text, fontSize }: CellProps) => {
+  return (
+    <p className="cell" style={{ fontSize }}>
+      {text}
+    </p>
+  );
 };
 
 export default Cell;

--- a/frontend/src/components/translation/EditableCell.tsx
+++ b/frontend/src/components/translation/EditableCell.tsx
@@ -6,14 +6,21 @@ export type EditableCellProps = {
   storyTranslationContentId: number;
   lineIndex: number;
   onChange: (newContent: string, lineIndex: number) => void;
+  fontSize: string;
 };
 
-const EditableCell = ({ text, lineIndex, onChange }: EditableCellProps) => {
+const EditableCell = ({
+  text,
+  lineIndex,
+  onChange,
+  fontSize,
+}: EditableCellProps) => {
   return (
     <textarea
       className="input-translation"
       value={text}
       onChange={(event) => onChange(event.target.value, lineIndex)}
+      style={{ fontSize }}
     />
   );
 };

--- a/frontend/src/components/translation/FontSizeSlider.css
+++ b/frontend/src/components/translation/FontSizeSlider.css
@@ -1,0 +1,3 @@
+.slider-container{
+    max-width: 100px;
+}

--- a/frontend/src/components/translation/FontSizeSlider.css
+++ b/frontend/src/components/translation/FontSizeSlider.css
@@ -1,3 +1,21 @@
 .slider-container{
     max-width: 100px;
 }
+
+.slider-labels{
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.sm-font{
+    font-size: 12px;
+}
+
+.md-font{
+    font-size: 16px;
+}
+
+.lg-font {
+    font-size: 24px;
+}

--- a/frontend/src/components/translation/FontSizeSlider.tsx
+++ b/frontend/src/components/translation/FontSizeSlider.tsx
@@ -16,13 +16,13 @@ const FontSizeSlider = ({ setFontSize }: FontSizeSliderProps) => {
   const handleSliderChange = (val: number) => {
     switch (val) {
       case 0:
-        setFontSize("10px");
-        break;
-      case 1:
         setFontSize("12px");
         break;
+      case 1:
+        setFontSize("16px");
+        break;
       case 2:
-        setFontSize("14px");
+        setFontSize("24px");
         break;
       default:
         setFontSize("12px");
@@ -32,11 +32,13 @@ const FontSizeSlider = ({ setFontSize }: FontSizeSliderProps) => {
 
   return (
     <div className="slider-container">
-      <div>
-        <p>aa</p>
+      <div className="slider-labels">
+        <div className="sm-font">Aa</div>
+        <div className="med-font"> Aa</div>
+        <div className="lg-font">Aa</div>
       </div>
       <Slider
-        defaultValue={1}
+        defaultValue={0}
         min={0}
         max={2}
         step={1}
@@ -47,7 +49,7 @@ const FontSizeSlider = ({ setFontSize }: FontSizeSliderProps) => {
           <Box position="relative" right={10} />
           <SliderFilledTrack />
         </SliderTrack>
-        <SliderThumb boxSize={6} />
+        <SliderThumb boxSize={3} />
       </Slider>
     </div>
   );

--- a/frontend/src/components/translation/FontSizeSlider.tsx
+++ b/frontend/src/components/translation/FontSizeSlider.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import {
+  Box,
+  Slider,
+  SliderTrack,
+  SliderFilledTrack,
+  SliderThumb,
+} from "@chakra-ui/react";
+import "./FontSizeSlider.css";
+
+type FontSizeSliderProps = {
+  setFontSize: (val: string) => void;
+};
+
+const FontSizeSlider = ({ setFontSize }: FontSizeSliderProps) => {
+  const handleSliderChange = (val: number) => {
+    switch (val) {
+      case 0:
+        setFontSize("10px");
+        break;
+      case 1:
+        setFontSize("12px");
+        break;
+      case 2:
+        setFontSize("14px");
+        break;
+      default:
+        setFontSize("12px");
+        break;
+    }
+  };
+
+  return (
+    <div className="slider-container">
+      <div>
+        <p>aa</p>
+      </div>
+      <Slider
+        defaultValue={1}
+        min={0}
+        max={2}
+        step={1}
+        colorScheme="twitter"
+        onChange={(val) => handleSliderChange(val)}
+      >
+        <SliderTrack>
+          <Box position="relative" right={10} />
+          <SliderFilledTrack />
+        </SliderTrack>
+        <SliderThumb boxSize={6} />
+      </Slider>
+    </div>
+  );
+};
+
+export default FontSizeSlider;


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Change font size slider](https://www.notion.so/uwblueprintexecs/Change-font-size-slider-1b6a084df97e43e1828d938554c2e0f4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* added a FontSizeSlider component (using slider from Chakra library)
* update sizes by passing as prop


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Open any translation page
2. Drag the slider, font sizes should change immediately
<img width="1293" alt="Screen Shot 2021-08-18 at 12 21 26 PM" src="https://user-images.githubusercontent.com/37675216/129935384-29660192-2d59-4a35-838f-5713bbfc5b48.png">
<img width="1408" alt="Screen Shot 2021-08-18 at 12 21 12 PM" src="https://user-images.githubusercontent.com/37675216/129935380-d0ec6c09-e825-4fdd-9277-bf7b42e457b9.png">
<img width="1367" alt="Screen Shot 2021-08-18 at 12 21 20 PM" src="https://user-images.githubusercontent.com/37675216/129935385-3dd9badf-6f20-4baf-92db-e627c77229ed.png">


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* frontend/src/components/pages/TranslationPage.tsx
* frontend/src/components/translation/FontSizeSlider.tsx

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
