### PR TITLE
Fix seed script empty translation bug

### DIFF
--- a/backend/python/tools/insert_test_data.py
+++ b/backend/python/tools/insert_test_data.py
@@ -112,7 +112,7 @@ def insert_test_data():
 
     empty_translation = [1, 4, 6, 8, 9, 10, 12]
     for story_translation_id in empty_translation:
-        for line_index in range(9):
+        for line_index in range(10):
             id = story_count * 10 + line_index + 1
             db.engine.execute(
                 f'INSERT IGNORE INTO story_translation_contents \


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Add 10 empty lines to story translation contents instead of 9 empty lines in seed script

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Run (inside of backend container): `python -m tools.insert_test_data erase` and `python -m tools.insert_test_data`
2. Verify that story translation platform works properly (this should fix the bug where the last line in the translation table doesn't render properly)
![image](https://user-images.githubusercontent.com/32009013/135772815-e6dbe77c-42b1-4b9a-b1a3-7f8644bcc895.png)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
