### PR TITLE
Disable editing on translation platform if stage is REVIEW

### DIFF
--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -30,6 +30,7 @@ export const GET_STORY_AND_TRANSLATION_CONTENTS = (
     }
     storyTranslationById(id: ${storyTranslationId}) {
       language
+      stage
       translationContents {
         id
         lineIndex

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -139,6 +139,7 @@ const ReviewPage = () => {
           </Flex>
         </Flex>
         <CommentsPanel
+          disabled={false}
           commentStoryTranslationContentId={commentStoryTranslationContentId}
           commentLine={commentLine}
           storyTranslationId={storyTranslationId}

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -117,6 +117,7 @@ const ReviewPage = () => {
               setCommentStoryTranslationContentId={
                 setCommentStoryTranslationContentId
               }
+              translator={false}
             />
           </Flex>
           <Flex margin="20px 30px" justify="flex-start" alignItems="center">

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -14,7 +14,7 @@ import convertLanguageTitleCase from "../../utils/LanguageUtils";
 import deepCopy from "../../utils/DeepCopyUtils";
 import Header from "../navigation/Header";
 import CommentsPanel from "../review/CommentsPanel";
-import TRANSLATION_PAGE_TOOL_TIP_COPY from "../../utils/Copy";
+import { TRANSLATION_PAGE_TOOL_TIP_COPY } from "../../utils/Copy";
 
 type TranslationPageProps = {
   storyIdParam: string | undefined;

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
-import { Box, Button, Divider, Flex, Text } from "@chakra-ui/react";
+import { Box, Button, Divider, Flex, Text, Tooltip } from "@chakra-ui/react";
 import { useParams } from "react-router-dom";
+
 import ProgressBar from "../utils/ProgressBar";
 import TranslationTable from "../translation/TranslationTable";
 import UndoRedo from "../translation/UndoRedo";
@@ -121,6 +122,8 @@ const TranslationPage = () => {
   const clearUnsavedChangesMap = () => {
     setChangedStoryLines(new Map());
   };
+  const tooltipCopy =
+    "Your story translation is pending review. You can edit your translation and leave comments once a reviewer has given feedback.";
 
   useQuery(GET_STORY_AND_TRANSLATION_CONTENTS(storyId, storyTranslationId), {
     fetchPolicy: "cache-and-network",
@@ -238,14 +241,18 @@ const TranslationPage = () => {
               }
               type="Translation"
             />
-            <Button
-              colorScheme="blue"
-              size="secondary"
-              margin="0 10px 0"
-              disabled={!editable}
-            >
-              {editable ? "SEND FOR REVIEW" : "IN REVIEW"}
-            </Button>
+            <Tooltip hasArrow label={tooltipCopy} isDisabled={editable}>
+              <Box>
+                <Button
+                  colorScheme="blue"
+                  size="secondary"
+                  margin="0 10px 0"
+                  disabled={!editable}
+                >
+                  {editable ? "SEND FOR REVIEW" : "IN REVIEW"}
+                </Button>
+              </Box>
+            </Tooltip>
           </Flex>
         </Flex>
         <CommentsPanel

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -244,7 +244,7 @@ const TranslationPage = () => {
               margin="0 10px 0"
               disabled={!editable}
             >
-              SEND FOR REVIEW
+              {editable ? "SEND FOR REVIEW" : "IN REVIEW"}
             </Button>
           </Flex>
         </Flex>

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -14,6 +14,7 @@ import convertLanguageTitleCase from "../../utils/LanguageUtils";
 import deepCopy from "../../utils/DeepCopyUtils";
 import Header from "../navigation/Header";
 import CommentsPanel from "../review/CommentsPanel";
+import TRANSLATION_PAGE_TOOL_TIP_COPY from "../../utils/Copy";
 
 type TranslationPageProps = {
   storyIdParam: string | undefined;
@@ -41,6 +42,8 @@ const TranslationPage = () => {
   );
   const [title, setTitle] = useState<string>("");
   const [language, setLanguage] = useState<string>("");
+  const [stage, setStage] = useState<string>("");
+
   // AutoSave
   const [changedStoryLines, setChangedStoryLines] = useState<
     Map<number, StoryLine>
@@ -60,7 +63,6 @@ const TranslationPage = () => {
   // Font Size Slider
   const [fontSize, setFontSize] = useState<string>("12px");
 
-  const [stage, setStage] = useState<string>("");
   const editable = stage === "TRANSLATE";
   const [commentLine, setCommentLine] = useState(-1);
   const [
@@ -122,8 +124,6 @@ const TranslationPage = () => {
   const clearUnsavedChangesMap = () => {
     setChangedStoryLines(new Map());
   };
-  const tooltipCopy =
-    "Your story translation is pending review. You can edit your translation and leave comments once a reviewer has given feedback.";
 
   useQuery(GET_STORY_AND_TRANSLATION_CONTENTS(storyId, storyTranslationId), {
     fetchPolicy: "cache-and-network",
@@ -232,6 +232,7 @@ const TranslationPage = () => {
               setCommentStoryTranslationContentId={
                 setCommentStoryTranslationContentId
               }
+              translator
             />
           </Flex>
           <Flex margin="20px 30px" justify="space-between" alignItems="center">
@@ -241,7 +242,11 @@ const TranslationPage = () => {
               }
               type="Translation"
             />
-            <Tooltip hasArrow label={tooltipCopy} isDisabled={editable}>
+            <Tooltip
+              hasArrow
+              label={TRANSLATION_PAGE_TOOL_TIP_COPY}
+              isDisabled={editable}
+            >
               <Box>
                 <Button
                   colorScheme="blue"

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -59,6 +59,8 @@ const TranslationPage = () => {
   // Font Size Slider
   const [fontSize, setFontSize] = useState<string>("12px");
 
+  const [stage, setStage] = useState<string>("");
+  const editable = stage === "TRANSLATE";
   const [commentLine, setCommentLine] = useState(-1);
   const [
     commentStoryTranslationContentId,
@@ -125,6 +127,7 @@ const TranslationPage = () => {
     onCompleted: (data) => {
       const storyContent = data.storyById.contents;
       const translatedContent = data.storyTranslationById.translationContents;
+      setStage(data.storyTranslationById.stage);
       setLanguage(data.storyTranslationById.language);
       setTitle(data.storyById.title);
       setNumTranslatedLines(data.storyTranslationById.numTranslatedLines);
@@ -217,7 +220,7 @@ const TranslationPage = () => {
             <TranslationTable
               translatedStoryLines={translatedStoryLines}
               onUserInput={onUserInput}
-              editable
+              editable={editable}
               fontSize={fontSize}
               originalLanguage="English"
               translatedLanguage={convertLanguageTitleCase(language)}
@@ -235,12 +238,18 @@ const TranslationPage = () => {
               }
               type="Translation"
             />
-            <Button colorScheme="blue" size="secondary" margin="0 10px 0">
+            <Button
+              colorScheme="blue"
+              size="secondary"
+              margin="0 10px 0"
+              disabled={!editable}
+            >
               SEND FOR REVIEW
             </Button>
           </Flex>
         </Flex>
         <CommentsPanel
+          disabled={!editable}
           commentStoryTranslationContentId={commentStoryTranslationContentId}
           commentLine={commentLine}
           storyTranslationId={storyTranslationId}

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -6,7 +6,7 @@ import {
   buildCommentsQuery,
 } from "../../APIClients/queries/CommentQueries";
 import WIPComment from "./WIPComment";
-import TRANSLATION_PAGE_TOOL_TIP_COPY from "../../utils/Copy";
+import { TRANSLATION_PAGE_TOOL_TIP_COPY } from "../../utils/Copy";
 
 export type CommentPanelProps = {
   storyTranslationId: number;

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -12,6 +12,7 @@ export type CommentPanelProps = {
   commentLine: number;
   setCommentLine: (line: number) => void;
   commentStoryTranslationContentId: number;
+  disabled: boolean;
 };
 
 const CommentsPanel = ({
@@ -19,6 +20,7 @@ const CommentsPanel = ({
   commentLine,
   commentStoryTranslationContentId,
   setCommentLine,
+  disabled,
 }: CommentPanelProps) => {
   const [comments, setComments] = useState<CommentResponse[]>([]);
   const [filterIndex, setFilterIndex] = useState(0);
@@ -83,6 +85,7 @@ const CommentsPanel = ({
           size="secondary"
           marginRight="10px"
           onClick={handleCommentButton}
+          disabled={disabled}
         >
           Comment
         </Button>
@@ -93,6 +96,7 @@ const CommentsPanel = ({
           variant="commentsFilter"
           onChange={handleCommentFilterSelectChange}
           width="160px"
+          disabled={disabled}
         >
           {filterOptionsComponent}
         </Select>

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
-import { Box, Button, Flex, Text, Select } from "@chakra-ui/react";
+import { Box, Button, Flex, Select, Text, Tooltip } from "@chakra-ui/react";
 import {
   CommentResponse,
   buildCommentsQuery,
@@ -77,18 +77,25 @@ const CommentsPanel = ({
     else setCommentLine(-1);
   };
 
+  const tooltipCopy =
+    "Your story translation is pending review. You can edit your translation and leave comments once a reviewer has given feedback.";
+
   return (
     <Box backgroundColor="gray.100" float="right" width="350px" padding="20px">
       <Flex marginBottom="50px">
-        <Button
-          colorScheme="blue"
-          size="secondary"
-          marginRight="10px"
-          onClick={handleCommentButton}
-          disabled={disabled}
-        >
-          Comment
-        </Button>
+        <Tooltip hasArrow label={tooltipCopy} isDisabled={!disabled}>
+          <Box>
+            <Button
+              colorScheme="blue"
+              size="secondary"
+              marginRight="10px"
+              onClick={handleCommentButton}
+              disabled={disabled}
+            >
+              Comment
+            </Button>
+          </Box>
+        </Tooltip>
         <Select
           name="comment filter"
           id="comment filter"

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -6,6 +6,7 @@ import {
   buildCommentsQuery,
 } from "../../APIClients/queries/CommentQueries";
 import WIPComment from "./WIPComment";
+import TRANSLATION_PAGE_TOOL_TIP_COPY from "../../utils/Copy";
 
 export type CommentPanelProps = {
   storyTranslationId: number;
@@ -77,13 +78,14 @@ const CommentsPanel = ({
     else setCommentLine(-1);
   };
 
-  const tooltipCopy =
-    "Your story translation is pending review. You can edit your translation and leave comments once a reviewer has given feedback.";
-
   return (
     <Box backgroundColor="gray.100" float="right" width="350px" padding="20px">
       <Flex marginBottom="50px">
-        <Tooltip hasArrow label={tooltipCopy} isDisabled={!disabled}>
+        <Tooltip
+          hasArrow
+          label={TRANSLATION_PAGE_TOOL_TIP_COPY}
+          isDisabled={!disabled}
+        >
           <Box>
             <Button
               colorScheme="blue"

--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -3,7 +3,7 @@ import { Badge, Button, Flex, Text, Tooltip } from "@chakra-ui/react";
 import EditableCell from "./EditableCell";
 import { StoryLine } from "./Autosave";
 import { getStatusVariant } from "../../utils/StatusUtils";
-import TRANSLATION_PAGE_TOOL_TIP_COPY from "../../utils/Copy";
+import { TRANSLATION_PAGE_TOOL_TIP_COPY } from "../../utils/Copy";
 
 export type TranslationTableProps = {
   translatedStoryLines: StoryLine[];

--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -3,10 +3,12 @@ import { Badge, Button, Flex, Text, Tooltip } from "@chakra-ui/react";
 import EditableCell from "./EditableCell";
 import { StoryLine } from "./Autosave";
 import { getStatusVariant } from "../../utils/StatusUtils";
+import TRANSLATION_PAGE_TOOL_TIP_COPY from "../../utils/Copy";
 
 export type TranslationTableProps = {
   translatedStoryLines: StoryLine[];
   editable?: boolean;
+  translator: boolean;
   onUserInput?: (
     newContent: string,
     lineIndex: number,
@@ -30,6 +32,7 @@ const TranslationTable = ({
   commentLine,
   setCommentLine,
   setCommentStoryTranslationContentId,
+  translator,
 }: TranslationTableProps) => {
   const handleCommentButton = (
     displayLineNumber: number,
@@ -38,8 +41,7 @@ const TranslationTable = ({
     setCommentLine(displayLineNumber);
     setCommentStoryTranslationContentId(storyTranslationContentId);
   };
-  const tooltipCopy =
-    "Your story translation is pending review. You can edit your translation and leave comments once a reviewer has given feedback.";
+
   const storyCells = translatedStoryLines.map((storyLine: StoryLine) => {
     const displayLineNumber = storyLine.lineIndex + 1;
     return (
@@ -62,7 +64,11 @@ const TranslationTable = ({
             fontSize={fontSize}
           />
         ) : (
-          <Tooltip hasArrow label={tooltipCopy}>
+          <Tooltip
+            hasArrow
+            label={TRANSLATION_PAGE_TOOL_TIP_COPY}
+            isDisabled={!translator}
+          >
             <Text variant="cell" fontSize={fontSize}>
               {" "}
               {storyLine.translatedContent!!}{" "}

--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Badge, Button, Flex, Text } from "@chakra-ui/react";
+import { Badge, Button, Flex, Text, Tooltip } from "@chakra-ui/react";
 import EditableCell from "./EditableCell";
 import { StoryLine } from "./Autosave";
 import { getStatusVariant } from "../../utils/StatusUtils";
@@ -38,6 +38,8 @@ const TranslationTable = ({
     setCommentLine(displayLineNumber);
     setCommentStoryTranslationContentId(storyTranslationContentId);
   };
+  const tooltipCopy =
+    "Your story translation is pending review. You can edit your translation and leave comments once a reviewer has given feedback.";
   const storyCells = translatedStoryLines.map((storyLine: StoryLine) => {
     const displayLineNumber = storyLine.lineIndex + 1;
     return (
@@ -60,10 +62,12 @@ const TranslationTable = ({
             fontSize={fontSize}
           />
         ) : (
-          <Text variant="cell" fontSize={fontSize}>
-            {" "}
-            {storyLine.translatedContent!!}{" "}
-          </Text>
+          <Tooltip hasArrow label={tooltipCopy}>
+            <Text variant="cell" fontSize={fontSize}>
+              {" "}
+              {storyLine.translatedContent!!}{" "}
+            </Text>
+          </Tooltip>
         )}
         <Flex direction="column" width="130px" margin="10px">
           <Badge

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -1,0 +1,4 @@
+const TRANSLATION_PAGE_TOOL_TIP_COPY =
+  "Your story translation is pending review. You can edit your translation and leave comments once a reviewer has given feedback.";
+
+export default TRANSLATION_PAGE_TOOL_TIP_COPY;

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -1,4 +1,5 @@
+/* eslint-disable import/prefer-default-export */
 const TRANSLATION_PAGE_TOOL_TIP_COPY =
   "Your story translation is pending review. You can edit your translation and leave comments once a reviewer has given feedback.";
 
-export default TRANSLATION_PAGE_TOOL_TIP_COPY;
+export { TRANSLATION_PAGE_TOOL_TIP_COPY };


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Disable editing on translation platform if stage is REVIEW](https://www.notion.so/uwblueprintexecs/Disable-editing-on-translation-platform-if-stage-is-REVIEW-2b719a09478146e29d2c43d2cfa64c43)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- disabled commenting, editing, and submitting when story translation is NOT in TRANSLATE state (instead of when story is in review)
- added tooltips 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Set a story to be in REVIEW through mysql CLI 
2. "Send for review" button should now show "In review", table should not be editable, commenting should be disabled 
3. Tooltips should show up on these three areas 
4. Tooltips should NOT show up when in translate, buttons, commenting, and editing should work properly 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- I personally found that the tooltips on the text cells (in the table) were felt a bit unnecessary (and even distracting) --> would like to hear other people's thoughts 
- The tooltip label is currently repeated across three files but this was in case the copy needed to be different for different components 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
