### PR TITLE
Add status pill for single line

### DIFF
--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ...middlewares.auth import require_authorization_as_story_translator
+from ...models.story_translation_content_status import StoryTranslationContentStatus
 from ..service import services
 from ..types.story_type import (
     CreateStoryTranslationRequestDTO,
@@ -9,6 +10,7 @@ from ..types.story_type import (
     StoryResponseDTO,
     StoryTranslationContentRequestDTO,
     StoryTranslationContentResponseDTO,
+    StoryTranslationUpdateStatusResponseDTO,
     UpdateStoryTranslationStageRequestDTO,
 )
 
@@ -78,6 +80,24 @@ class UpdateStoryTranslationContents(graphene.Mutation):
                 "story"
             ].update_story_translation_contents(story_translation_contents)
             return UpdateStoryTranslationContents(new_story_translation_contents)
+        except Exception as e:
+            error_message = getattr(e, "message", None)
+            raise Exception(error_message if error_message else str(e))
+
+
+class UpdateStoryTranslationContentStatus(graphene.Mutation):
+    class Arguments:
+        story_translation_content_id = graphene.Int(required=True)
+        status = graphene.String(required=True)
+
+    story = graphene.Field(lambda: StoryTranslationUpdateStatusResponseDTO)
+    # TODO: require authorization as reviewer
+    def mutate(root, info, story_translation_content_id, status):
+        try:
+            new_story = services["story"].update_story_translation_content_status(
+                story_translation_content_id, status
+            )
+            return UpdateStoryTranslationContentStatus(new_story)
         except Exception as e:
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -15,6 +15,7 @@ from .mutations.story_mutation import (
     CreateStory,
     CreateStoryTranslation,
     UpdateStoryTranslationContents,
+    UpdateStoryTranslationContentStatus,
     UpdateStoryTranslationStage,
 )
 from .mutations.user_mutation import CreateUser, UpdateUser
@@ -52,6 +53,9 @@ class Mutation(graphene.ObjectType):
     update_comment_by_id = UpdateCommentById.Field()
     update_comments = UpdateComments.Field()
     update_story_translation_contents = UpdateStoryTranslationContents.Field()
+    update_story_translation_content_status = (
+        UpdateStoryTranslationContentStatus.Field()
+    )
     update_story_translation_stage = UpdateStoryTranslationStage.Field()
 
 

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -77,6 +77,12 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
     num_approved_lines = graphene.Int()
 
 
+class StoryTranslationUpdateStatusResponseDTO(graphene.ObjectType):
+    id = graphene.Int(required=True)
+    line_index = graphene.Int(required=True)
+    status = graphene.String(required=True)
+
+
 class UpdateStoryTranslationStageRequestDTO(graphene.InputObjectType):
     id = graphene.Int(required=True)
     stage = graphene.Field(StageEnum, required=True)

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -1,6 +1,10 @@
 from flask import current_app
 
-from ...graphql.types.story_type import StageEnum, StoryTranslationContentResponseDTO
+from ...graphql.types.story_type import (
+    StageEnum,
+    StoryTranslationContentResponseDTO,
+    StoryTranslationUpdateStatusResponseDTO,
+)
 from ...middlewares.auth import get_user_id_from_request
 from ...models import db
 from ...models.story import Story
@@ -394,6 +398,31 @@ class StoryService(IStoryService):
         except Exception as error:
             self.logger.error(str(error))
             raise error
