### PR TITLE
Return stories equal to provided level from storiesAvailableForTranslation query

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -61,7 +61,7 @@ class StoryService(IStoryService):
 
     def get_stories_available_for_translation(self, language, level):
         stories = (
-            Story.query.filter(Story.level <= level)
+            Story.query.filter(Story.level == level)
             .filter(~Story.translated_languages.contains(language))
             .all()
         )
@@ -108,7 +108,7 @@ class StoryService(IStoryService):
                     else StoryTranslation.reviewer_id == user_id
                 )
                 .filter(StoryTranslation.language == language if language else True)
-                .filter(Story.level <= level if level else True)
+                .filter(Story.level == level if level else True)
                 .order_by(Story.id)
                 .all()
             )
@@ -123,7 +123,7 @@ class StoryService(IStoryService):
                     else StoryTranslation.reviewer_id == user_id
                 )
                 .filter(StoryTranslation.language == language if language else True)
-                .filter(Story.level <= level if level else True)
+                .filter(Story.level == level if level else True)
                 .order_by(Story.id)
                 .all()
             )
@@ -273,7 +273,7 @@ class StoryService(IStoryService):
                 Story.query.join(
                     StoryTranslation, Story.id == StoryTranslation.story_id
                 )
-                .filter(Story.level <= level)
+                .filter(Story.level == level)
                 .filter(StoryTranslation.language == language)
                 .filter(StoryTranslation.reviewer_id == None)
                 .order_by(Story.id)
@@ -284,7 +284,7 @@ class StoryService(IStoryService):
                 StoryTranslation.query.join(
                     Story, Story.id == StoryTranslation.story_id
                 )
-                .filter(Story.level <= level)
+                .filter(Story.level == level)
                 .filter(StoryTranslation.language == language)
                 .filter(StoryTranslation.reviewer_id == None)
                 .order_by(Story.id)


### PR DESCRIPTION
## Notion ticket link

[<!-- Please replace with your ticket's URL -->](url)

[return stories of specific level from storiesAvailableForTranslation](https://www.notion.so/uwblueprintexecs/return-stories-of-specific-level-from-storiesAvailableForTranslation-79bf358ea4f9483c93460ccfe38cd7f0)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Converted all of the lines filtering using `Story.level <= level` to `Story.level == level`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Click on "My Work" or "Browse Stories" under either Translator or Reviewer roles
2. Click through different access levels
3. Verify that only stories equal to the selected access level are displayed

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Some of the lines use `Story.level == level if level else True` to handle the case that level is None, not sure if this should be added for all lines that check `Story.level == level` (for the sake of consistency)

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
