### PR TITLE
Create Existing comment component

### DIFF
--- a/frontend/src/APIClients/mutations/CommentMutations.ts
+++ b/frontend/src/APIClients/mutations/CommentMutations.ts
@@ -27,3 +27,27 @@ export type CreateCommentResponse = {
     content: string;
   };
 };
+
+export const UPDATE_COMMENT_BY_ID = gql`
+  mutation UpdateCommentById($commentData: UpdateCommentRequestDTO!) {
+    updateCommentById(commentData: $commentData) {
+      ok
+      comment {
+        id
+        commentIndex
+        resolved
+        content
+      }
+    }
+  }
+`;
+
+export type UpdateCommentResponse = {
+  ok: boolean;
+  comment: {
+    id: number;
+    commentIndex: number;
+    resolved: boolean;
+    content: string;
+  };
+};

--- a/frontend/src/APIClients/queries/CommentQueries.ts
+++ b/frontend/src/APIClients/queries/CommentQueries.ts
@@ -6,6 +6,7 @@ const COMMENT_FIELDS = `
     commentIndex
     content
     storyTranslationContentId
+    resolved
     time
     `;
 

--- a/frontend/src/APIClients/queries/CommentQueries.ts
+++ b/frontend/src/APIClients/queries/CommentQueries.ts
@@ -6,6 +6,7 @@ const COMMENT_FIELDS = `
     commentIndex
     content
     storyTranslationContentId
+    time
     `;
 
 export type CommentResponse = {

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -56,6 +56,14 @@ const CommentsPanel = ({
     setFilterIndex(event.target.selectedIndex);
   };
 
+  const updateCommentsAsResolved = (index: number) => {
+    const newComments = [...comments];
+    const updatedComment = { ...newComments[index - 1] };
+    updatedComment.resolved = true;
+    newComments[index - 1] = updatedComment;
+    setComments(newComments);
+  };
+
   const CommentsList = () => {
     if (comments.length > 0) {
       return (
@@ -72,6 +80,7 @@ const CommentsPanel = ({
                 commentStoryTranslationContentId
               }
               lineIndex={commentLine}
+              updateCommentsAsResolved={updateCommentsAsResolved}
             />
           ))}
         </Box>

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -81,6 +81,10 @@ const CommentsPanel = ({
               }
               lineIndex={commentLine}
               updateCommentsAsResolved={updateCommentsAsResolved}
+              comments={comments}
+              setComments={setComments}
+              setTranslatedStoryLines={setTranslatedStoryLines}
+              translatedStoryLines={translatedStoryLines}
             />
           ))}
         </Box>

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -11,6 +11,7 @@ import {
   TRANSLATION_PAGE_TOOL_TIP_COPY,
   REVIEW_PAGE_TOOL_TIP_COPY,
 } from "../../utils/Copy";
+import ExistingComment from "./ExistingComment";
 
 export type CommentPanelProps = {
   storyTranslationId: number;
@@ -61,10 +62,17 @@ const CommentsPanel = ({
         <Box>
           {/* TODO: show correct placement of the WIPComment component once existing comment is displayed */}
           {comments.map((comment: CommentResponse) => (
-            // TODO: replace with actual comment component
-            <Text key={comment.id} variant="comment">
-              {JSON.stringify(comment.content)}
-            </Text>
+            <ExistingComment
+              key={comment.id}
+              id={comment.id}
+              resolved={comment.resolved}
+              content={comment.content}
+              time={comment.time}
+              commentStoryTranslationContentId={
+                commentStoryTranslationContentId
+              }
+              lineIndex={commentLine}
+            />
           ))}
         </Box>
       );

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -7,6 +7,8 @@ import {
   UPDATE_COMMENT_BY_ID,
   UpdateCommentResponse,
 } from "../../APIClients/mutations/CommentMutations";
+import { CommentResponse } from "../../APIClients/queries/CommentQueries";
+import { StoryLine } from "../translation/Autosave";
 
 export type ExistingCommentProps = {
   id: number;
@@ -16,6 +18,10 @@ export type ExistingCommentProps = {
   commentStoryTranslationContentId: number;
   lineIndex: number;
   updateCommentsAsResolved: (index: number) => void;
+  comments: CommentResponse[];
+  setComments: (comments: CommentResponse[]) => void;
+  translatedStoryLines: StoryLine[];
+  setTranslatedStoryLines: (storyLines: StoryLine[]) => void;
 };
 
 const ExistingComment = ({
@@ -26,6 +32,10 @@ const ExistingComment = ({
   commentStoryTranslationContentId,
   lineIndex,
   updateCommentsAsResolved,
+  setComments,
+  setTranslatedStoryLines,
+  comments,
+  translatedStoryLines,
 }: ExistingCommentProps) => {
   const handleError = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
@@ -94,9 +104,13 @@ const ExistingComment = ({
       </Flex>
       {reply > 0 && lineIndex > -1 && (
         <WIPComment
-          commentStoryTranslationContentId={commentStoryTranslationContentId}
           lineIndex={lineIndex}
+          commentStoryTranslationContentId={commentStoryTranslationContentId}
           setCommentLine={setReply}
+          comments={comments}
+          setComments={setComments}
+          setTranslatedStoryLines={setTranslatedStoryLines}
+          translatedStoryLines={translatedStoryLines}
         />
       )}
     </Flex>

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from "react";
 import { useMutation } from "@apollo/client";
-import { Flex, Button } from "@chakra-ui/react";
+import { Text, Flex, Button } from "@chakra-ui/react";
 import AuthContext from "../../contexts/AuthContext";
 import WIPComment from "./WIPComment";
 import {
@@ -14,7 +14,6 @@ export type ExistingCommentProps = {
   content: string;
   time: string;
   commentStoryTranslationContentId: number;
-  setCommentLine: (line: number) => void;
   lineIndex: number;
 };
 
@@ -24,7 +23,6 @@ const ExistingComment = ({
   content,
   time,
   commentStoryTranslationContentId,
-  setCommentLine,
   lineIndex,
 }: ExistingCommentProps) => {
   const handleError = (errorMessage: string) => {
@@ -32,7 +30,7 @@ const ExistingComment = ({
     alert(errorMessage);
   };
 
-  const [reply, setReply] = useState(false);
+  const [reply, setReply] = useState(0);
 
   const { authenticatedUser } = useContext(AuthContext);
   const [updateComment] = useMutation<{
@@ -48,7 +46,7 @@ const ExistingComment = ({
           content,
         };
 
-        await updateComment({
+        const result = await updateComment({
           variables: { commentData },
         });
       }
@@ -71,27 +69,31 @@ const ExistingComment = ({
         borderRadius: 8,
         width: "320px",
       }}
-      backgroundColor="white"
+      backgroundColor="transparent"
     >
-      <b>Line {lineIndex}</b>
-      <Flex justify="space-between">
+      <Text fontWeight="bold" marginBottom="15px">
+        Line {lineIndex}
+      </Text>
+      <Flex justify="space-between" marginBottom="10px">
         <p>{name}</p>
         <p>{time}</p>
       </Flex>
-      {content}
+      <Text fontSize="sm" marginBottom="5px">
+        {content}
+      </Text>
       <Flex>
-        <Button onClick={() => setReply(true)} variant="text">
+        <Button onClick={() => setReply(1)} variant="label">
           Reply
         </Button>
-        <Button onClick={resolveExistingComment} variant="text">
+        <Button onClick={resolveExistingComment} variant="label">
           Resolve
         </Button>
       </Flex>
-      {reply && lineIndex > 0 && (
+      {reply > 0 && lineIndex > -1 && (
         <WIPComment
           commentStoryTranslationContentId={commentStoryTranslationContentId}
           lineIndex={lineIndex}
-          setCommentLine={setCommentLine}
+          setCommentLine={setReply}
         />
       )}
     </Flex>

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from "react";
 import { useMutation } from "@apollo/client";
-import { Flex, Box, Button } from "@chakra-ui/react";
+import { Flex, Button } from "@chakra-ui/react";
 import AuthContext from "../../contexts/AuthContext";
 import WIPComment from "./WIPComment";
 import {
@@ -12,7 +12,9 @@ export type ExistingCommentProps = {
   id: number;
   resolved: boolean;
   content: string;
-  storyTranslationContentId: number;
+  time: string;
+  commentStoryTranslationContentId: number;
+  setCommentLine: (line: number) => void;
   lineIndex: number;
 };
 
@@ -20,7 +22,9 @@ const ExistingComment = ({
   id,
   resolved,
   content,
-  storyTranslationContentId,
+  time,
+  commentStoryTranslationContentId,
+  setCommentLine,
   lineIndex,
 }: ExistingCommentProps) => {
   const handleError = (errorMessage: string) => {
@@ -58,17 +62,36 @@ const ExistingComment = ({
     ${authenticatedUser!!.lastName}`;
 
   return (
-    <Flex>
-      <Box backgroundColor="gray.300" float="right" width="250px">
+    <Flex
+      border="1px solid"
+      borderColor="blue.50"
+      padding="14px 15px"
+      direction="column"
+      style={{
+        borderRadius: 8,
+        width: "320px",
+      }}
+      backgroundColor="white"
+    >
+      <b>Line {lineIndex}</b>
+      <Flex justify="space-between">
         <p>{name}</p>
-        {content}
-        <Button onClick={() => setReply(true)}>Reply</Button>
-        <Button onClick={resolveExistingComment}>Resolve</Button>
-      </Box>
-      {reply === true && (
+        <p>{time}</p>
+      </Flex>
+      {content}
+      <Flex>
+        <Button onClick={() => setReply(true)} variant="text">
+          Reply
+        </Button>
+        <Button onClick={resolveExistingComment} variant="text">
+          Resolve
+        </Button>
+      </Flex>
+      {reply && lineIndex > 0 && (
         <WIPComment
-          storyTranslationContentId={storyTranslationContentId}
+          commentStoryTranslationContentId={commentStoryTranslationContentId}
           lineIndex={lineIndex}
+          setCommentLine={setCommentLine}
         />
       )}
     </Flex>

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -66,15 +66,13 @@ const ExistingComment = ({
 
   return (
     <Flex
+      backgroundColor="transparent"
       border="1px solid"
       borderColor="blue.50"
-      padding="14px 15px"
+      borderRadius="8"
       direction="column"
-      style={{
-        borderRadius: 8,
-        width: "320px",
-      }}
-      backgroundColor="transparent"
+      padding="14px 15px"
+      width="320px"
     >
       <Text fontWeight="bold" marginBottom="15px">
         Line {lineIndex}
@@ -87,10 +85,10 @@ const ExistingComment = ({
         {content}
       </Text>
       <Flex>
-        <Button onClick={() => setReply(1)} variant="label">
+        <Button onClick={() => setReply(1)} variant="commentLabel">
           Reply
         </Button>
-        <Button onClick={resolveExistingComment} variant="label">
+        <Button onClick={resolveExistingComment} variant="commentLabel">
           Resolve
         </Button>
       </Flex>

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -15,6 +15,7 @@ export type ExistingCommentProps = {
   time: string;
   commentStoryTranslationContentId: number;
   lineIndex: number;
+  updateCommentsAsResolved: (index: number) => void;
 };
 
 const ExistingComment = ({
@@ -24,6 +25,7 @@ const ExistingComment = ({
   time,
   commentStoryTranslationContentId,
   lineIndex,
+  updateCommentsAsResolved,
 }: ExistingCommentProps) => {
   const handleError = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
@@ -49,6 +51,9 @@ const ExistingComment = ({
         const result = await updateComment({
           variables: { commentData },
         });
+        if (result.data?.updateCommentById.ok) {
+          updateCommentsAsResolved(id);
+        }
       }
     } catch (err) {
       handleError(err ?? "Error occurred, please try again.");

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -1,0 +1,78 @@
+import React, { useState, useContext } from "react";
+import { useMutation } from "@apollo/client";
+import { Flex, Box, Button } from "@chakra-ui/react";
+import AuthContext from "../../contexts/AuthContext";
+import WIPComment from "./WIPComment";
+import {
+  UPDATE_COMMENT_BY_ID,
+  UpdateCommentResponse,
+} from "../../APIClients/mutations/CommentMutations";
+
+export type ExistingCommentProps = {
+  id: number;
+  resolved: boolean;
+  content: string;
+  storyTranslationContentId: number;
+  lineIndex: number;
+};
+
+const ExistingComment = ({
+  id,
+  resolved,
+  content,
+  storyTranslationContentId,
+  lineIndex,
+}: ExistingCommentProps) => {
+  const handleError = (errorMessage: string) => {
+    // eslint-disable-next-line no-alert
+    alert(errorMessage);
+  };
+
+  const [reply, setReply] = useState(false);
+
+  const { authenticatedUser } = useContext(AuthContext);
+  const [updateComment] = useMutation<{
+    updateCommentById: UpdateCommentResponse;
+  }>(UPDATE_COMMENT_BY_ID);
+
+  const resolveExistingComment = async () => {
+    try {
+      if (!resolved) {
+        const commentData = {
+          id,
+          resolved: true,
+          content,
+        };
+
+        await updateComment({
+          variables: { commentData },
+        });
+      }
+    } catch (err) {
+      handleError(err ?? "Error occurred, please try again.");
+    }
+  };
+
+  const name = `
+    ${authenticatedUser!!.firstName}
+    ${authenticatedUser!!.lastName}`;
+
+  return (
+    <Flex>
+      <Box backgroundColor="gray.300" float="right" width="250px">
+        <p>{name}</p>
+        {content}
+        <Button onClick={() => setReply(true)}>Reply</Button>
+        <Button onClick={resolveExistingComment}>Resolve</Button>
+      </Box>
+      {reply === true && (
+        <WIPComment
+          storyTranslationContentId={storyTranslationContentId}
+          lineIndex={lineIndex}
+        />
+      )}
+    </Flex>
+  );
+};
+
+export default ExistingComment;

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -78,11 +78,14 @@ const Button = {
       padding: "30px 30px 27px 30px",
       textTransform: "capitalize",
       width: "fit-content",
-    text: {
+    },
+    label: {
       background: "transparent",
-      fontSize: "14px",
-      width: "50px",
+      fontSize: "12px",
+      width: "40px",
       textTransform: "capitalize",
+      padding: "0px",
+      justifyContent: "flex-start",
     },
   },
 };

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -79,13 +79,13 @@ const Button = {
       textTransform: "capitalize",
       width: "fit-content",
     },
-    label: {
+    commentLabel: {
       background: "transparent",
       fontSize: "12px",
-      width: "40px",
-      textTransform: "capitalize",
-      padding: "0px",
       justifyContent: "flex-start",
+      padding: "0px",
+      textTransform: "capitalize",
+      width: "40px",
     },
   },
 };

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -78,6 +78,11 @@ const Button = {
       padding: "30px 30px 27px 30px",
       textTransform: "capitalize",
       width: "fit-content",
+    text: {
+      background: "transparent",
+      fontSize: "14px",
+      width: "50px",
+      textTransform: "capitalize",
     },
   },
 };


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Create existing comment component](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=4a47edc475b34bb99b25ff1fae2a5507&p=db62b18f0f9f4422a833567c45883520)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Created gql mutation for updating user
- Created Existing comment component
![image](https://user-images.githubusercontent.com/32991028/139783005-11f46def-6caa-439b-a80e-b7dcf80d7b08.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Confirm pressing reply opens a WIPComment component (only when the Comments button is toggled) and pressing cancel on the WIPComment component closes it
2. Confirm pressing respond updates the resolved value for the comment in the db and updates the value of the comments state var

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- That the functionality is as desired

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
