### PR TITLE
Implement Send For Review Flow

### DIFF
--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -64,3 +64,14 @@ export const ASSIGN_REVIEWER = gql`
   }
 `;
 export type AssignReviewerResponse = { ok: boolean };
+
+export const UPDATE_STORY_TRANSLATION_STAGE = gql`
+  mutation UpdateStoryTranslationStage(
+    $storyTranslationData: UpdateStoryTranslationStageRequestDTO!
+  ) {
+    updateStoryTranslationStage(storyTranslationData: $storyTranslationData) {
+      ok
+    }
+  }
+`;
+export type UpdateStoryTranslationStageResponse = { ok: boolean };

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -1,11 +1,6 @@
 import React, { useState } from "react";
-<<<<<<< HEAD
-import { useQuery } from "@apollo/client";
-import { Box, Button, Divider, Flex, Text, Tooltip } from "@chakra-ui/react";
-=======
 import { useQuery, useMutation } from "@apollo/client";
-import { Box, Button, Divider, Flex, Text } from "@chakra-ui/react";
->>>>>>> 22dea0f... Implement Send To Translator flow
+import { Box, Button, Divider, Flex, Text, Tooltip } from "@chakra-ui/react";
 import { useParams } from "react-router-dom";
 
 import ProgressBar from "../utils/ProgressBar";
@@ -23,11 +18,8 @@ import convertLanguageTitleCase from "../../utils/LanguageUtils";
 import deepCopy from "../../utils/DeepCopyUtils";
 import Header from "../navigation/Header";
 import CommentsPanel from "../review/CommentsPanel";
-<<<<<<< HEAD
 import { TRANSLATION_PAGE_TOOL_TIP_COPY } from "../../utils/Copy";
