### PR TITLE
Fix ButtonRadioGroup bug

### DIFF
--- a/frontend/src/components/homepage/Filter.tsx
+++ b/frontend/src/components/homepage/Filter.tsx
@@ -53,7 +53,7 @@ const Filter = ({
     // if user isn't permitted to translate/review in the same language, default
     // to the first language
     if (!Object.keys(newApprovedLanguages).find((x) => x === language)) {
-      newLanguage = Object.keys(newApprovedLanguages)[0];
+      [newLanguage] = Object.keys(newApprovedLanguages);
     }
     setIsTranslator(nextRole === "Translator");
     setLanguage(newLanguage);
@@ -61,6 +61,7 @@ const Filter = ({
 
   const handleLevelChangeStr = (nextLevel: string) => {
     setLevel(parseInt(nextLevel.replace("Level ", ""), 10));
+    // handle level change
   };
 
   const languageOptions = isDisabled ? (
@@ -125,6 +126,7 @@ const Filter = ({
           onChange={handleLevelChangeStr}
           defaultValue={`Level ${level}`}
           isDisabled={isDisabled}
+          language={language}
         />
       </Box>
     </Flex>

--- a/frontend/src/components/homepage/Filter.tsx
+++ b/frontend/src/components/homepage/Filter.tsx
@@ -61,7 +61,6 @@ const Filter = ({
 
   const handleLevelChangeStr = (nextLevel: string) => {
     setLevel(parseInt(nextLevel.replace("Level ", ""), 10));
-    // handle level change
   };
 
   const languageOptions = isDisabled ? (

--- a/frontend/src/components/utils/ButtonRadioGroup.tsx
+++ b/frontend/src/components/utils/ButtonRadioGroup.tsx
@@ -1,6 +1,6 @@
 /*  eslint react/jsx-props-no-spreading: 0 */
 /*  eslint react/destructuring-assignment: 0 */
-import React from "react";
+import React, { useEffect } from "react";
 import {
   Box,
   Flex,
@@ -47,6 +47,7 @@ export type ButtonRadioGroupProps = {
   isDisabled?: boolean;
   options: string[];
   onChange: (newState: string) => void;
+  language?: string;
 };
 
 function ButtonRadioGroup({
@@ -57,15 +58,23 @@ function ButtonRadioGroup({
   defaultValue,
   isDisabled = false,
   options,
+  language,
   onChange,
 }: ButtonRadioGroupProps) {
-  const { getRootProps, getRadioProps } = useRadioGroup({
+  const { getRootProps, getRadioProps, setValue } = useRadioGroup({
     name,
     defaultValue,
     onChange,
   });
 
   const group = getRootProps();
+
+  useEffect(() => {
+    if (!options.includes(defaultValue)) {
+      onChange(options[options.length - 1]);
+      setValue(options[options.length - 1]);
+    }
+  }, [language]);
 
   return (
     <Flex direction={stacked ? "column" : "row"} {...group}>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Set default value in  ButtonRadioGroup](https://www.notion.so/uwblueprintexecs/Set-default-value-in-ButtonRadioGroup-271b5ab56e2346adb6c598d96efec24a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added an event listener for when the language is changed -- checks that if the selected level is not part of the options, it updates to the max available option 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test
![Oct-10-2021 18-57-45](https://user-images.githubusercontent.com/37675216/136722820-c1708ec9-be22-470c-8b93-67a5f8518dc3.gif)

1. Login as a user who has at least two different approved languages for either translation/review 
2. On the homepage, filter select the max level on the language with the higher level, and then switch to the language with a lower approved level

The level should automatically update to the highest possible level, and this should be accurately displayed in the displayed stories (look at badges). 


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
