### PR TITLE
Fix bug where 'Progress Saving' indicator appears on Review Page

### DIFF
--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -129,11 +129,13 @@ const TranslationTable = ({
           </Text>
           <Text variant="cellHeader">
             Translate to <strong>{translatedLanguage}</strong>
-            <Text as="span" variant="saveStatus">
-              {changedStoryLines === 0
-                ? "(Progress Saved)"
-                : "(Progress Saving...)"}
-            </Text>
+            {editable && (
+              <Text as="span" variant="saveStatus">
+                {changedStoryLines === 0
+                  ? "(Progress Saved)"
+                  : "(Progress Saving...)"}
+              </Text>
+            )}
           </Text>
         </Flex>
         <Text variant="statusHeader">Status</Text>


### PR DESCRIPTION
Made a quick bug fix to prevent 'Progress Saving...' indicator from appearing on the review page. 

## Checklist
![image](https://user-images.githubusercontent.com/54864799/135702539-d9b1ffd5-e8dd-4489-9e71-3be5f9cf0d3e.png)

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
