### PR TITLE
Reflect filter based on two approved languages pipelines

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -18,5 +18,6 @@ module.exports = {
   extends: ["airbnb-typescript", "prettier", "plugin:prettier/recommended"],
   rules: {
     "prettier/prettier": ["error", { endOfLine: "auto" }],
+    "prefer-destructuring": ["error", { object: true, array: false }],
   },
 };

--- a/frontend/src/APIClients/mutations/AuthMutations.ts
+++ b/frontend/src/APIClients/mutations/AuthMutations.ts
@@ -9,6 +9,7 @@ export const LOGIN = gql`
       email
       role
       approvedLanguagesTranslation
+      approvedLanguagesReview
       accessToken
       refreshToken
     }
@@ -24,6 +25,7 @@ export const LOGIN_WITH_GOOGLE = gql`
       email
       role
       approvedLanguagesTranslation
+      approvedLanguagesReview
       accessToken
       refreshToken
     }

--- a/frontend/src/components/homepage/Filter.tsx
+++ b/frontend/src/components/homepage/Filter.tsx
@@ -34,27 +34,37 @@ const Filter = ({
   setIsTranslator,
   isDisabled = false,
 }: FilterProps) => {
+  const approvedLanguages = role
+    ? approvedLanguagesTranslation
+    : approvedLanguagesReview;
+
+  // handles edge case of switching from higher approved level to lower level
+  const handleLevelDecrease = (newLevel: number) => {
+    if (level > newLevel) {
+      setLevel(newLevel);
+    }
+  };
+
   const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setLanguage(event.target.value);
+    handleLevelDecrease(approvedLanguages[event.target.value]);
   };
+
   const handleRoleChange = (nextRole: string) => {
-    const approvedLanguages =
+    const newApprovedLanguages =
       nextRole === "Translator"
         ? approvedLanguagesTranslation
         : approvedLanguagesReview;
-    const newLanguage = Object.keys(approvedLanguages)[0];
+    const newLanguage = Object.keys(newApprovedLanguages)[0];
     setIsTranslator(nextRole === "Translator");
     setLanguage(newLanguage);
-    setLevel(approvedLanguages[newLanguage]);
+
+    handleLevelDecrease(newApprovedLanguages[newLanguage]);
   };
 
   const handleLevelChangeStr = (nextLevel: string) => {
     setLevel(parseInt(nextLevel.replace("Level ", ""), 10));
   };
