### PR TITLE
return with level param only

### DIFF
--- a/backend/python/app/services/implementations/user_service.py
+++ b/backend/python/app/services/implementations/user_service.py
@@ -122,7 +122,7 @@ class UserService(IUserService):
 
         query = User.query.filter_by(role="User").filter(appr_langs.isnot(None))
 
-        if language is not None and language is not "":
+        if language:
             query = query.filter(appr_langs.contains(language))
             if level:
                 query = query.filter(appr_langs[language] == level)
@@ -149,6 +149,20 @@ class UserService(IUserService):
                     )
                 )
                 raise e
+
+        if (level is not None) and (not language):
+            if isTranslators:
+                return filter(
+                    lambda user_dto: level
+                    in user_dto.approved_languages_translation.values(),
+                    user_dtos,
+                )
+            else:
+                return filter(
+                    lambda user_dto: level
+                    in user_dto.approved_languages_review.values(),
+                    user_dtos,
+                )
 
         return user_dtos
 


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[:3](https://www.notion.so/uwblueprintexecs/Return-getUsers-with-level-param-only-aee4ad72b23947c182b9a6f951d1bcea)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- in get_users() in `\backend\python\app\services\implementations\user_service.py`, filter the list of `user_dtos` by level before returning 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to admin page and Manage Reviewers / Translators 
2. Only select the level filter parameter 
3. The resulting list of users should be all users that are approved for a language in that level 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Small PR, just make sure nothing breaks 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR

[hi](https://www.economist.com/leaders/2020/10/29/why-it-has-to-be-biden)
