### PR TITLE
Create Translators/Reviewers Table

### DIFF
--- a/frontend/src/APIClients/queries/UserQueries.ts
+++ b/frontend/src/APIClients/queries/UserQueries.ts
@@ -1,0 +1,32 @@
+import { gql } from "@apollo/client";
+
+export type User = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  approvedLanguagesTranslation: string;
+  approvedLanguagesReview: string;
+} | null;
+
+export const buildUsersQuery = () => {
+  // TODO: Modify when users query is modified
+  return {
+    fieldName: "users",
+    string: gql`
+      query Users {
+        users {
+          id
+          firstName
+          lastName
+          role
+          email
+          resume
+          profilePic
+          approvedLanguagesTranslation
+          approvedLanguagesReview
+        }
+      }
+    `,
+  };
+};

--- a/frontend/src/components/admin/ManageReviewers.tsx
+++ b/frontend/src/components/admin/ManageReviewers.tsx
@@ -1,9 +1,25 @@
-import React from "react";
+import React, { useState } from "react";
+import { useQuery } from "@apollo/client";
+import { Heading } from "@chakra-ui/react";
+import UsersTable from "./UsersTable";
+import { buildUsersQuery, User } from "../../APIClients/queries/UserQueries";
 
 const ManageReviewers = () => {
+  const query = buildUsersQuery();
+  const [users, setUsers] = useState<User[]>([]);
+  useQuery(query.string, {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      setUsers(data[query.fieldName]);
+    },
+  });
   return (
     <div style={{ textAlign: "center" }}>
-      <h1>ManageReviewers Page :)</h1>
+      <Heading float="left" margin="20px 30px" size="lg">
+        Manage Reviewers
+      </Heading>
+      {/* TODO: add filter component */}
+      <UsersTable users={users} />
     </div>
   );
 };

--- a/frontend/src/components/admin/ManageTranslators.tsx
+++ b/frontend/src/components/admin/ManageTranslators.tsx
@@ -1,9 +1,25 @@
-import React from "react";
+import React, { useState } from "react";
+import { useQuery } from "@apollo/client";
+import { Heading } from "@chakra-ui/react";
+import UsersTable from "./UsersTable";
+import { buildUsersQuery, User } from "../../APIClients/queries/UserQueries";
 
 const ManageTranslators = () => {
+  const query = buildUsersQuery();
+  const [users, setUsers] = useState<User[]>([]);
+  useQuery(query.string, {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      setUsers(data[query.fieldName]);
+    },
+  });
   return (
     <div style={{ textAlign: "center" }}>
-      <h1>ManageTranslators Page :)</h1>
+      <Heading float="left" margin="20px 30px" size="lg">
+        Manage Translators
+      </Heading>
+      {/* TODO: add filter component */}
+      <UsersTable isTranslators users={users} />
     </div>
   );
 };

--- a/frontend/src/components/admin/UsersTable.tsx
+++ b/frontend/src/components/admin/UsersTable.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+
+import { Icon } from "@chakra-ui/icon";
+import { MdDelete } from "react-icons/md";
+import {
+  Badge,
+  Link,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  IconButton,
+} from "@chakra-ui/react";
+import { User } from "../../APIClients/queries/UserQueries";
+import convertLanguageTitleCase from "../../utils/LanguageUtils";
+
+export type UsersTableProps = {
+  isTranslators?: boolean;
+  users: User[];
+};
+
+const UsersTable = ({ isTranslators = false, users }: UsersTableProps) => {
+  const approvedLanguages = users.map((userObj: User) => {
+    const approvedLanguage = isTranslators
+      ? userObj?.approvedLanguagesTranslation
+      : userObj?.approvedLanguagesReview;
+    return approvedLanguage
+      ? JSON.parse(approvedLanguage!!.trim().replace(/'/g, '"'))
+      : "";
+  });
+
+  const generateBadges = (appvdLanguages: any) =>
+    Object.keys(appvdLanguages).map((apprLang: string) => (
+      // TODO: determine badge color by label
+      <Badge
+        background="orange.50"
+        marginBottom="3px"
+        marginTop="3px"
+      >{`${convertLanguageTitleCase(apprLang)} | Level ${
+        appvdLanguages[apprLang]
+      }`}</Badge>
+    ));
+
+  const tableBody = users.map((userObj: User, index: number) => (
+    <Tr
+      borderBottom={index === users.length - 1 ? "1em solid transparent" : ""}
+    >
+      <Td>
+        <Link
+          isExternal
+          href={`/user/${userObj?.id}`}
+        >{`${userObj?.firstName} ${userObj?.lastName}`}</Link>
+      </Td>
+      <Td>
+        <Link href={`mailto:${userObj?.email}`}>{userObj?.email}</Link>
+      </Td>
+      <Td>{generateBadges(approvedLanguages[index])}</Td>
+      {/* TODO: make delete button functional */}
+      <Td>
+        <IconButton
+          aria-label={`Delete user ${userObj?.firstName} ${userObj?.lastName}`}
+          background="transparent"
+          icon={<Icon as={MdDelete} />}
+          width="fit-content"
+        />
+      </Td>
+    </Tr>
+  ));
+  return (
+    <Table
+      borderRadius="12px"
+      borderCollapse="collapse"
+      borderSpacing="0px"
+      boxShadow="0px 0px 2px grey"
+      margin="auto"
+      size="sm"
+      theme="gray"
+      variant="striped"
+      width="95%"
+    >
+      <Thead>
+        <Tr
+          borderTop="1em solid transparent"
+          borderBottom="0.5em solid transparent"
+        >
+          <Th>NAME</Th>
+          <Th>EMAIL</Th>
+          <Th>APPROVED LANGUAGES</Th>
+          <Th>ACTION</Th>
+        </Tr>
+      </Thead>
+      <Tbody>{tableBody}</Tbody>
+    </Table>
+  );
+};
+
+export default UsersTable;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15113249/137062401-3898b813-f375-4776-85c8-913c4805c24b.png)

## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Create Translators/Reviewers Table](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=4412841e4ef34210968a3aec024b7b07)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- used current `users` query for now
- added `UserTable`, flexible with `Translators` and `Reviewers` screens

**note** that
- name column does not sort
- delete user button does nothing
- there is no pagination

Tickets in our task board will be updated accordingly based on what is left over to complete

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login and go to /admin
2. view manage translators and manage stories
3. admire the lit af tables 🔥 
4. hover and click a user's name. observe that it takes you to their user page
5. hover and click a user's email. observe that it opens your email client to the user's email
6. observe that the APPROVED LANGUAGES column displays approvedLanguagesTranslation or approvedLanguagesReview based on which admin page tab is selected 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- theres no way to make margins in tables. Convoluted transparent borders are the only way
- sorting by name is not implemented
- delete user button does nothing
- there is no pagination

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
