### PR TITLE
Open /review for reviewer story card "View Translation" button

### DIFF
--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -62,6 +62,7 @@ const StoryCard = ({
     // eslint-disable-next-line no-alert
     alert(errorMessage);
   };
+  const isTranslator = +authenticatedUser!!.id === translatorId;
 
   const [assignUserAsReviewer] = useMutation<{
     assignUserAsReviewer: AssignReviewerResponse;
@@ -111,9 +112,12 @@ const StoryCard = ({
     setPreview(!preview);
   };
 
-  const openTranslation = () =>
-    history.push(`/translation/${storyId}/${storyTranslationId}`);
-
+  const openTranslation = () => {
+    const storyTranslationUrl = isTranslator
+      ? `/translation/${storyId}/${storyTranslationId}`
+      : `/review/${storyId}/${storyTranslationId}`;
+    history.push(storyTranslationUrl);
+  };
   const primaryBtnText = () => {
     if (isMyStory) {
       return storyTranslationId ? "view translation" : "edit translation";
@@ -162,9 +166,7 @@ const StoryCard = ({
             )}`}</Badge>
             {isMyStory && (
               <Badge background="green.50">
-                {+authenticatedUser!!.id === translatorId
-                  ? "Translator"
-                  : "Reviewer"}
+                {isTranslator ? "Translator" : "Reviewer"}
               </Badge>
             )}
           </Flex>

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -113,10 +113,10 @@ const StoryCard = ({
   };
 
   const openTranslation = () => {
-    const storyTranslationUrl = isTranslator
-      ? `/translation/${storyId}/${storyTranslationId}`
-      : `/review/${storyId}/${storyTranslationId}`;
-    history.push(storyTranslationUrl);
+    const storyTranslationUrlBase = isTranslator ? "translation" : "review";
+    history.push(
+      `/${storyTranslationUrlBase}/${storyId}/${storyTranslationId}`,
+    );
   };
   const primaryBtnText = () => {
     if (isMyStory) {


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

["View translation" button should open to /review for homepage reviewer story card](https://www.notion.so/uwblueprintexecs/View-translation-button-should-open-to-review-for-homepage-reviewer-story-card-ed428178d71a4c8a83be6f5ce7bd183b)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Check if user is reviewer before routing to `/translation` or `/review` 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Log in as a user and navigate to the "My Work" tab
* Make sure the user is translating and reviewing at least one story (Dwight D Eisenhower is already translating and reviewing stories based on the seed script)
2. Click on the "View Translation" button for a story the user is translating; this should open up the translation platform
3. Click on the "View Translation" button for a story the user is reviewing; this should open up the review platform

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Checking that change didn't break any existing functionality

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
