### PR TITLE
Return translator name and reviewer name in getStoryTranslations

### DIFF
--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -75,6 +75,8 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
     level = graphene.Int(required=True)
     num_translated_lines = graphene.Int()
     num_approved_lines = graphene.Int()
+    translator_name = graphene.String()
+    reviewer_name = graphene.String()
 
 
 class StoryTranslationUpdateStatusResponseDTO(graphene.ObjectType):


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Return translator name and reviewer name in getStoryTranslations](https://www.notion.so/uwblueprintexecs/Return-translator-name-and-reviewer-name-in-getStoryTranslations-70e77a15524f4f8cbf11c1991450e8d7)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Updated `getStoryTranslations` to return translator/reviewer full name

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin
2. Test that translator and reviewer full names are returned in getStoryTranslations [query](http://localhost:5000/graphql?query=%7B%0A%20%20storyTranslations%20(storyTitle%3A%20%22and%22)%20%7B%0A%20%20%20%20title%0A%20%20%20%20id%0A%20%20%20%20description%0A%20%20%20%20level%0A%20%20%20%20language%0A%20%20%20%20stage%0A%20%20%20%20translatorId%0A%20%20%20%20reviewerId%0A%20%20%20%20translator%0A%20%20%20%20reviewer%0A%20%20%7D%0A%7D%0A)
3. Play around with the filters to ensure joining with users table didn't break anything

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- is it unclear that `translator` and `reviewer` are names (would something like `translator_name` be better)?
   -  or should first name/last name be returned separately? (`translator_fname`, `translator_lname`)
- `StoryTranslationResponseDTO` is used in multiple queries; I did not modify anything other than `get_story_translations` so `translator`/`reviewer` will always be null in the response even if there is a translator/reviewer, is that okay? (e.g. in `storyTranslationsAvailableForReview`)

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
