### PR TITLE
Stick to prop styling for chakraui components

### DIFF
--- a/frontend/src/components/admin/ManageStoryTranslations.tsx
+++ b/frontend/src/components/admin/ManageStoryTranslations.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
-import { Heading } from "@chakra-ui/react";
+import { Box, Heading } from "@chakra-ui/react";
 import StoryTranslationsTable from "./StoryTranslationsTable";
 import {
   buildStoriesQuery,
@@ -19,12 +19,12 @@ const ManageStoryTranslations = () => {
     },
   });
   return (
-    <div style={{ textAlign: "center" }}>
+    <Box textAlign="center">
       <Heading float="left" margin="20px 30px" size="lg">
         Manage Story Translations
       </Heading>
       <StoryTranslationsTable storyTranslations={storyTranslations} />
-    </div>
+    </Box>
   );
 };
 

--- a/frontend/src/components/admin/ManageUsers.tsx
+++ b/frontend/src/components/admin/ManageUsers.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
-import { Flex, Heading } from "@chakra-ui/react";
+import { Box, Flex, Heading } from "@chakra-ui/react";
 import UsersTable, { alphabeticalCompare } from "./UsersTable";
 import { buildUsersQuery, User } from "../../APIClients/queries/UserQueries";
 import UsersTableFilter from "./UsersTableFilter";
@@ -31,7 +31,7 @@ const ManageUsers = ({ isTranslators }: ManageUsersProps) => {
     },
   });
   return (
-    <div style={{ textAlign: "center" }}>
+    <Box textAlign="center">
       <Flex>
         <Heading float="left" margin="20px 30px" size="lg">
           {`Manage ${isTranslators ? "Translators" : "Reviewers"}`}
@@ -50,7 +50,7 @@ const ManageUsers = ({ isTranslators }: ManageUsersProps) => {
         users={users}
         setUsers={setUsers}
       />
-    </div>
+    </Box>
   );
 };
 

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -149,7 +149,7 @@ const StoryCard = ({
         }}
       >
         <iframe
-          style={{ width: "100%" }}
+          width="100%"
           src={embedLink(youtubeLink)}
           title="YouTube video player"
           frameBorder="0"

--- a/frontend/src/components/pages/ManageStoryTranslationPage.tsx
+++ b/frontend/src/components/pages/ManageStoryTranslationPage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useParams } from "react-router-dom";
+import { Box } from "@chakra-ui/react";
 
 type ManageStoryTranslationPageProps = {
   storyIdParam: string | undefined;
@@ -13,11 +14,11 @@ const ManageStoryTranslationPage = () => {
   } = useParams<ManageStoryTranslationPageProps>();
 
   return (
-    <div style={{ textAlign: "center" }}>
+    <Box textAlign="center">
       <h1>
         Manage story translation {storyIdParam} {storyTranslationIdParam} :)
       </h1>
-    </div>
+    </Box>
   );
 };
 

--- a/frontend/src/components/pages/NotFound.tsx
+++ b/frontend/src/components/pages/NotFound.tsx
@@ -1,10 +1,11 @@
 import React from "react";
+import { Box } from "@chakra-ui/react";
 
 const NotFound = () => {
   return (
-    <div style={{ textAlign: "center" }}>
+    <Box textAlign="center">
       <h1>404 Not Found 🙁</h1>
-    </div>
+    </Box>
   );
 };
 

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useParams } from "react-router-dom";
+import { Box } from "@chakra-ui/react";
 
 type UserProfilePageProps = {
   userId: string | undefined;
@@ -9,9 +10,9 @@ const UserProfilePage = () => {
   const { userId } = useParams<UserProfilePageProps>();
 
   return (
-    <div style={{ textAlign: "center" }}>
+    <Box textAlign="center">
       <h1>User Profile for {userId} :)</h1>
-    </div>
+    </Box>
   );
 };
 

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -69,22 +69,20 @@ const WIPComment = ({
                 ${authenticatedUser!!.lastName}`;
   return (
     <Flex
+      backgroundColor="white"
       border="1px solid"
       borderColor="blue.50"
-      padding="14px 15px"
+      borderRadius={8}
       direction="column"
-      style={{
-        borderRadius: 8,
-        width: "320px",
-      }}
-      backgroundColor="white"
+      padding="14px 15px"
+      width="320px"
     >
       <b>Line {lineIndex}</b>
       <p>{name}</p>
       <Textarea
         value={text}
         onChange={(e) => setText(e.target.value)}
-        style={{ margin: "8px 0" }}
+        margin="8px 0"
         placeholder="Comment or add others with @"
       />
       <Flex direction="row">

--- a/frontend/src/components/translation/ConfirmationModal.tsx
+++ b/frontend/src/components/translation/ConfirmationModal.tsx
@@ -55,14 +55,7 @@ const ConfirmationModal = ({
             />
           </Flex>
         </ModalHeader>
-        <ModalBody>
-          <hr
-            style={{
-              marginLeft: "10px",
-              marginRight: "10px",
-              paddingBottom: "15px",
-            }}
-          />
+        <ModalBody paddingBottom="15px">
           <Text fontSize="16px" paddingLeft="10px" paddingRight="10px">
             {confirmationMessage}
           </Text>

--- a/frontend/src/components/translation/EditableCell.tsx
+++ b/frontend/src/components/translation/EditableCell.tsx
@@ -34,12 +34,10 @@ const EditableCell = ({
         text?.length === maxChars ? "maxCharsReached" : "translationEditable"
       }
       value={text}
-      style={{
-        fontSize,
-        height,
-        flexGrow: 1,
-        overflow: "hidden",
-      }}
+      fontSize={fontSize}
+      height={height}
+      flexGrow={1}
+      overflow="hidden"
       onChange={(event) => onChange(event.target.value, lineIndex, maxChars)}
     />
   );


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Stick to prop styling for chakraui components](https://www.notion.so/uwblueprintexecs/Stick-to-prop-styling-for-chakraui-components-4e89ba21f5c445e3b9082fe401ae916e)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Update prop styling in
     - admin page
     - user profile page
     - not found page
     - story card
     - comment component
     - confirmation modal
     - translation table

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin
2. Check all changed files to make sure styling looks the same and nothing looks broken
3. Check there are no more instances of `style = {{ ... }}` in codebase

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- did i break any CSS :( 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
