### PR TITLE
Remove START stage from story_translation

### DIFF
--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -4,7 +4,6 @@ from .language_enum import LanguageEnum
 
 
 class StageEnum(graphene.Enum):
-    START = "START"
     TRANSLATE = "TRANSLATE"
     REVIEW = "REVIEW"
     PUBLISH = "PUBLISH"

--- a/backend/python/app/models/story_translation.py
+++ b/backend/python/app/models/story_translation.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm.properties import ColumnProperty
 from . import db
 from .story_translation_content import StoryTranslationContent
 
-stages_enum = db.Enum("START", "TRANSLATE", "REVIEW", "PUBLISH", name="stages")
+stages_enum = db.Enum("TRANSLATE", "REVIEW", "PUBLISH", name="stages")
 
 
 class StoryTranslation(db.Model):

--- a/backend/python/migrations/versions/3f6fff20884c_initial_migration.py
+++ b/backend/python/migrations/versions/3f6fff20884c_initial_migration.py
@@ -1,7 +1,7 @@
 """initial migration
 
 Revision ID: 3f6fff20884c
-Revises: 
+Revises:
 Create Date: 2021-08-30 16:07:51.455852
 
 """
@@ -78,7 +78,7 @@ def upgrade():
         sa.Column("language", mysql.TEXT(), nullable=False),
         sa.Column(
             "stage",
-            sa.Enum("START", "TRANSLATE", "REVIEW", "PUBLISH", name="stages"),
+            sa.Enum("TRANSLATE", "REVIEW", "PUBLISH", name="stages"),
             nullable=False,
         ),
         sa.Column("translator_id", sa.Integer(), nullable=True),


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Remove START stage from story_translation](https://www.notion.so/uwblueprintexecs/Remove-START-stage-from-story_translation-50c198ff022e498bbca0b9be4ea82b47)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Removed START stage from story translation by deleting all START translation stage enums from project files (3 instances found)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Translation page should be working exactly as it was before
2. Check that starting a translation works:
    a. Set role required to translator
    b. Click my work
    c. Note the books currently being translated
    d. Click browse stories
    e. Click translate book for any book that is not currently being translated
    f.  Click my work
    g. Check that the book is now being translated

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- All 3 instances of the START translation stage enum were removed, and it doesn't seem to be used anywhere else. If possible, please double check that it isn't used.
- Please test translation functionality, especially starting a translation

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
