### PR TITLE
Create save status component

### DIFF
--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -234,6 +234,7 @@ const TranslationPage = () => {
               }
               translator
               setTranslatedStoryLines={setTranslatedStoryLines}
+              changedStoryLines={changedStoryLines.size}
             />
           </Flex>
           <Flex margin="20px 30px" justify="space-between" alignItems="center">

--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -24,6 +24,7 @@ export type TranslationTableProps = {
   setCommentStoryTranslationContentId: (id: number) => void;
   numApprovedLines?: number;
   setNumApprovedLines?: (numLines: number) => void;
+  changedStoryLines?: number;
 };
 
 const TranslationTable = ({
@@ -40,6 +41,7 @@ const TranslationTable = ({
   translator,
   numApprovedLines,
   setNumApprovedLines,
+  changedStoryLines,
 }: TranslationTableProps) => {
   const handleCommentButton = (
     displayLineNumber: number,
@@ -127,6 +129,11 @@ const TranslationTable = ({
           </Text>
           <Text variant="cellHeader">
             Translate to <strong>{translatedLanguage}</strong>
+            <Text as="span" variant="saveStatus">
+              {changedStoryLines === 0
+                ? "(Progress Saved)"
+                : "(Progress Saving...)"}
+            </Text>
           </Text>
         </Flex>
         <Text variant="statusHeader">Status</Text>

--- a/frontend/src/theme/components/Text.ts
+++ b/frontend/src/theme/components/Text.ts
@@ -26,6 +26,11 @@ const Text = {
     comment: {
       fontSize: "14px",
     },
+    saveStatus: {
+      color: "gray.400",
+      fontSize: "16px",
+      marginLeft: "10px",
+    },
   },
 };
 export default Text;


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Create save status component](https://www.notion.so/uwblueprintexecs/Create-Save-status-component-a9c1daa9d59548b3aff85cbe109e6902)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added `Progress Saved`/`Progress Saving...` text to indicate when translator edits are saved

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as a user who is translating a story
2. Go to the translation platform 
3. Enter some text and verify that the progress status changes from `Progress Saved` to `Progress Saving...`
4. Wait until the text says `Progress Saved` again
5. Refresh the page and verify that changes persist
![save status](https://user-images.githubusercontent.com/32009013/135553002-e973ecaf-de65-49c7-ac24-a55100e6e3cf.gif)
<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?
- `frontend/src/components/translation/TranslationTable.tsx`
- still waiting on thumbs up from #planetread-design

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