-=======
-import SendForReviewModal2 from "../translation/SendForReviewModal";
->>>>>>> 22dea0f... Implement Send To Translator flow
+import SendForReviewModal from "../translation/SendForReviewModal";
 
 type TranslationPageProps = {
   storyIdParam: string | undefined;
@@ -294,6 +286,7 @@ const TranslationPage = () => {
                   size="secondary"
                   margin="0 10px 0"
                   disabled={!editable}
+                  onClick={onSendForReviewClick}
                 >
                   {editable ? "SEND FOR REVIEW" : "IN REVIEW"}
                 </Button>
@@ -314,9 +307,9 @@ const TranslationPage = () => {
         onSuccess={clearUnsavedChangesMap}
       />
       {sendForReview && (
-        <SendForReviewModal2
+        <SendForReviewModal
           sendForReview={sendForReview}
-          onSendForReviewClick={onSendForReviewClick}
+          onClose={onSendForReviewClick}
           onSendForReviewConfirmationClick={onSendForReviewConfirmationClick}
         />
       )}

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from "react";
+<<<<<<< HEAD
 import { useQuery } from "@apollo/client";
 import { Box, Button, Divider, Flex, Text, Tooltip } from "@chakra-ui/react";
+=======
+import { useQuery, useMutation } from "@apollo/client";
+import { Box, Button, Divider, Flex, Text } from "@chakra-ui/react";
+>>>>>>> 22dea0f... Implement Send To Translator flow
 import { useParams } from "react-router-dom";
 
 import ProgressBar from "../utils/ProgressBar";
@@ -9,12 +14,20 @@ import UndoRedo from "../translation/UndoRedo";
 import Autosave, { StoryLine } from "../translation/Autosave";
 import { convertStatusTitleCase } from "../../utils/StatusUtils";
 import { GET_STORY_AND_TRANSLATION_CONTENTS } from "../../APIClients/queries/StoryQueries";
+import {
+  UPDATE_STORY_TRANSLATION_STAGE,
+  UpdateStoryTranslationStageResponse,
+} from "../../APIClients/mutations/StoryMutations";
 import FontSizeSlider from "../translation/FontSizeSlider";
 import convertLanguageTitleCase from "../../utils/LanguageUtils";
 import deepCopy from "../../utils/DeepCopyUtils";
 import Header from "../navigation/Header";
 import CommentsPanel from "../review/CommentsPanel";
+<<<<<<< HEAD
 import { TRANSLATION_PAGE_TOOL_TIP_COPY } from "../../utils/Copy";
+=======
+import SendForReviewModal2 from "../translation/SendForReviewModal";
+>>>>>>> 22dea0f... Implement Send To Translator flow
 
 type TranslationPageProps = {
   storyIdParam: string | undefined;
@@ -123,6 +136,33 @@ const TranslationPage = () => {
 
   const clearUnsavedChangesMap = () => {
     setChangedStoryLines(new Map());
+  };
+
+  const [sendForReview, setSendForReview] = useState(false);
+  const onSendForReviewClick = async () => {
+    setSendForReview(!sendForReview);
+  };
+
+  const [updateStoryTranslationStage] = useMutation<{
+    updateStoryTranslationStage: UpdateStoryTranslationStageResponse;
+  }>(UPDATE_STORY_TRANSLATION_STAGE);
+  const onSendForReviewConfirmationClick = async () => {
+    try {
+      const storyTranslationData = {
+        id: storyTranslationId,
+        stage: "REVIEW",
+      };
+      const result = await updateStoryTranslationStage({
+        variables: { storyTranslationData },
+      });
+      if (result.data?.updateStoryTranslationStage.ok) {
+        window.location.reload(false);
+      } else {
+        window.alert("Unable to send for review.");
+      }
+    } catch (error) {
+      window.alert(error ?? "Error occurred, please try again.");
+    }
   };
 
   useQuery(GET_STORY_AND_TRANSLATION_CONTENTS(storyId, storyTranslationId), {
@@ -273,6 +313,13 @@ const TranslationPage = () => {
         storylines={Array.from(changedStoryLines.values())}
         onSuccess={clearUnsavedChangesMap}
       />
+      {sendForReview && (
+        <SendForReviewModal2
+          sendForReview={sendForReview}
+          onSendForReviewClick={onSendForReviewClick}
+          onSendForReviewConfirmationClick={onSendForReviewConfirmationClick}
+        />
+      )}
     </Flex>
   );
 };

--- a/frontend/src/components/translation/SendForReviewModal.tsx
+++ b/frontend/src/components/translation/SendForReviewModal.tsx
@@ -60,8 +60,10 @@ const SendForReviewModal = ({
             }}
           />
           <Text fontSize="16px" paddingLeft="10px" paddingRight="10px">
-            Once you send your translation for review, the action cannot be
-            undone. Please make sure that there are no mistakes.
+            Once you send your translation for review, you wont be able to edit
+            the translation or leave comments until a reviewer reviews your
+            translation. This action cannot be undone. Please make sure that
+            there are no mistakes.
           </Text>
           <Flex paddingTop="20px" paddingBottom="25px" paddingLeft="10px">
             <Button

--- a/frontend/src/components/translation/SendForReviewModal.tsx
+++ b/frontend/src/components/translation/SendForReviewModal.tsx
@@ -15,19 +15,19 @@ import {
 
 type SendForReviewModalProps = {
   sendForReview: boolean;
-  onSendForReviewClick: () => void;
+  onClose: () => void;
   onSendForReviewConfirmationClick: () => void;
 };
 
-export const SendForReviewModal = ({
+const SendForReviewModal = ({
   sendForReview,
-  onSendForReviewClick,
+  onClose,
   onSendForReviewConfirmationClick,
 }: SendForReviewModalProps) => {
   return (
     <Modal
       isOpen={sendForReview}
-      onClose={onSendForReviewClick}
+      onClose={onClose}
       motionPreset="slideInBottom"
       size="xl"
     >
@@ -47,7 +47,7 @@ export const SendForReviewModal = ({
               position="static"
               marginLeft="auto"
               borderRadius="15px"
-              backgroundColor="#F3F3F3"
+              backgroundColor="gray.100"
             />
           </Flex>
         </ModalHeader>
@@ -73,7 +73,7 @@ export const SendForReviewModal = ({
             </Button>
           </Flex>
         </ModalBody>
-        <Box bg="#1D6CA5" w="100%" p="5px" borderRadius="0 0 5px 5px" />
+        <Box bg="blue.500" w="100%" p="5px" borderRadius="0 0 5px 5px" />
       </ModalContent>
     </Modal>
   );

--- a/frontend/src/components/translation/SendForReviewModal.tsx
+++ b/frontend/src/components/translation/SendForReviewModal.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  Text,
+} from "@chakra-ui/react";
+
+type SendForReviewModalProps = {
+  sendForReview: boolean;
+  onSendForReviewClick: () => void;
+  onSendForReviewConfirmationClick: () => void;
+};
+
+export const SendForReviewModal = ({
+  sendForReview,
+  onSendForReviewClick,
+  onSendForReviewConfirmationClick,
+}: SendForReviewModalProps) => {
+  return (
+    <Modal
+      isOpen={sendForReview}
+      onClose={onSendForReviewClick}
+      motionPreset="slideInBottom"
+      size="xl"
+    >
+      <ModalOverlay />
+      <ModalContent marginTop="30vh">
+        <ModalHeader
+          paddingTop="30px"
+          paddingBottom="-10px"
+          paddingLeft="35px"
+          paddingRight="35px"
+        >
+          <Flex>
+            <Heading as="h3" size="md">
+              Are you sure?
+            </Heading>
+            <ModalCloseButton
+              position="static"
+              marginLeft="auto"
+              borderRadius="15px"
+              backgroundColor="#F3F3F3"
+            />
+          </Flex>
+        </ModalHeader>
+        <ModalBody>
+          <hr
+            style={{
+              marginLeft: "10px",
+              marginRight: "10px",
+              paddingBottom: "15px",
+            }}
+          />
+          <Text fontSize="16px" paddingLeft="10px" paddingRight="10px">
+            Once you send your translation for review, the action cannot be
+            undone. Please make sure that there are no mistakes.
+          </Text>
+          <Flex paddingTop="20px" paddingBottom="25px" paddingLeft="10px">
+            <Button
+              width="55%"
+              colorScheme="blue"
+              onClick={onSendForReviewConfirmationClick}
+            >
+              I&apos;m sure, send for review
+            </Button>
+          </Flex>
+        </ModalBody>
+        <Box bg="#1D6CA5" w="100%" p="5px" borderRadius="0 0 5px 5px" />
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default SendForReviewModal;


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Implement Send For Review Flow](https://www.notion.so/uwblueprintexecs/Implement-Send-To-Translator-flow-b235b41a9e4b43c892b17af495fdbb52)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added SendForReviewModal that opens when a user clicks Send for Review
- When modal is confirmed, story is moved to review stage and page refreshes 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Click View Translation for a story under My Work
2. Click Send for Review (modal should appear)
3. Test closing and reopening the modal
4. Click I'm Sure, Send for Review
5. Check that page refreshes
6. Check that story stage is Review in story_translations table

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does modal look good?
- Do buttons work as intended?
- Is story stage changed to review?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
