### PR TITLE
Implemented debounced undo

### DIFF
--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -69,7 +69,7 @@ const TranslationPage = () => {
     setFontSize(val);
   };
 
-  const onChangeTranslationContent = async (
+  const onChangeTranslationContent = (
     newContent: string,
     lineIndex: number,
   ) => {

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -49,6 +49,12 @@ const TranslationPage = () => {
   const [versionHistoryStack, setVersionHistoryStack] = useState<
     Array<StoryLine[]>
   >([]);
+  const [snapShotLineIndexes, snapSnapShotLineIndexes] = useState<Set<number>>(
+    new Set(),
+  );
+  const [versionSnapShotStack, setVersionSnapShotStack] = useState<
+    Array<number[]>
+  >([]);
   const [currentVersion, setCurrentVersion] = useState<number>(0);
   // Font Size Slider
   const [fontSize, setFontSize] = useState<string>("12px");
@@ -68,6 +74,7 @@ const TranslationPage = () => {
     lineIndex: number,
   ) => {
     const updatedContentArray = [...translatedStoryLines];
+    snapSnapShotLineIndexes((val: Set<number>) => new Set(val.add(lineIndex)));
     if (
       // user deleted translation line
       !newContent.trim() &&
@@ -97,6 +104,9 @@ const TranslationPage = () => {
       onChangeTranslationContent(newContent, lineIndex);
       setVersionHistoryStack([
         ...deepCopy(versionHistoryStack.slice(0, currentVersion + 1)),
+      ]);
+      setVersionSnapShotStack([
+        ...deepCopy(versionSnapShotStack.slice(0, currentVersion + 1)),
       ]);
       setCurrentVersion(
         versionHistoryStack.length === MAX_STACK_SIZE
@@ -138,6 +148,7 @@ const TranslationPage = () => {
       );
       setTranslatedStoryLines(contentArray);
       setVersionHistoryStack([deepCopy(contentArray)]);
+      setVersionSnapShotStack([]);
       setCurrentVersion(0);
     },
   });
@@ -185,9 +196,12 @@ const TranslationPage = () => {
               setCurrentVersion={setCurrentVersion}
               versionHistoryStack={versionHistoryStack}
               setVersionHistoryStack={setVersionHistoryStack}
+              versionSnapShotStack={versionSnapShotStack}
+              setVersionSnapShotStack={setVersionSnapShotStack}
+              snapShotLineIndexes={snapShotLineIndexes}
+              snapSnapShotLineIndexes={snapSnapShotLineIndexes}
               translatedStoryLines={translatedStoryLines}
-              setTranslatedStoryLines={setTranslatedStoryLines}
-              setNumTranslatedLines={setNumTranslatedLines}
+              onChangeTranslationContent={onChangeTranslationContent}
               MAX_STACK_SIZE={MAX_STACK_SIZE}
             />
           </Flex>

--- a/frontend/src/components/translation/UndoRedo.tsx
+++ b/frontend/src/components/translation/UndoRedo.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useRef } from "react";
+
+import { Icon } from "@chakra-ui/icon";
+import { MdRedo, MdUndo } from "react-icons/md";
+import { Flex, IconButton } from "@chakra-ui/react";
+
+import { StoryLine } from "./Autosave";
+import deepCopy from "../../utils/DeepCopyUtils";
+
+export type UndoRedoProps = {
+  currentVersion: number;
+  setCurrentVersion: (val: number) => void;
+  versionHistoryStack: Array<StoryLine[]>;
+  setVersionHistoryStack: (val: Array<StoryLine[]>) => void;
+  translatedStoryLines: StoryLine[];
+  setTranslatedStoryLines: (val: StoryLine[]) => void;
+  setNumTranslatedLines: (val: number) => void;
+  MAX_STACK_SIZE: number;
+};
+
+const UndoRedo = ({
+  currentVersion,
+  setCurrentVersion,
+  versionHistoryStack,
+  setVersionHistoryStack,
+  translatedStoryLines,
+  setTranslatedStoryLines,
+  setNumTranslatedLines,
+  MAX_STACK_SIZE,
+}: UndoRedoProps) => {
+  const versionUpdateTimeout = useRef(false);
+  const saveVersionState = () => {
+    if (
+      versionHistoryStack.length > 0 &&
+      currentVersion === versionHistoryStack.length &&
+      JSON.stringify(translatedStoryLines) !==
+        JSON.stringify(versionHistoryStack[currentVersion])
+    ) {
+      setVersionHistoryStack(
+        versionHistoryStack.length === MAX_STACK_SIZE
+          ? [
+              ...deepCopy(versionHistoryStack.slice(1)),
+              deepCopy(translatedStoryLines),
+            ]
+          : [...deepCopy(versionHistoryStack), deepCopy(translatedStoryLines)],
+      );
+      setCurrentVersion(
+        versionHistoryStack.length === MAX_STACK_SIZE
+          ? MAX_STACK_SIZE - 1
+          : versionHistoryStack.length,
+      );
+    }
+  };
+
+  // Approach from https://leewarrick.com/blog/how-to-debounce/ (the throttling stuff)
+  useEffect(() => {
+    if (versionUpdateTimeout.current) return;
+    versionUpdateTimeout.current = true;
+    setTimeout(() => {
+      versionUpdateTimeout.current = false;
+      saveVersionState();
+    }, 750);
+  }, [translatedStoryLines]);
+
+  const undoChange = () => {
+    if (currentVersion > 0) {
+      const newContent = versionHistoryStack[currentVersion - 1];
+      setCurrentVersion(currentVersion - 1);
+      setTranslatedStoryLines(newContent);
+      setNumTranslatedLines(newContent.length);
+    }
+  };
+
+  const redoChange = () => {
+    if (currentVersion < versionHistoryStack.length - 1) {
+      const newContent = versionHistoryStack[currentVersion + 1];
+      setCurrentVersion(currentVersion + 1);
+      setTranslatedStoryLines(newContent);
+      setNumTranslatedLines(newContent.length);
+    }
+  };
+  return (
+    <Flex direction="row">
+      <IconButton
+        size="undoRedo"
+        variant="ghost"
+        aria-label="Undo Change"
+        onClick={undoChange}
+        icon={<Icon as={MdUndo} />}
+        isDisabled={!(currentVersion > 0)}
+      />
+      <IconButton
+        variant="ghost"
+        size="undoRedo"
+        aria-label="Redo Change"
+        onClick={redoChange}
+        icon={<Icon as={MdRedo} />}
+        isDisabled={!(currentVersion < versionHistoryStack.length - 1)}
+      />
+    </Flex>
+  );
+};
+
+export default UndoRedo;

--- a/frontend/src/utils/DeepCopyUtils.ts
+++ b/frontend/src/utils/DeepCopyUtils.ts
@@ -1,0 +1,8 @@
+const deepCopy = (lines: Object) => {
+  // This is a funky method to make deep copies on objects with primative values
+  // https://javascript.plainenglish.io/how-to-deep-copy-objects-and-arrays-in-javascript-7c911359b089
+  // Should probably go under some util
+  return JSON.parse(JSON.stringify(lines));
+};
+
+export default deepCopy;


### PR DESCRIPTION
## Notion ticket link
[Debounce translation undo redo](https://www.notion.so/uwblueprintexecs/Debounce-translation-undo-redo-12b5178abf5e4120ab34f23e666d190c)

## Implementation description
* The name is a misnomer, since it's not quite debounced, since users might want to have more granularity in undos than what the debounced approach would offer. 
* Instead, the state is stored every second and users can iterate over those in the undo, otherwise all functionality is essentially the same as https://github.com/uwblueprint/planet-read/pull/55.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Open a story
2. Type some things
3. Undo some things
4. Redo some things
5. Try undoing all your changes and redoing all your changes
6. Try undoing after no changes
7. Give yourself a pat on the back for being a cool person :)

## What should reviewers focus on?
* Not sure about how the timings feel, whether or not the exact amount of time should be changed, let me know what you think.

## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters:  `docker exec -it <backend-container-id> /bin/bash -c "black . && isort --profile black ."`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR

<p align="center">
  <img src="https://user-images.githubusercontent.com/53587708/131600776-10ed74ba-9ead-4d3a-9018-fed3dd408e3d.png" />
</p>