+
+    def update_story_translation_content_status(
+        self, story_translation_content_id, status
+    ):
+        try:
+            story_translation_content = StoryTranslationContent.query.filter_by(
+                id=story_translation_content_id
+            ).first()
+
+            story_translation_content.status = status
+            db.session.commit()
+        except Exception as error:
+            reason = getattr(error, "message", None)
+            self.logger.error(
+                "Failed to update story translation status. Reason = {reason}".format(
+                    reason=(reason if reason else str(error))
+                )
+            )
+            raise error
+
+        return StoryTranslationUpdateStatusResponseDTO(
+            story_translation_content_id,
+            story_translation_content.line_index,
+            status,
+        )
 
     def _get_num_translated_lines(self, translation_contents):
         return len(translation_contents) - [

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -102,3 +102,15 @@ class IStoryService(ABC):
         :rtype: list of StoryTranslationResponseDTO's
         """
         pass
+
+    @abstractmethod
+    def update_story_translation_content_status(
+        self, story_translation_content_id, status
+    ):
+        """Update a single story translation content status
+        :param story_translation_content: StoryTranslationContentRequestDTO id and updated
+        status for story translation
+        :return: StoryTranslationContentResponseDTO
+        :rtype: StoryTranslationContentResponseDTO
+        """
+        pass

--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -14,6 +14,28 @@ export const UPDATE_STORY_TRANSLATION_CONTENTS = gql`
   }
 `;
 
+export const UPDATE_STORY_TRANSLATION_CONTENT_STATUS = gql`
+  mutation UpdateStoryTranslationContent(
+    $storyTranslationContentId: Int!
+    $status: String!
+  ) {
+    updateStoryTranslationContentStatus(
+      storyTranslationContentId: $storyTranslationContentId
+      status: $status
+    ) {
+      story {
+        id
+      }
+    }
+  }
+`;
+
+export type UpdateStoryTranslationContentStatusResponse = {
+  story: {
+    id: number;
+  };
+};
+
 export const CREATE_TRANSLATION = gql`
   mutation CreateStoryTranslation(
     $storyTranslationData: CreateStoryTranslationRequestDTO!

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
 import { Box, Divider, Flex } from "@chakra-ui/react";
-
 import { useParams } from "react-router-dom";
+
 import ProgressBar from "../utils/ProgressBar";
 import TranslationTable from "../translation/TranslationTable";
 import { StoryLine } from "../translation/Autosave";
+import { convertStatusTitleCase } from "../../utils/StatusUtils";
 import { GET_STORY_AND_TRANSLATION_CONTENTS } from "../../APIClients/queries/StoryQueries";
 import CommentsPanel from "../review/CommentsPanel";
 import FontSizeSlider from "../translation/FontSizeSlider";
@@ -68,16 +69,18 @@ const ReviewPage = () => {
         contentArray.push({
           lineIndex,
           originalContent: content,
-          status: "Default",
         });
       });
 
       contentArray.sort((a, b) => a.lineIndex - b.lineIndex);
 
-      translatedContent.forEach(({ id, content, lineIndex }: Content) => {
-        contentArray[lineIndex].translatedContent = content;
-        contentArray[lineIndex].storyTranslationContentId = id;
-      });
+      translatedContent.forEach(
+        ({ id, content, lineIndex, status }: Content) => {
+          contentArray[lineIndex].translatedContent = content;
+          contentArray[lineIndex].storyTranslationContentId = id;
+          contentArray[lineIndex].status = convertStatusTitleCase(status);
+        },
+      );
       setTranslatedStoryLines(contentArray);
     },
   });
@@ -118,6 +121,9 @@ const ReviewPage = () => {
                 setCommentStoryTranslationContentId
               }
               translator={false}
+              setTranslatedStoryLines={setTranslatedStoryLines}
+              numApprovedLines={numApprovedLines}
+              setNumApprovedLines={setNumApprovedLines}
             />
           </Flex>
           <Flex margin="20px 30px" justify="flex-start" alignItems="center">

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -233,6 +233,7 @@ const TranslationPage = () => {
                 setCommentStoryTranslationContentId
               }
               translator
+              setTranslatedStoryLines={setTranslatedStoryLines}
             />
           </Flex>
           <Flex margin="20px 30px" justify="space-between" alignItems="center">

--- a/frontend/src/components/review/StatusBadge.tsx
+++ b/frontend/src/components/review/StatusBadge.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { Badge, Menu, MenuButton, MenuList, MenuItem } from "@chakra-ui/react";
+import { useMutation } from "@apollo/client";
+import { Icon } from "@chakra-ui/icon";
+import { MdCheck, MdTimer, MdArrowDropDown } from "react-icons/md";
+import {
+  getStatusVariant,
+  convertStatusTitleCase,
+} from "../../utils/StatusUtils";
+import {
+  UPDATE_STORY_TRANSLATION_CONTENT_STATUS,
+  UpdateStoryTranslationContentStatusResponse,
+} from "../../APIClients/mutations/StoryMutations";
+import { StoryLine } from "../translation/Autosave";
+
+export type StatusBadgeProps = {
+  translatedStoryLines: StoryLine[];
+  setTranslatedStoryLines: (storyLines: StoryLine[]) => void;
+  storyLine: StoryLine;
+  numApprovedLines: number;
+  setNumApprovedLines: (numLines: number) => void;
+};
+
+const StatusBadge = ({
+  translatedStoryLines,
+  setTranslatedStoryLines,
+  storyLine,
+  numApprovedLines,
+  setNumApprovedLines,
+}: StatusBadgeProps) => {
+  const [updateStatus] = useMutation<{
+    response: UpdateStoryTranslationContentStatusResponse;
+  }>(UPDATE_STORY_TRANSLATION_CONTENT_STATUS);
+  const handleStatusChange = async (newStatus: string) => {
+    const result = await updateStatus({
+      variables: {
+        storyTranslationContentId: storyLine.storyTranslationContentId!!,
+        status: newStatus,
+      },
+    });
+    if (result) {
+      const prevState = translatedStoryLines[storyLine.lineIndex].status;
+
+      const updatedStatusArray = [...translatedStoryLines!];
+      updatedStatusArray[storyLine.lineIndex].status = convertStatusTitleCase(
+        newStatus,
+      );
+
+      setTranslatedStoryLines(updatedStatusArray);
+      if (
+        prevState !== convertStatusTitleCase("APPROVED") &&
+        newStatus === "APPROVED"
+      ) {
+        setNumApprovedLines!!(numApprovedLines!! + 1);
+      } else if (
+        prevState === convertStatusTitleCase("APPROVED") &&
+        newStatus !== "APPROVED"
+      ) {
+        setNumApprovedLines!!(numApprovedLines!! - 1);
+      }
+    }
+  };
+
+  return (
+    <Menu>
+      <MenuButton
+        as={Badge}
+        textTransform="capitalize"
+        variant={getStatusVariant(storyLine.status)}
+        marginBottom="10px"
+        text-align="center"
+      >
+        {storyLine.status}
+        <Icon as={MdArrowDropDown} height={6} width={6} />
+      </MenuButton>
+      <MenuList>
+        <MenuItem
+          icon={<Icon as={MdCheck} height={6} width={6} />}
+          onClick={async () => {
+            handleStatusChange("APPROVED");
+          }}
+        >
+          Approve
+        </MenuItem>
+        <MenuItem
+          icon={<Icon as={MdTimer} height={6} width={6} />}
+          onClick={async () => {
+            handleStatusChange("DEFAULT");
+          }}
+        >
+          Pending
+        </MenuItem>
+      </MenuList>
+    </Menu>
+  );
+};
+
+export default StatusBadge;

--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Badge, Button, Flex, Text, Tooltip } from "@chakra-ui/react";
 import EditableCell from "./EditableCell";
 import { StoryLine } from "./Autosave";
+import StatusBadge from "../review/StatusBadge";
 import { getStatusVariant } from "../../utils/StatusUtils";
 import { TRANSLATION_PAGE_TOOL_TIP_COPY } from "../../utils/Copy";
 
@@ -16,10 +17,13 @@ export type TranslationTableProps = {
   ) => Promise<void>;
   fontSize: string;
   translatedLanguage: string;
-  originalLanguage?: string;
+  originalLanguage: string;
+  setTranslatedStoryLines: (storyLines: StoryLine[]) => void;
   commentLine: number;
   setCommentLine: (line: number) => void;
   setCommentStoryTranslationContentId: (id: number) => void;
+  numApprovedLines?: number;
+  setNumApprovedLines?: (numLines: number) => void;
 };
 
 const TranslationTable = ({
@@ -29,10 +33,13 @@ const TranslationTable = ({
   fontSize,
   translatedLanguage,
   originalLanguage,
+  setTranslatedStoryLines,
   commentLine,
   setCommentLine,
   setCommentStoryTranslationContentId,
   translator,
+  numApprovedLines,
+  setNumApprovedLines,
 }: TranslationTableProps) => {
   const handleCommentButton = (
     displayLineNumber: number,
@@ -75,14 +82,24 @@ const TranslationTable = ({
             </Text>
           </Tooltip>
         )}
-        <Flex direction="column" width="130px" margin="10px">
-          <Badge
-            textTransform="capitalize"
-            variant={getStatusVariant(storyLine.status)}
-            marginBottom="10px"
-          >
-            {storyLine.status}
-          </Badge>
+        <Flex direction="column" width="140px" margin="5px">
+          {!editable ? (
+            <StatusBadge
+              translatedStoryLines={translatedStoryLines}
+              setTranslatedStoryLines={setTranslatedStoryLines}
+              storyLine={storyLine}
+              numApprovedLines={numApprovedLines!!}
+              setNumApprovedLines={setNumApprovedLines!!}
+            />
+          ) : (
+            <Badge
+              textTransform="capitalize"
+              variant={getStatusVariant(storyLine.status)}
+              marginBottom="10px"
+            >
+              {storyLine.status}
+            </Badge>
+          )}
           {commentLine > -1 && (
             <Button
               variant="addComment"


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add Status Pill](https://www.notion.so/uwblueprintexecs/Add-status-pill-to-lines-and-allow-reviewer-to-change-status-e672959f12f642dfbcd13d0661b613ad)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description
- Add GQL mutation to change the status of a line on the review page 
- Add menu to status pill on frontend to allow user to select new status 
- Update the review progress bar from the frontend as well 


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate --

## Steps to test

1. Go to review page 
2. Change the status of a few lines 
3. Reload page to ensure changes persist 
4. Watch to see if the Review Progress Bar updates 
5. Go to Translation Page and see if corresponding changes have been made 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Nothing is broken, no weird edge cases 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
