### PR TITLE
Limit story card description to 100 characters

### DIFF
--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -47,7 +47,7 @@ const StoryCard = ({
     /*
     Transforms originalYoutubeLink into embed link appropriate for iframe.
       If already given link in the embed version, does nothing.
-    
+
     Example:
     - Real link: https://www.youtube.com/watch?v=_OBlgSz8sSM
     - Embed link: https://www.youtube.com/embed/_OBlgSz8sSM
@@ -126,6 +126,10 @@ const StoryCard = ({
   };
   const storyCardStyle = useStyleConfig("StoryCard");
 
+  const truncateDescription = () => {
+    return `${description.substring(0, 100).trim()}...`;
+  };
+
   return (
     <Flex id={`story-${storyId}`} sx={storyCardStyle}>
       <Box
@@ -155,7 +159,7 @@ const StoryCard = ({
             )}`}</Badge>
           </Flex>
         </Flex>
-        <Text size="xs">{description}</Text>
+        <Text size="xs">{truncateDescription()}</Text>
       </Box>
       <Flex
         direction="column"

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -126,8 +126,8 @@ const StoryCard = ({
   };
   const storyCardStyle = useStyleConfig("StoryCard");
 
-  const truncateDescription = () => {
-    return `${description.substring(0, 100).trim()}...`;
+  const truncateText = (text: string, length: number) => {
+    return `${text.substring(0, length).trim()}...`;
   };
 
   return (
@@ -159,7 +159,7 @@ const StoryCard = ({
             )}`}</Badge>
           </Flex>
         </Flex>
-        <Text size="xs">{truncateDescription()}</Text>
+        <Text size="xs">{truncateText(description, 100)}</Text>
       </Box>
       <Flex
         direction="column"


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Limit story card description to 175 characters](https://www.notion.so/uwblueprintexecs/Limit-story-card-description-to-175-characters-b205ce918a7d4d9d8b205d706a91e8e2)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Limited story card description to 100 characters (instead of 175) to ensure that all descriptions don't exceed the IFrame height

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Click on My Work or Browse Stories
2. Check each story card
3. Ensure that the descriptions are truncated so that they don't exceed the IFrame height
4. Ensure that the descriptions end in ... if they were truncated

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Character limit can be changed, based on my testing 100 characters ensured that all descriptions don't exceed the IFrame height

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
