### PR TITLE
Make per-line comment button functional

### DIFF
--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -42,6 +42,14 @@ const ReviewPage = () => {
   const [title, setTitle] = useState<string>("");
   const [language, setLanguage] = useState<string>("");
 
+  const [isCommenting, setIsCommenting] = useState(false);
+  const [commentLine, setCommentLine] = useState(0);
+
+  const [
+    storyTranslationContentId,
+    setStoryTranslationContentId,
+  ] = useState<number>(-1);
+
   const handleFontSizeChange = (val: string) => {
     setFontSize(val);
   };
@@ -105,6 +113,9 @@ const ReviewPage = () => {
               fontSize={fontSize}
               originalLanguage="English"
               translatedLanguage={convertLanguageTitleCase(language)}
+              isCommenting={isCommenting}
+              setCommentLine={setCommentLine}
+              setStoryTranslationContentId={setStoryTranslationContentId}
             />
           </Flex>
           <Flex margin="20px 30px" justify="flex-start" alignItems="center">
@@ -126,7 +137,13 @@ const ReviewPage = () => {
             </Box>
           </Flex>
         </Flex>
-        <CommentsPanel storyTranslationId={storyTranslationId} />
+        <CommentsPanel
+          storyTranslationId={storyTranslationId}
+          storyTranslationContentId={storyTranslationContentId}
+          isCommenting={isCommenting}
+          setIsCommenting={setIsCommenting}
+          commentLine={commentLine}
+        />
       </Flex>
     </Flex>
   );

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -143,6 +143,7 @@ const ReviewPage = () => {
           isCommenting={isCommenting}
           setIsCommenting={setIsCommenting}
           commentLine={commentLine}
+          setCommentLine={setCommentLine}
         />
       </Flex>
     </Flex>

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -42,12 +42,11 @@ const ReviewPage = () => {
   const [title, setTitle] = useState<string>("");
   const [language, setLanguage] = useState<string>("");
 
-  const [isCommenting, setIsCommenting] = useState(false);
-  const [commentLine, setCommentLine] = useState(0);
+  const [commentLine, setCommentLine] = useState(-1);
 
   const [
-    storyTranslationContentId,
-    setStoryTranslationContentId,
+    commentStoryTranslationContentId,
+    setCommentStoryTranslationContentId,
   ] = useState<number>(-1);
 
   const handleFontSizeChange = (val: string) => {
@@ -113,9 +112,11 @@ const ReviewPage = () => {
               fontSize={fontSize}
               originalLanguage="English"
               translatedLanguage={convertLanguageTitleCase(language)}
-              isCommenting={isCommenting}
+              commentLine={commentLine}
               setCommentLine={setCommentLine}
-              setStoryTranslationContentId={setStoryTranslationContentId}
+              setCommentStoryTranslationContentId={
+                setCommentStoryTranslationContentId
+              }
             />
           </Flex>
           <Flex margin="20px 30px" justify="flex-start" alignItems="center">
@@ -138,11 +139,9 @@ const ReviewPage = () => {
           </Flex>
         </Flex>
         <CommentsPanel
-          storyTranslationId={storyTranslationId}
-          storyTranslationContentId={storyTranslationContentId}
-          isCommenting={isCommenting}
-          setIsCommenting={setIsCommenting}
+          commentStoryTranslationContentId={commentStoryTranslationContentId}
           commentLine={commentLine}
+          storyTranslationId={storyTranslationId}
           setCommentLine={setCommentLine}
         />
       </Flex>

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -57,11 +57,10 @@ const TranslationPage = () => {
   const [title, setTitle] = useState<string>("");
   const [language, setLanguage] = useState<string>("");
 
-  const [isCommenting, setIsCommenting] = useState<boolean>(false);
-  const [commentLine, setCommentLine] = useState(0);
+  const [commentLine, setCommentLine] = useState(-1);
   const [
-    storyTranslationContentId,
-    setStoryTranslationContentId,
+    commentStoryTranslationContentId,
+    setCommentStoryTranslationContentId,
   ] = useState<number>(-1);
 
   const handleFontSizeChange = (val: string) => {
@@ -279,9 +278,11 @@ const TranslationPage = () => {
               fontSize={fontSize}
               originalLanguage="English"
               translatedLanguage={convertLanguageTitleCase(language)}
-              isCommenting={isCommenting}
+              commentLine={commentLine}
               setCommentLine={setCommentLine}
-              setStoryTranslationContentId={setStoryTranslationContentId}
+              setCommentStoryTranslationContentId={
+                setCommentStoryTranslationContentId
+              }
             />
           </Flex>
           <Flex margin="20px 30px" justify="space-between" alignItems="center">
@@ -297,9 +298,7 @@ const TranslationPage = () => {
           </Flex>
         </Flex>
         <CommentsPanel
-          storyTranslationContentId={storyTranslationContentId}
-          isCommenting={isCommenting}
-          setIsCommenting={setIsCommenting}
+          commentStoryTranslationContentId={commentStoryTranslationContentId}
           commentLine={commentLine}
           storyTranslationId={storyTranslationId}
           setCommentLine={setCommentLine}

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -302,6 +302,7 @@ const TranslationPage = () => {
           setIsCommenting={setIsCommenting}
           commentLine={commentLine}
           storyTranslationId={storyTranslationId}
+          setCommentLine={setCommentLine}
         />
       </Flex>
       <Autosave

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -57,6 +57,13 @@ const TranslationPage = () => {
   const [title, setTitle] = useState<string>("");
   const [language, setLanguage] = useState<string>("");
 
+  const [isCommenting, setIsCommenting] = useState<boolean>(false);
+  const [commentLine, setCommentLine] = useState(0);
+  const [
+    storyTranslationContentId,
+    setStoryTranslationContentId,
+  ] = useState<number>(-1);
+
   const handleFontSizeChange = (val: string) => {
     setFontSize(val);
   };
@@ -272,6 +279,9 @@ const TranslationPage = () => {
               fontSize={fontSize}
               originalLanguage="English"
               translatedLanguage={convertLanguageTitleCase(language)}
+              isCommenting={isCommenting}
+              setCommentLine={setCommentLine}
+              setStoryTranslationContentId={setStoryTranslationContentId}
             />
           </Flex>
           <Flex margin="20px 30px" justify="space-between" alignItems="center">
@@ -286,7 +296,13 @@ const TranslationPage = () => {
             </Button>
           </Flex>
         </Flex>
-        <CommentsPanel storyTranslationId={storyTranslationId} />
+        <CommentsPanel
+          storyTranslationContentId={storyTranslationContentId}
+          isCommenting={isCommenting}
+          setIsCommenting={setIsCommenting}
+          commentLine={commentLine}
+          storyTranslationId={storyTranslationId}
+        />
       </Flex>
       <Autosave
         storylines={Array.from(changedStoryLines.values())}

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -5,12 +5,23 @@ import {
   CommentResponse,
   buildCommentsQuery,
 } from "../../APIClients/queries/CommentQueries";
+import WIPComment from "./WIPComment";
 
 export type CommentPanelProps = {
   storyTranslationId: number;
+  setIsCommenting: (isCommenting: boolean) => void;
+  isCommenting: boolean;
+  commentLine: number;
+  storyTranslationContentId: number;
 };
 
-const CommentsPanel = ({ storyTranslationId }: CommentPanelProps) => {
+const CommentsPanel = ({
+  storyTranslationId,
+  setIsCommenting,
+  isCommenting,
+  commentLine,
+  storyTranslationContentId,
+}: CommentPanelProps) => {
   const [comments, setComments] = useState<CommentResponse[]>([]);
   const [filterIndex, setFilterIndex] = useState(0);
 
@@ -37,6 +48,7 @@ const CommentsPanel = ({ storyTranslationId }: CommentPanelProps) => {
     if (comments.length > 0) {
       return (
         <Box>
+          {/* TODO: show correct placement of the WIPComment component once existing comment is displayed */}
           {comments.map((comment: CommentResponse) => (
             // TODO: replace with actual comment component
             <Text key={comment.id} variant="comment">
@@ -63,7 +75,14 @@ const CommentsPanel = ({ storyTranslationId }: CommentPanelProps) => {
   return (
     <Box backgroundColor="gray.100" float="right" width="350px" padding="20px">
       <Flex marginBottom="50px">
-        <Button colorScheme="blue" size="secondary" marginRight="10px">
+        <Button
+          colorScheme="blue"
+          size="secondary"
+          marginRight="10px"
+          onClick={() => {
+            setIsCommenting(!isCommenting);
+          }}
+        >
           Comment
         </Button>
         <Select
@@ -77,6 +96,13 @@ const CommentsPanel = ({ storyTranslationId }: CommentPanelProps) => {
           {filterOptionsComponent}
         </Select>
       </Flex>
+      {commentLine !== 0 && (
+        <WIPComment
+          lineIndex={commentLine}
+          storyTranslationContentId={storyTranslationContentId}
+          setIsCommenting={setIsCommenting}
+        />
+      )}
       <CommentsList />
     </Box>
   );

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -13,6 +13,7 @@ export type CommentPanelProps = {
   isCommenting: boolean;
   commentLine: number;
   storyTranslationContentId: number;
+  setCommentLine: (line: number) => void;
 };
 
 const CommentsPanel = ({
@@ -21,6 +22,7 @@ const CommentsPanel = ({
   isCommenting,
   commentLine,
   storyTranslationContentId,
+  setCommentLine,
 }: CommentPanelProps) => {
   const [comments, setComments] = useState<CommentResponse[]>([]);
   const [filterIndex, setFilterIndex] = useState(0);
@@ -81,6 +83,7 @@ const CommentsPanel = ({
           marginRight="10px"
           onClick={() => {
             setIsCommenting(!isCommenting);
+            setCommentLine(0);
           }}
         >
           Comment
@@ -96,7 +99,7 @@ const CommentsPanel = ({
           {filterOptionsComponent}
         </Select>
       </Flex>
-      {commentLine !== 0 && (
+      {isCommenting && commentLine !== 0 && (
         <WIPComment
           lineIndex={commentLine}
           storyTranslationContentId={storyTranslationContentId}

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -9,19 +9,15 @@ import WIPComment from "./WIPComment";
 
 export type CommentPanelProps = {
   storyTranslationId: number;
-  setIsCommenting: (isCommenting: boolean) => void;
-  isCommenting: boolean;
   commentLine: number;
-  storyTranslationContentId: number;
   setCommentLine: (line: number) => void;
+  commentStoryTranslationContentId: number;
 };
 
 const CommentsPanel = ({
   storyTranslationId,
-  setIsCommenting,
-  isCommenting,
   commentLine,
-  storyTranslationContentId,
+  commentStoryTranslationContentId,
   setCommentLine,
 }: CommentPanelProps) => {
   const [comments, setComments] = useState<CommentResponse[]>([]);
@@ -74,6 +70,11 @@ const CommentsPanel = ({
     </option>
   ));
 
+  const handleCommentButton = () => {
+    if (commentLine === -1) setCommentLine(0);
+    else setCommentLine(-1);
+  };
+
   return (
     <Box backgroundColor="gray.100" float="right" width="350px" padding="20px">
       <Flex marginBottom="50px">
@@ -81,10 +82,7 @@ const CommentsPanel = ({
           colorScheme="blue"
           size="secondary"
           marginRight="10px"
-          onClick={() => {
-            setIsCommenting(!isCommenting);
-            setCommentLine(0);
-          }}
+          onClick={handleCommentButton}
         >
           Comment
         </Button>
@@ -99,11 +97,11 @@ const CommentsPanel = ({
           {filterOptionsComponent}
         </Select>
       </Flex>
-      {isCommenting && commentLine !== 0 && (
+      {commentLine > 0 && (
         <WIPComment
           lineIndex={commentLine}
-          storyTranslationContentId={storyTranslationContentId}
-          setIsCommenting={setIsCommenting}
+          commentStoryTranslationContentId={commentStoryTranslationContentId}
+          setCommentLine={setCommentLine}
         />
       )}
       <CommentsList />

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -60,6 +60,7 @@ const WIPComment = ({
         borderRadius: 8,
         width: "320px",
       }}
+      backgroundColor="white"
     >
       <b>Line {lineIndex}</b>
       <p>{name}</p>

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -10,11 +10,13 @@ import {
 export type WIPCommentProps = {
   storyTranslationContentId: number;
   lineIndex: number;
+  setIsCommenting: (isCommenting: boolean) => void;
 };
 
 const WIPComment = ({
   storyTranslationContentId,
   lineIndex,
+  setIsCommenting,
 }: WIPCommentProps) => {
   const handleError = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
@@ -29,6 +31,7 @@ const WIPComment = ({
   }>(CREATE_COMMMENT);
 
   const createNewComment = async () => {
+    setIsCommenting(false);
     try {
       const commentData = {
         storyTranslationContentId,
@@ -75,7 +78,11 @@ const WIPComment = ({
         >
           Comment
         </Button>
-        <Button size="secondary" variant="outline">
+        <Button
+          size="secondary"
+          variant="outline"
+          onClick={() => setIsCommenting(false)}
+        >
           Cancel
         </Button>
       </Flex>

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -8,15 +8,15 @@ import {
 } from "../../APIClients/mutations/CommentMutations";
 
 export type WIPCommentProps = {
-  storyTranslationContentId: number;
+  commentStoryTranslationContentId: number;
   lineIndex: number;
-  setIsCommenting: (isCommenting: boolean) => void;
+  setCommentLine: (line: number) => void;
 };
 
 const WIPComment = ({
-  storyTranslationContentId,
+  commentStoryTranslationContentId,
   lineIndex,
-  setIsCommenting,
+  setCommentLine,
 }: WIPCommentProps) => {
   const handleError = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
@@ -31,10 +31,9 @@ const WIPComment = ({
   }>(CREATE_COMMMENT);
 
   const createNewComment = async () => {
-    setIsCommenting(false);
     try {
       const commentData = {
-        storyTranslationContentId,
+        storyTranslationContentId: commentStoryTranslationContentId,
         userId: authenticatedUser!!.id,
         content: text,
       };
@@ -43,6 +42,7 @@ const WIPComment = ({
       });
       if (result.data?.createComment.ok) {
         setText("");
+        setCommentLine(0);
       }
     } catch (err) {
       handleError(err ?? "Error occurred, please try again.");
@@ -82,7 +82,7 @@ const WIPComment = ({
         <Button
           size="secondary"
           variant="outline"
-          onClick={() => setIsCommenting(false)}
+          onClick={() => setCommentLine(0)}
         >
           Cancel
         </Button>

--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -15,6 +15,9 @@ export type TranslationTableProps = {
   fontSize: string;
   translatedLanguage: string;
   originalLanguage?: string;
+  isCommenting: boolean;
+  setCommentLine: (line: number) => void;
+  setStoryTranslationContentId: (id: number) => void;
 };
 
 const TranslationTable = ({
@@ -24,7 +27,17 @@ const TranslationTable = ({
   fontSize,
   translatedLanguage,
   originalLanguage,
+  isCommenting,
+  setCommentLine,
+  setStoryTranslationContentId,
 }: TranslationTableProps) => {
+  const handleCommentButton = (
+    displayLineNumber: number,
+    contentId: number,
+  ) => {
+    setCommentLine(displayLineNumber);
+    setStoryTranslationContentId(contentId);
+  };
   const storyCells = translatedStoryLines.map((storyLine: StoryLine) => {
     const displayLineNumber = storyLine.lineIndex + 1;
     return (
@@ -60,7 +73,19 @@ const TranslationTable = ({
           >
             {storyLine.status}
           </Badge>
-          <Button variant="addComment">Comment</Button>
+          {isCommenting && (
+            <Button
+              variant="addComment"
+              onClick={() =>
+                handleCommentButton(
+                  displayLineNumber,
+                  storyLine.storyTranslationContentId!!,
+                )
+              }
+            >
+              Comment
+            </Button>
+          )}
         </Flex>
       </Flex>
     );

--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -15,9 +15,9 @@ export type TranslationTableProps = {
   fontSize: string;
   translatedLanguage: string;
   originalLanguage?: string;
-  isCommenting: boolean;
+  commentLine: number;
   setCommentLine: (line: number) => void;
-  setStoryTranslationContentId: (id: number) => void;
+  setCommentStoryTranslationContentId: (id: number) => void;
 };
 
 const TranslationTable = ({
@@ -27,16 +27,16 @@ const TranslationTable = ({
   fontSize,
   translatedLanguage,
   originalLanguage,
-  isCommenting,
+  commentLine,
   setCommentLine,
-  setStoryTranslationContentId,
+  setCommentStoryTranslationContentId,
 }: TranslationTableProps) => {
   const handleCommentButton = (
     displayLineNumber: number,
-    contentId: number,
+    storyTranslationContentId: number,
   ) => {
     setCommentLine(displayLineNumber);
-    setStoryTranslationContentId(contentId);
+    setCommentStoryTranslationContentId(storyTranslationContentId);
   };
   const storyCells = translatedStoryLines.map((storyLine: StoryLine) => {
     const displayLineNumber = storyLine.lineIndex + 1;
@@ -73,7 +73,7 @@ const TranslationTable = ({
           >
             {storyLine.status}
           </Badge>
-          {isCommenting && (
+          {commentLine > -1 && (
             <Button
               variant="addComment"
               onClick={() =>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Make per-line comment button functional](https://www.notion.so/uwblueprintexecs/Make-per-line-comment-button-functional-9cb870ccaae44e8eba0f899370ea288f)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description
- added flow for adding comments, with the exception of displaying them 
- added state variables at the TranslationPage level, to pass them between TranslationTable and CommentsPanel

<img width="1440" alt="Screen Shot 2021-09-14 at 7 48 24 PM" src="https://user-images.githubusercontent.com/37675216/133364710-149b8af5-8587-4151-b992-2a0efb981443.png">
<img width="1439" alt="Screen Shot 2021-09-14 at 8 00 04 PM" src="https://user-images.githubusercontent.com/37675216/133364702-9257cb03-9922-44d4-aaa6-90c8385ea8f6.png">


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Open the app frontend and navigate to a story 
2. Click the comment button in the commentspanel (top right) -> comment buttons should appear in each row 
3. Pick a line and click the comment button -> WIPComment component should appear in pannel
4. Add a comment in the WIPComment component  

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Flow as expected?
- Better way to store state? 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
