### PR TITLE
Generalize story role auth middleware

### DIFF
--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ...middlewares.auth import require_authorization_as_story_translator
+from ...middlewares.auth import require_authorization_as_story_user_by_role
 from ...models.story_translation_content_status import StoryTranslationContentStatus
 from ..service import services
 from ..types.story_type import (
@@ -73,7 +73,7 @@ class UpdateStoryTranslationContents(graphene.Mutation):
 
     story = graphene.Field(lambda: graphene.List(StoryTranslationContentResponseDTO))
 
-    @require_authorization_as_story_translator()
+    @require_authorization_as_story_user_by_role(as_translator=True)
     def mutate(root, info, story_translation_contents):
         try:
             new_story_translation_contents = services[
@@ -91,7 +91,8 @@ class UpdateStoryTranslationContentStatus(graphene.Mutation):
         status = graphene.String(required=True)
 
     story = graphene.Field(lambda: StoryTranslationUpdateStatusResponseDTO)
-    # TODO: require authorization as reviewer
+
+    @require_authorization_as_story_user_by_role(as_translator=False)
     def mutate(root, info, story_translation_content_id, status):
         try:
             new_story = services["story"].update_story_translation_content_status(


### PR DESCRIPTION
## Notion ticket link

oops there is none

## Implementation description

- generalized `require_authorization_as_story_translator` to `require_authorization_as_story_user_by_role` for flexibility on both roles

## Steps to test
**erase and reseed database.** 
1. log in as planetread+dwightdeisenhower@uwblueprint.org
2. http://localhost:3000/translation/6/13
3. attempt to change translation (fail, he is not translator)
2. `docker exec -it planet-read_db_1 /bin/bash
`2. `mysql -u root -proot`
3. `UPDATE story_translations SET stage = 'REVIEW' where id =13;`
5. http://localhost:3000/review/6/13
6. attempt to change status (pass, he is reviewer)
7. http://localhost:3000/translation/4/8
8. attempt to change translation (pass, he is reviewer)
9. http://localhost:3000/review/4/8
10. attempt to change status (and fail, he is not reviewer)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- is the middleware clear and resusable?

## Checklist

- [ x ] My PR name is descriptive and in imperative tense
- [ x ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ x ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [ x ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
