### PR TITLE
Fix: Correctly format LoginWithGoogle mutation for functional google login/signup

### DIFF
--- a/backend/python/app/graphql/mutations/auth_mutation.py
+++ b/backend/python/app/graphql/mutations/auth_mutation.py
@@ -110,8 +110,8 @@ class LoginWithGoogle(graphene.Mutation):
             last_name = auth_dto.last_name
             role = auth_dto.role
             email = auth_dto.email
-            approved_languages_translation = (auth_dto.approved_languages_translation,)
-            approved_languages_review = (auth_dto.approved_languages_review,)
+            approved_languages_translation = auth_dto.approved_languages_translation
+            approved_languages_review = auth_dto.approved_languages_review
 
             return LoginWithGoogle(
                 access_token,

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -15,9 +15,12 @@ import { buildHomePageStoriesQuery } from "../../APIClients/queries/StoryQueries
 const HomePage = () => {
   const { authenticatedUser } = useContext(AuthContext);
 
-  const approvedLanguagesTranslation = JSON.parse(
-    authenticatedUser!!.approvedLanguagesTranslation.replace(/'/g, '"'),
-  );
+  const approvedLanguagesTranslation = authenticatedUser!!
+    .approvedLanguagesTranslation
+    ? JSON.parse(
+        authenticatedUser!!.approvedLanguagesTranslation.replace(/'/g, '"'),
+      )
+    : {};
 
   const approvedLanguagesReview = authenticatedUser!!.approvedLanguagesReview
     ? JSON.parse(authenticatedUser!!.approvedLanguagesReview.replace(/'/g, '"'))


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- For users with no approved languages (eg brand new users), LoginWithGoogle would return approved languages like `(None,)` rather than `null` in json.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as `planetread@uwblueprint.com` through gmail.
2. using the google button, login to our web app. observe successful login
3. open o[ur firebase user auth platform](https://console.firebase.google.com/u/5/project/planet-read-uwbp/authentication/users). delete the user with email `planetread@uwblueprint.com`
4. using the google button, login to our web app. observe successful signup
5. **log in using email and password (using an account that signuped with email& password)**
6. **verify that everything behaves as usual**

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
