### PR TITLE
Style preview modal according to hi-fi designs

### DIFF
--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -122,7 +122,7 @@ const StoryCard = ({
     if (isMyStory) {
       return storyTranslationId ? "view translation" : "edit translation";
     }
-    return storyTranslationId ? "review book" : "translate book";
+    return storyTranslationId ? "review" : "translate";
   };
 
   const primaryBtnOnClick = () => {
@@ -200,6 +200,7 @@ const StoryCard = ({
       {preview && (
         <PreviewModal
           storyId={storyId}
+          storyTranslationId={storyTranslationId}
           title={title}
           youtubeLink={youtubeLink}
           level={level}

--- a/frontend/src/theme/components/Badge.ts
+++ b/frontend/src/theme/components/Badge.ts
@@ -20,6 +20,19 @@ const Badge = {
       backgroundColor: "green.50",
       color: "green.100",
     },
+    stage: {
+      backgroundColor: "blue.50",
+    },
+    language: {
+      backgroundColor: "gray.200",
+    },
+  },
+  sizes: {
+    s: {
+      fontSize: "xs",
+      marginLeft: "0px",
+      marginRight: "15px",
+    },
   },
 };
 export default Badge;

--- a/frontend/src/theme/components/Text.ts
+++ b/frontend/src/theme/components/Text.ts
@@ -10,13 +10,13 @@ const Text = {
     },
     cellHeader: {
       borderRadius: "3px",
-      width: "100%",
       margin: "12px",
+      width: "100%",
     },
     lineIndex: {
       fontSize: "16px",
-      minWidth: "40px",
       margin: "12px",
+      minWidth: "40px",
     },
     statusHeader: {
       fontSize: "16px",
@@ -30,6 +30,20 @@ const Text = {
       color: "gray.400",
       fontSize: "16px",
       marginLeft: "10px",
+    },
+    previewModalLineIndex: {
+      minWidth: "30px",
+      margin: "10px",
+    },
+    previewModalTranslationContent: {
+      border: "1px solid",
+      borderColor: "gray.300",
+      borderRadius: "3px",
+      color: "gray.500",
+      fontSize: "16px",
+      padding: "10px",
+      margin: "12px",
+      width: "100%",
     },
   },
 };

--- a/frontend/src/utils/StatusUtils.ts
+++ b/frontend/src/utils/StatusUtils.ts
@@ -26,4 +26,19 @@ function getStatusVariant(status: string | undefined) {
   }
 }
 
-export { convertStatusTitleCase, getStatusVariant };
+const getLevelVariant = (level: number) => {
+  switch (level) {
+    case 1:
+      return "green.50";
+    case 2:
+      return "red.50";
+    case 3:
+      return "purple.50";
+    case 4:
+      return "orange.50";
+    default:
+      return "green.50";
+  }
+};
+
+export { convertStatusTitleCase, getStatusVariant, getLevelVariant };


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Style Preview Modal](https://www.notion.so/uwblueprintexecs/Style-preview-modal-according-to-hi-fi-designs-cc078c98da544fc4a40fab0127bdaae5)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Style the preview modal according to design document 
- Add new option to preview story translation by displaying both the original story and the translated content 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Open the preview modal on a story from the 'Browse Stories' tab and ensure styling is consistent 
2. Open the preview modal on a story translation and ensure that the styling is consistent 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Styling matches design document 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