-
-  const approvedLanguages = role
-    ? approvedLanguagesTranslation
-    : approvedLanguagesReview;
 
   const languageOptions = isDisabled ? (
     <option key="undefined" value="undefined">

--- a/frontend/src/components/homepage/Filter.tsx
+++ b/frontend/src/components/homepage/Filter.tsx
@@ -13,6 +13,7 @@ import convertLanguageTitleCase from "../../utils/LanguageUtils";
 
 export type FilterProps = {
   approvedLanguagesTranslation: { [name: string]: number };
+  approvedLanguagesReview: { [name: string]: number };
   level: number;
   setLevel: (newState: number) => void;
   language: string;
@@ -24,6 +25,7 @@ export type FilterProps = {
 
 const Filter = ({
   approvedLanguagesTranslation,
+  approvedLanguagesReview,
   level,
   setLevel,
   language,
@@ -36,35 +38,61 @@ const Filter = ({
     setLanguage(event.target.value);
   };
   const handleRoleChange = (nextRole: string) => {
+    const approvedLanguages =
+      nextRole === "Translator"
+        ? approvedLanguagesTranslation
+        : approvedLanguagesReview;
+    const newLanguage = Object.keys(approvedLanguages)[0];
     setIsTranslator(nextRole === "Translator");
+    setLanguage(newLanguage);
+    setLevel(approvedLanguages[newLanguage]);
   };
+
   const handleLevelChangeStr = (nextLevel: string) => {
     setLevel(parseInt(nextLevel.replace("Level ", ""), 10));
   };
+
+  const approvedLanguages = role
+    ? approvedLanguagesTranslation
+    : approvedLanguagesReview;
+
   const languageOptions = isDisabled ? (
     <option key="undefined" value="undefined">
       {" "}
     </option>
   ) : (
-    Object.keys(approvedLanguagesTranslation).map((lang) => (
+    Object.keys(approvedLanguages).map((lang) => (
       <option key={lang} value={lang}>
         {convertLanguageTitleCase(lang)}
       </option>
     ))
   );
-  const maxLvl = approvedLanguagesTranslation[language];
-  const lvlOptions = [];
-  for (let i = 1; i <= maxLvl; i += 1) {
-    lvlOptions.push(
-      <option key={i.toString()} value={i.toString()} label={i.toString()} />,
-    );
-  }
+
+  const maxApprovedLevel = approvedLanguages[language];
+  const levelOptions = Array.from(Array(maxApprovedLevel).keys()).map(
+    (val) => `Level ${val + 1}`,
+  );
+
   const filterStyle = useStyleConfig("Filter");
   const disabledStyle = useStyleConfig("Disabled");
   return (
     <Flex sx={filterStyle}>
       <Heading size="lg">Filters</Heading>
-      <Divider />
+      {Object.keys(approvedLanguagesReview).length > 0 && (
+        <>
+          <Divider marginTop="24px" marginBottom="18px" />
+          <Box sx={isDisabled ? disabledStyle : undefined}>
+            <Heading size="sm">Role Required</Heading>
+            <ButtonRadioGroup
+              name="Role"
+              options={["Translator", "Reviewer"]}
+              onChange={handleRoleChange}
+              defaultValue={role ? "Translator" : "Reviewer"}
+            />
+          </Box>
+        </>
+      )}
+      <Divider marginTop="24px" marginBottom="18px" />
       <Box sx={isDisabled ? disabledStyle : undefined}>
         <Heading size="sm">Translation Language</Heading>
         <Select
@@ -77,23 +105,12 @@ const Filter = ({
           {languageOptions}
         </Select>
       </Box>
-      <Divider />
-      <Box sx={isDisabled ? disabledStyle : undefined}>
-        <Heading size="sm">Role Required</Heading>
-        <ButtonRadioGroup
-          name="Role"
-          options={["Translator", "Reviewer"]}
-          onChange={handleRoleChange}
-          defaultValue={role ? "Translator" : "Reviewer"}
-          isDisabled={isDisabled}
-        />
-      </Box>
-      <Divider />
+      <Divider marginTop="24px" marginBottom="18px" />
       <Box sx={isDisabled ? disabledStyle : undefined}>
         <Heading size="sm">Access Level</Heading>
         <ButtonRadioGroup
           name="Level"
-          options={["Level 1", "Level 2", "Level 3", "Level 4"]}
+          options={levelOptions}
           onChange={handleLevelChangeStr}
           defaultValue={`Level ${level}`}
           isDisabled={isDisabled}

--- a/frontend/src/components/homepage/Filter.tsx
+++ b/frontend/src/components/homepage/Filter.tsx
@@ -38,16 +38,8 @@ const Filter = ({
     ? approvedLanguagesTranslation
     : approvedLanguagesReview;
 
-  // handles edge case of switching from higher approved level to lower level
-  const handleLevelDecrease = (newLevel: number) => {
-    if (level > newLevel) {
-      setLevel(newLevel);
-    }
-  };
-
   const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setLanguage(event.target.value);
-    handleLevelDecrease(approvedLanguages[event.target.value]);
   };
 
   const handleRoleChange = (nextRole: string) => {
@@ -55,11 +47,16 @@ const Filter = ({
       nextRole === "Translator"
         ? approvedLanguagesTranslation
         : approvedLanguagesReview;
-    const newLanguage = Object.keys(newApprovedLanguages)[0];
+
+    let newLanguage = language;
+
+    // if user isn't permitted to translate/review in the same language, default
+    // to the first language
+    if (!Object.keys(newApprovedLanguages).find((x) => x === language)) {
+      newLanguage = Object.keys(newApprovedLanguages)[0];
+    }
     setIsTranslator(nextRole === "Translator");
     setLanguage(newLanguage);
-
-    handleLevelDecrease(newApprovedLanguages[newLanguage]);
   };
 
   const handleLevelChangeStr = (nextLevel: string) => {
@@ -79,9 +76,13 @@ const Filter = ({
   );
 
   const maxApprovedLevel = approvedLanguages[language];
-  const levelOptions = Array.from(Array(maxApprovedLevel).keys()).map(
-    (val) => `Level ${val + 1}`,
-  );
+
+  // if not disabled, display levels only up to the maxApprovedLevel
+  const levelOptions = isDisabled
+    ? ["Level 1", "Level 2", "Level 3", "Level 4"]
+    : [...Array(maxApprovedLevel + 1).keys()]
+        .slice(1)
+        .map((val) => `Level ${val}`);
 
   const filterStyle = useStyleConfig("Filter");
   const disabledStyle = useStyleConfig("Disabled");

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -28,9 +28,7 @@ const HomePage = () => {
     Object.keys(approvedLanguagesTranslation)[0],
   );
   const [isTranslator, setIsTranslator] = useState<boolean>(true);
-  const [level, setLevel] = useState<number>(
-    approvedLanguagesTranslation[language],
-  );
+  const [level, setLevel] = useState<number>(1);
   const [stories, setStories] = useState<StoryCardProps[] | null>(null);
 
   const [showScrollToTop, setShowScrollToTop] = useState(false);

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -19,6 +19,10 @@ const HomePage = () => {
     authenticatedUser!!.approvedLanguagesTranslation.replace(/'/g, '"'),
   );
 
+  const approvedLanguagesReview = authenticatedUser!!.approvedLanguagesReview
+    ? JSON.parse(authenticatedUser!!.approvedLanguagesReview.replace(/'/g, '"'))
+    : {};
+
   const [displayMyStories, setDisplayMyStories] = useState<boolean>(true);
   const [language, setLanguage] = useState<string>(
     Object.keys(approvedLanguagesTranslation)[0],
@@ -84,6 +88,7 @@ const HomePage = () => {
       <Flex direction="row">
         <Filter
           approvedLanguagesTranslation={approvedLanguagesTranslation}
+          approvedLanguagesReview={approvedLanguagesReview}
           level={level}
           setLevel={setLevel}
           language={language}

--- a/frontend/src/contexts/AuthContext.ts
+++ b/frontend/src/contexts/AuthContext.ts
@@ -8,6 +8,7 @@ export type AuthenticatedUser = {
   role: "Admin" | "User";
   accessToken: string;
   approvedLanguagesTranslation: string;
+  approvedLanguagesReview: string;
 } | null;
 
 type AuthContextType = {

--- a/frontend/src/theme/components/Filter.ts
+++ b/frontend/src/theme/components/Filter.ts
@@ -2,8 +2,7 @@ const Filter = {
   baseStyle: {
     boxShadow: "0 0 12px -9px rgba(0, 0, 0, 0.7)",
     flexDirection: "column",
-    height: "800px",
-    justifyContent: "space-between",
+    justifyContent: "flex-start",
     marginRight: "10px",
     minWidth: "292px",
     padding: "50px 50px 50px 50px",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "downlevelIteration": true,
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Reflect filter based on two approved languages pipelines](https://www.notion.so/uwblueprintexecs/reflect-filter-based-on-two-approved-languages-pipelines-f0b7b4a5aa634f8ea515e47701cbf003)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description
- updated mutation and auth user type to fetch approvedLanguagesReview
- minor restyling for Filter component to use margins instead of `justifyContent: space-between`
- display "Role required" box only if `approvedLanguagesReview` object is not empty
- display access level options based on approved level, **previously all levels from 1->4 were displayed**
    

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Log in using `planetread+carlsagan@uwblueprint.org`, the sidebar shouldn't display the "Role required" section (since Carl Sagan is only approved as a translator)
2. Clear localStorage and log in as `planetread+miroslavklose@uwblueprint.org`, the sidebar should display the "Translator/Reviewer" selection
3. Switch back and forth between the roles and access levels and verify that the proper languages are shown

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?
- making sure that switching between translator/reviewer shows the appropriate access levels and the correct ones are selected
- dynamically displaying the level options leads to an edge case where switching from a language with a higher level to one with a lower level doesn't change the UI appropriately (will need to refactor `ButtonRadioGroup` in a different ticket)

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
