### PR TITLE
Create updateStoryTranslationStage mutation

### DIFF
--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -82,6 +82,7 @@ class UpdateStoryTranslationContents(graphene.Mutation):
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))
 
+
 class UpdateStoryTranslationStage(graphene.Mutation):
     class Arguments:
         story_translation_data = UpdateStoryTranslationStageRequestDTO(required=True)

--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -9,6 +9,7 @@ from ..types.story_type import (
     StoryResponseDTO,
     StoryTranslationContentRequestDTO,
     StoryTranslationContentResponseDTO,
+    UpdateStoryTranslationStageRequestDTO,
 )
 
 
@@ -77,6 +78,20 @@ class UpdateStoryTranslationContents(graphene.Mutation):
                 "story"
             ].update_story_translation_contents(story_translation_contents)
             return UpdateStoryTranslationContents(new_story_translation_contents)
+        except Exception as e:
+            error_message = getattr(e, "message", None)
+            raise Exception(error_message if error_message else str(e))
+
+class UpdateStoryTranslationStage(graphene.Mutation):
+    class Arguments:
+        story_translation_data = UpdateStoryTranslationStageRequestDTO(required=True)
+
+    ok = graphene.Boolean()
+
+    def mutate(root, info, story_translation_data):
+        try:
+            services["story"].update_story_translation_stage(story_translation_data)
+            return UpdateStoryTranslationStage(ok=True)
         except Exception as e:
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -54,6 +54,7 @@ class Mutation(graphene.ObjectType):
     update_story_translation_contents = UpdateStoryTranslationContents.Field()
     update_story_translation_stage = UpdateStoryTranslationStage.Field()
 
