### PR TITLE
Open View anibook link in new tab

### DIFF
--- a/frontend/src/components/homepage/PreviewModal.tsx
+++ b/frontend/src/components/homepage/PreviewModal.tsx
@@ -111,7 +111,9 @@ const PreviewModal = ({
         </ModalHeader>
         <Box display="block" paddingLeft="30px">
           <Text fontSize="16px" color="grey">
-            <Link href={youtubeLink}>→ Watch the English AniBook</Link>
+            <Link href={youtubeLink} isExternal>
+              → Watch the English AniBook
+            </Link>
           </Text>
         </Box>
         <ModalBody>{storyContents}</ModalBody>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[open View anibook link in new tab](https://www.notion.so/uwblueprintexecs/open-View-anibook-link-in-new-tab-ae8c1ec3f25240059b9341d003680283)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Quick one line (one prop?) change to pass in `isExternal=true` to [Chakra UI Link](https://chakra-ui.com/docs/navigation/link#external-link) to have View anibook link open in a new tab

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Pull latest changes and login to any user
2. Click on "Preview Book" button, and click "→ Watch the English AniBook"; verify that the youtube link opens in a new tab

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- `frontend\src\components\homepage\PreviewModal.tsx`
- since Chakra UI Links makes it really easy to open in a new tab, I don't think a utility is necessary; let me know if you think creating a wrapper around the Chakra UI Link component to ensure all links have an `isExternal=true` prop set by default would be useful

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
