### PR TITLE
Implement admin Header

### DIFF
--- a/frontend/src/components/admin/ManageReviewers.tsx
+++ b/frontend/src/components/admin/ManageReviewers.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const ManageReviewers = () => {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <h1>ManageReviewers Page :)</h1>
+    </div>
+  );
+};
+
+export default ManageReviewers;

--- a/frontend/src/components/admin/ManageStoryTranslations.tsx
+++ b/frontend/src/components/admin/ManageStoryTranslations.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const ManageStoryTranslations = () => {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <h1>ManageStoryTranslations Page :)</h1>
+    </div>
+  );
+};
+
+export default ManageStoryTranslations;

--- a/frontend/src/components/admin/ManageTranslators.tsx
+++ b/frontend/src/components/admin/ManageTranslators.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const ManageTranslators = () => {
+  return (
+    <div style={{ textAlign: "center" }}>
+      <h1>ManageTranslators Page :)</h1>
+    </div>
+  );
+};
+
+export default ManageTranslators;

--- a/frontend/src/components/navigation/Header.tsx
+++ b/frontend/src/components/navigation/Header.tsx
@@ -1,23 +1,80 @@
 import React from "react";
-import { Flex, Heading, Image } from "@chakra-ui/react";
+import { Button, Flex, Heading, Image } from "@chakra-ui/react";
 import Logo from "../../assets/planet-read-logo.svg";
 import PlaceholderUserIcon from "../../assets/user-icon.svg";
 
+export enum AdminPageOption {
+  StoryTranslations = 1,
+  Translators,
+  Reviewers,
+}
+
 export type HeaderProps = {
   title?: string;
+  adminPageOption?: AdminPageOption;
+  setAdminPageOption?: (val: AdminPageOption) => void;
 };
 
-const Header = ({ title }: HeaderProps) => {
+const Header = ({
+  title,
+  adminPageOption,
+  setAdminPageOption,
+}: HeaderProps) => {
   return (
-    <Flex justify="space-between" alignItems="center" margin="20px 30px">
-      <Flex width="300px" justify="flex-start" alignItems="center">
-        <Heading size="md" marginRight="10px">
+    <Flex
+      justify="space-between"
+      alignItems="stretch"
+      boxShadow="0px -9px 10px black"
+    >
+      <Flex margin="0px 30px">
+        <Heading size="md" margin="10px">
           Add my Language
         </Heading>
         <Image width="40px" src={Logo} alt="Planet read logo" />
       </Flex>
-      <Heading size="lg">{title || ""}</Heading>
-      <Flex width="300px" justify="flex-end">
+
+      {title && (
+        <Heading size="lg" margin="10px">
+          {title}
+        </Heading>
+      )}
+      {adminPageOption && setAdminPageOption && (
+        <Flex alignItems="flex-end">
+          <Button
+            variant={
+              adminPageOption === AdminPageOption.StoryTranslations
+                ? "headerSelect"
+                : "header"
+            }
+            onClick={() => {
+              setAdminPageOption(AdminPageOption.StoryTranslations);
+            }}
+          >
+            Manage Story Translations
+          </Button>
+          <Button
+            variant={
+              adminPageOption === AdminPageOption.Translators
+                ? "headerSelect"
+                : "header"
+            }
+            onClick={() => setAdminPageOption(AdminPageOption.Translators)}
+          >
+            Manage Translators
+          </Button>
+          <Button
+            variant={
+              adminPageOption === AdminPageOption.Reviewers
+                ? "headerSelect"
+                : "header"
+            }
+            onClick={() => setAdminPageOption(AdminPageOption.Reviewers)}
+          >
+            Manage Reviewers
+          </Button>
+        </Flex>
+      )}
+      <Flex width="300px" justify="flex-end" margin="0px 30px">
         <Image width="40px" src={PlaceholderUserIcon} alt="User icon" />
       </Flex>
     </Flex>

--- a/frontend/src/components/pages/AdminPage.tsx
+++ b/frontend/src/components/pages/AdminPage.tsx
@@ -12,16 +12,12 @@ const AdminPage = () => {
     switch (adminPgOption) {
       case AdminPageOption.StoryTranslations:
         return <ManageStoryTranslations />;
-        break;
       case AdminPageOption.Translators:
         return <ManageTranslators />;
-        break;
       case AdminPageOption.Reviewers:
         return <ManageReviewers />;
-        break;
       default:
         return <ManageStoryTranslations />;
-        break;
     }
   };
   return (

--- a/frontend/src/components/pages/AdminPage.tsx
+++ b/frontend/src/components/pages/AdminPage.tsx
@@ -1,10 +1,37 @@
-import React from "react";
+import React, { useState } from "react";
+import Header, { AdminPageOption } from "../navigation/Header";
+import ManageStoryTranslations from "../admin/ManageStoryTranslations";
+import ManageTranslators from "../admin/ManageTranslators";
+import ManageReviewers from "../admin/ManageReviewers";
 
 const AdminPage = () => {
+  const [adminPageOption, setAdminPageOption] = useState(
+    AdminPageOption.StoryTranslations,
+  );
+  const bodyComponent = (adminPgOption: AdminPageOption) => {
+    switch (adminPgOption) {
+      case AdminPageOption.StoryTranslations:
+        return <ManageStoryTranslations />;
+        break;
+      case AdminPageOption.Translators:
+        return <ManageTranslators />;
+        break;
+      case AdminPageOption.Reviewers:
+        return <ManageReviewers />;
+        break;
+      default:
+        return <ManageStoryTranslations />;
+        break;
+    }
+  };
   return (
-    <div style={{ textAlign: "center" }}>
-      <h1>Admin Page :)</h1>
-    </div>
+    <>
+      <Header
+        adminPageOption={adminPageOption}
+        setAdminPageOption={setAdminPageOption}
+      />
+      {bodyComponent(adminPageOption)}
+    </>
   );
 };
 

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -51,6 +51,23 @@ const Button = {
       right: "10px",
       width: "50px",
     },
+    header: {
+      background: "transparent",
+      fontWeight: "lighter",
+      padding: "30px",
+      textTransform: "capitalize",
+      width: "fit-content",
+    },
+    headerSelect: {
+      background: "transparent",
+      borderRadius: "0px",
+      borderBottom: "3px solid",
+      borderBottomColor: "blue.100",
+      color: "blue.100",
+      padding: "30px",
+      textTransform: "capitalize",
+      width: "fit-content",
+    },
   },
 };
 export default Button;

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -64,7 +64,7 @@ const Button = {
       borderBottom: "3px solid",
       borderBottomColor: "blue.100",
       color: "blue.100",
-      padding: "30px",
+      padding: "30px 30px 27px 30px",
       textTransform: "capitalize",
       width: "fit-content",
     },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15113249/136824084-b4b23189-745f-45bd-b029-4de8bea7165e.png)
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Implement admin Header](https://www.notion.so/uwblueprintexecs/Implement-admin-Header-cf4f924ec0e04a26ac594a8cfc64dac4)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- /admin now has header options that switch what's displayed in the admin page
- the header has undergone some css changes to support this. The header appears thinner on the homepage and translation/review pages now

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. log in. observe the homepage header looks ok
2. view translation. observe the header looks ok
3. go to /admin. observe the header looks ok
4. clicking the different tabs should switch the component in the body of the admin page

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work
## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
