### PR TITLE
Fix bug where confirmation modal pops up unintentionally

### DIFF
--- a/frontend/src/components/review/StatusBadge.tsx
+++ b/frontend/src/components/review/StatusBadge.tsx
@@ -74,12 +74,16 @@ const StatusBadge = ({
   };
 
   const handleStatusChange = (newStatus: string) => {
+    const prevStatus = translatedStoryLines[storyLine.lineIndex].status;
+
     if (
-      newStatus !== "APPROVED" ||
-      numApprovedLines + 1 < translatedStoryLines.length
+      prevStatus !== convertStatusTitleCase(newStatus) &&
+      (newStatus !== "APPROVED" ||
+        numApprovedLines + 1 < translatedStoryLines.length)
     ) {
       changeStatus(newStatus);
     } else if (
+      prevStatus !== convertStatusTitleCase(newStatus) &&
       newStatus === "APPROVED" &&
       numApprovedLines + 1 === translatedStoryLines.length
     ) {


### PR DESCRIPTION
Found a bug on the status pill where the confirmation modal shows up if the reviewer wants to approve a line that is already approved. This is not intended behaviour as we only want the modal to show up when the reviewer wants to approve the last unapproved line. 

(Video for context) 
https://drive.google.com/file/d/13UxguDck9zsVMCuKmKwtqWJ-Ka6l_XcC/view?usp=sharing 