### PR TITLE
Add is_reviewer and get_user_id_from_request

### DIFF
--- a/backend/python/app/services/interfaces/auth_service.py
+++ b/backend/python/app/services/interfaces/auth_service.py
@@ -101,3 +101,35 @@ class IAuthService(ABC):
         :rtype: bool
         """
         pass
+
+    @abstractmethod
+    def is_translator(self, access_token, story_translation_content_id):
+        """
+        Determine if the provided access token is valid and issued to the requested user
+        and the user is a translator of the story translation of the given
+        story translation content id.
+
+        :param access_token: user's access token
+        :type access_token: str
+        :param story_translation_content_id: story translation content id being attempted to change
+        :type story_translation_content_id: str
+        :return: true if user is translator of story translation, false otherwise
+        :rtype: bool
+        """
+        pass
+
+    @abstractmethod
+    def is_reviewer(self, access_token, story_translation_content_id):
+        """
+        Determine if the provided access token is valid and issued to the requested user
+        and the user is a reviewer of the story translation of the given
+        story translation content id.
+
+        :param access_token: user's access token
+        :type access_token: str
+        :param story_translation_content_id: story translation content id being attempted to change
+        :type story_translation_content_id: str
+        :return: true if user is reviewer of story translation, false otherwise
+        :rtype: bool
+        """
+        pass


### PR DESCRIPTION
## Implementation description

- added `get_user_id_from_request `utility to middlewares.auth.py
- added `is_reviewer `to auth service

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test
`get_user_id_from_request `
You're gunna have to trust me on this one, LOL. Here's how to use it in a service:
![image](https://user-images.githubusercontent.com/15113249/133361246-96fefc1f-8873-4396-b6ca-7093618287f5.png)
opening the homepage and browsing stories as translator would cause the user id to be printed. 

is_reviewer 
This is essentially the same code as is_translator. To test, go to translation page and type some stuff. The translation should be successfully updated, ie refreshing the page will keep the changes made.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- clarity

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
