### PR TITLE
Add Scroll to Top Button

### DIFF
--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useQuery } from "@apollo/client";
 import { Box, Button, Divider, Flex } from "@chakra-ui/react";
 import { Icon } from "@chakra-ui/icon";
@@ -27,13 +27,24 @@ const HomePage = () => {
   const [level, setLevel] = useState<number>(approvedLanguages[language]);
   const [stories, setStories] = useState<StoryCardProps[] | null>(null);
 
+  const [showScrollToTop, setShowScrollToTop] = useState(false);
+
+  useEffect(() => {
+    window.addEventListener("scroll", () => {
+      // Show scroll to top button if user scrolls down vertically more than 100px
+      if (window.scrollY > 100) {
+        setShowScrollToTop(true);
+      } else {
+        setShowScrollToTop(false);
+      }
+    });
+  }, []);
+
   const handleScrollToTop = () => {
-    setTimeout(function () {
-      window.scrollTo({
-        top: 0,
-        behavior: "smooth",
-      });
-    }, 0);
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
   };
 
   const handleDisplayMyStoriesChange = (nextOption: string) => {
@@ -89,12 +100,11 @@ const HomePage = () => {
           />
         </Flex>
       </Flex>
-      <Button onClick={handleScrollToTop}>
-        <Flex direction="column" alignItems="centre">
-          <Icon as={MdKeyboardArrowUp} />
-          TOP
-        </Flex>
-      </Button>
+      {showScrollToTop && (
+        <Button onClick={handleScrollToTop} size="lg" variant="scrollToTop">
+          <Icon as={MdKeyboardArrowUp} height={8} width={8} />
+        </Button>
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -1,6 +1,8 @@
 import React, { useContext, useState } from "react";
 import { useQuery } from "@apollo/client";
-import { Box, Divider, Flex } from "@chakra-ui/react";
+import { Box, Button, Divider, Flex } from "@chakra-ui/react";
+import { Icon } from "@chakra-ui/icon";
+import { MdKeyboardArrowUp } from "react-icons/md";
 
 import Filter from "../homepage/Filter";
 import StoryList from "../homepage/StoryList";
@@ -24,6 +26,15 @@ const HomePage = () => {
   const [isTranslator, setIsTranslator] = useState<boolean>(true);
   const [level, setLevel] = useState<number>(approvedLanguages[language]);
   const [stories, setStories] = useState<StoryCardProps[] | null>(null);
+
+  const handleScrollToTop = () => {
+    setTimeout(function () {
+      window.scrollTo({
+        top: 0,
+        behavior: "smooth",
+      });
+    }, 0);
+  };
 
   const handleDisplayMyStoriesChange = (nextOption: string) => {
     setDisplayMyStories(nextOption === "My Work");
@@ -78,6 +89,12 @@ const HomePage = () => {
           />
         </Flex>
       </Flex>
+      <Button onClick={handleScrollToTop}>
+        <Flex direction="column" alignItems="centre">
+          <Icon as={MdKeyboardArrowUp} />
+          TOP
+        </Flex>
+      </Button>
     </Box>
   );
 };

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -41,6 +41,16 @@ const Button = {
       width: "100px",
       fontSize: "14px",
     },
+    scrollToTop: {
+      background: "white",
+      border: "1px solid",
+      borderColor: "gray.300",
+      bottom: "10px",
+      fontSize: "14px",
+      position: "fixed",
+      right: "10px",
+      width: "50px",
+    },
   },
 };
 export default Button;


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[add scroll to top button](https://www.notion.so/uwblueprintexecs/add-scroll-to-top-button-d326588e5ec24f9282abbb73b8998f00)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description
- added a scroll to top button to the stories homepage
![scroll](https://user-images.githubusercontent.com/32009013/132950852-07da2283-cb0d-4289-a11b-e9b616ce35f9.gif)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test
1. Rebuild frontend container
2. Login as a user
3. Scroll to bottom of stories page and click scroll to top button
4. Verify that button brings you to top of the page

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?
- `frontend/src/components/pages/HomePage.tsx`
- `frontend/src/theme/components/Button.ts`

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