+
 class Query(graphene.ObjectType):
     comments_by_story_translation = graphene.Field(
         graphene.List(CommentResponseDTO),

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -15,6 +15,7 @@ from .mutations.story_mutation import (
     CreateStory,
     CreateStoryTranslation,
     UpdateStoryTranslationContents,
+    UpdateStoryTranslationStage,
 )
 from .mutations.user_mutation import CreateUser, UpdateUser
 from .queries.comment_query import resolve_comments_by_story_translation
@@ -51,7 +52,7 @@ class Mutation(graphene.ObjectType):
     update_comment_by_id = UpdateCommentById.Field()
     update_comments = UpdateComments.Field()
     update_story_translation_contents = UpdateStoryTranslationContents.Field()
-
+    update_story_translation_stage = UpdateStoryTranslationStage.Field()
 
 class Query(graphene.ObjectType):
     comments_by_story_translation = graphene.Field(

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -75,3 +75,7 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
     level = graphene.Int(required=True)
     num_translated_lines = graphene.Int()
     num_approved_lines = graphene.Int()
+
+class UpdateStoryTranslationStageRequestDTO(graphene.InputObjectType):
+    id = graphene.Int(required=True)
+    stage = graphene.Field(StageEnum, required=True)

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -76,6 +76,7 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
     num_translated_lines = graphene.Int()
     num_approved_lines = graphene.Int()
 
+
 class UpdateStoryTranslationStageRequestDTO(graphene.InputObjectType):
     id = graphene.Int(required=True)
     stage = graphene.Field(StageEnum, required=True)

--- a/backend/python/app/middlewares/auth.py
+++ b/backend/python/app/middlewares/auth.py
@@ -12,6 +12,8 @@ auth_service = AuthService(current_app.logger, user_service)
 """
 Get authorization access token from flask request object
 """
+
+
 def get_access_token(request):
     auth_header = request.headers.get("Authorization")
     if auth_header:
@@ -20,9 +22,12 @@ def get_access_token(request):
             return auth_header_parts[1]
     return None
 
+
 """
 Get user id from flask request object
 """
+
+
 def get_user_id_from_request():
     access_token = get_access_token(request)
     decoded_id_token = firebase_admin.auth.verify_id_token(

--- a/backend/python/app/middlewares/auth.py
+++ b/backend/python/app/middlewares/auth.py
@@ -9,12 +9,9 @@ from ..services.implementations.user_service import UserService
 user_service = UserService(current_app.logger)
 auth_service = AuthService(current_app.logger, user_service)
 
-"""
-Get authorization access token from flask request object
-"""
-
 
 def get_access_token(request):
+    """Get authorization access token from flask request object"""
     auth_header = request.headers.get("Authorization")
     if auth_header:
         auth_header_parts = auth_header.split(" ")
@@ -23,12 +20,8 @@ def get_access_token(request):
     return None
 
 
-"""
-Get user id from flask request object
-"""
-
-
 def get_user_id_from_request():
+    """Get user id from flask request object"""
     access_token = get_access_token(request)
     decoded_id_token = firebase_admin.auth.verify_id_token(
         access_token, check_revoked=True

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -1,6 +1,6 @@
 from flask import current_app
 
-from ...graphql.types.story_type import StoryTranslationContentResponseDTO
+from ...graphql.types.story_type import StageEnum, StoryTranslationContentResponseDTO
 from ...models import db
 from ...models.story import Story
 from ...models.story_content import StoryContent
@@ -8,6 +8,7 @@ from ...models.story_translation import StoryTranslation
 from ...models.story_translation_content import StoryTranslationContent
 from ...models.story_translation_content_status import StoryTranslationContentStatus
 from ..interfaces.story_service import IStoryService
+from ...middlewares.auth import get_user_id_from_request
 
 
 class StoryService(IStoryService):
@@ -266,6 +267,21 @@ class StoryService(IStoryService):
                 )
             )
             raise error
+
+    def update_story_translation_stage(self, story_translation_data):
+        story_translation = StoryTranslation.query.filter_by(id=story_translation_data["id"]).first()
+        new_stage = story_translation_data["stage"]
+        user_id = get_user_id_from_request();
+
+        if (new_stage == StageEnum.TRANSLATE and story_translation.reviewer_id == user_id
+            or new_stage == StageEnum.REVIEW and story_translation.translator_id == user_id
+        ):
+            story_translation.stage = new_stage 
+            db.session.commit()
+        else:
+            error = "User is not authorized to update translation stage to: {stage}".format(stage=new_stage)
+            self.logger.error(error)
+            raise Exception(error)
 
     def get_story_translations_available_for_review(self, language, level):
         try:

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -84,7 +84,7 @@ class IStoryService(ABC):
     def update_story_translation_stage(self, story_translation_data):
         """Update the stage of a story translation
         :param story_translation_data: UpdateStoryTranslationStageRequestDTO
-        :raises Exception: if the user is not authorized to move the translation to the given stage 
+        :raises Exception: if the user is not authorized to move the translation to the given stage
         """
         pass
 

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -81,6 +81,14 @@ class IStoryService(ABC):
         pass
 
     @abstractmethod
+    def update_story_translation_stage(self, story_translation_data):
+        """Update the stage of a story translation
+        :param story_translation_data: UpdateStoryTranslationStageRequestDTO
+        :raises Exception: if the user is not authorized to move the translation to the given stage 
+        """
+        pass
+
+    @abstractmethod
     def get_story_translations_available_for_review(self, language, level):
         """
         Return a list of stories available to be reviewed by user


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Create updateStoryTranslationStage](https://www.notion.so/uwblueprintexecs/Create-updateStoryTranslationStage-c6bc9384ff07447e84f5a1f24eec627c)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- created a method in StoryService called `update_story_translation_stage` that updates the story translation's stage to the new stage if the user is authorized to perform the operation
- the mutation resolver pretty much just calls the method
- currently we only care about updating the stage to `TRANSLATE` or `REVIEW`, updating to `PUBLISH` will be handled separately in a different mutation

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to `localhost:5000/graphql`

2. To test the mutation you will need the `id` of a story_translation as well as its `translator_id`, for testing I used `id: 12` and `translator_id: 3`, which corresponds to user "Kevin Debryune"

3. Run the following mutation:

```
mutation {
  updateStoryTranslationStage(storyTranslationData: {id: 12, stage: TRANSLATE}) {
    ok
  }
}
```

and you should get an error response saying the user is not authorized to perform the update (only reviewers can move the stage to TRANSLATE)

**Note:** You will have to be signed in as the user "Kevin Debryune" because the method uses the access token from the request

4. Run the same mutation as above except with `stage: REVIEW` and you should get an ok response

5. Verify that the story_translation is now in the `REVIEW` stage by running the query

```
query {
  storyTranslationById(id:12) {
    stage
  }
}
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- clarity and code readability of the implemented `story_service` method

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
