### PR TITLE
Use correct badge styles

### DIFF
--- a/frontend/src/components/admin/UsersTable.tsx
+++ b/frontend/src/components/admin/UsersTable.tsx
@@ -15,6 +15,7 @@ import {
 } from "@chakra-ui/react";
 import { User } from "../../APIClients/queries/UserQueries";
 import convertLanguageTitleCase from "../../utils/LanguageUtils";
+import { getLevelVariant } from "../../utils/StatusUtils";
 
 export type UsersTableProps = {
   isTranslators?: boolean;
@@ -33,9 +34,8 @@ const UsersTable = ({ isTranslators = false, users }: UsersTableProps) => {
 
   const generateBadges = (appvdLanguages: any) =>
     Object.keys(appvdLanguages).map((apprLang: string) => (
-      // TODO: determine badge color by label
       <Badge
-        background="orange.50"
+        background={getLevelVariant(appvdLanguages[apprLang])}
         marginBottom="3px"
         marginTop="3px"
       >{`${convertLanguageTitleCase(apprLang)} | Level ${

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -13,6 +13,7 @@ import {
 import AuthContext from "../../contexts/AuthContext";
 import PreviewModal from "./PreviewModal";
 import convertLanguageTitleCase from "../../utils/LanguageUtils";
+import { getLevelVariant } from "../../utils/StatusUtils";
 import {
   ASSIGN_REVIEWER,
   AssignReviewerResponse,
@@ -160,12 +161,14 @@ const StoryCard = ({
         <Flex direction="column" wrap="wrap">
           <Heading size="md">{title}</Heading>
           <Flex direction="row" paddingBottom="10px">
-            <Badge background="orange.50">{`Level ${level}`}</Badge>
-            <Badge background="purple.50">{`${convertLanguageTitleCase(
+            <Badge
+              background={getLevelVariant(level)}
+            >{`Level ${level}`}</Badge>
+            <Badge variant="language">{`${convertLanguageTitleCase(
               language,
             )}`}</Badge>
             {isMyStory && (
-              <Badge background="green.50">
+              <Badge variant="role">
                 {isTranslator ? "Translator" : "Reviewer"}
               </Badge>
             )}

--- a/frontend/src/theme/components/Badge.ts
+++ b/frontend/src/theme/components/Badge.ts
@@ -23,6 +23,9 @@ const Badge = {
     stage: {
       backgroundColor: "blue.50",
     },
+    role: {
+      backgroundColor: "blue.50",
+    },
     language: {
       backgroundColor: "gray.200",
     },


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/15113249/137569029-5fb4f181-c7c7-4825-82a8-3217e0cb1a3e.png)
![image](https://user-images.githubusercontent.com/15113249/137569038-cae8123e-ec7e-48ca-80e9-ffcc5e7654a5.png)

## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Display correct language badge colors on UserTable](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=92be83d79e2d4a49900ca36c358c0dde)
(did not make separate ticket for StoryCard)
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- use variants `language` and `stage`
- make and use variant `role`
- use `getLevelVariant`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login
2. look at story cards. noice
3. go to /admin. look at manage translators and manage reviewers. noice

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it look pwetty uwu

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
