### PR TITLE
Implement pagination for getStoryTranslations query

### DIFF
--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -35,7 +35,7 @@ from .queries.story_query import (
 from .queries.user_query import resolve_user_by_email, resolve_user_by_id, resolve_users
 from .types.comment_type import CommentResponseDTO
 from .types.file_type import FileDTO
-from .types.story_type import StoryResponseDTO, StoryTranslationResponseDTO
+from .types.story_type import StoryResponseDTO, StoryTranslationConnection, StoryTranslationResponseDTO
 from .types.user_type import UserDTO
 
 
@@ -74,8 +74,8 @@ class Query(graphene.ObjectType):
     file_by_id = graphene.Field(FileDTO, id=graphene.Int(required=True))
     stories = graphene.Field(graphene.List(StoryResponseDTO))
     story_by_id = graphene.Field(StoryResponseDTO, id=graphene.Int(required=True))
-    story_translations = graphene.Field(
-        graphene.List(StoryTranslationResponseDTO),
+    story_translations = graphene.relay.ConnectionField(
+        StoryTranslationConnection,
         language=graphene.String(),
         level=graphene.Int(),
         stage=graphene.String(),
@@ -150,7 +150,7 @@ class Query(graphene.ObjectType):
         )
 
     def resolve_story_translations(
-        root, info, language=None, level=None, stage=None, story_title=None
+        root, info, language=None, level=None, stage=None, story_title=None, **kwargs
     ):
         return resolve_story_translations(
             root, info, language, level, stage, story_title

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -35,7 +35,11 @@ from .queries.story_query import (
 from .queries.user_query import resolve_user_by_email, resolve_user_by_id, resolve_users
 from .types.comment_type import CommentResponseDTO
 from .types.file_type import FileDTO
-from .types.story_type import StoryResponseDTO, StoryTranslationConnection, StoryTranslationResponseDTO
+from .types.story_type import (
+    StoryResponseDTO,
+    StoryTranslationConnection,
+    StoryTranslationResponseDTO,
+)
 from .types.user_type import UserDTO
 
 

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -78,6 +78,7 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
     translator_name = graphene.String()
     reviewer_name = graphene.String()
 
+
 class StoryTranslationNode(graphene.ObjectType):
     story_translation_id = graphene.Int(required=True)
     language = graphene.String(required=True)
@@ -94,12 +95,15 @@ class StoryTranslationNode(graphene.ObjectType):
     num_approved_lines = graphene.Int()
     translator_name = graphene.String()
     reviewer_name = graphene.String()
+
     class Meta:
         interfaces = (graphene.relay.Node,)
 
+
 class StoryTranslationConnection(graphene.relay.Connection):
     class Meta:
-        node = StoryTranslationNode 
+        node = StoryTranslationNode
+
 
 class StoryTranslationUpdateStatusResponseDTO(graphene.ObjectType):
     id = graphene.Int(required=True)

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -101,9 +101,12 @@ class StoryTranslationNode(graphene.ObjectType):
 
 
 class StoryTranslationConnection(graphene.relay.Connection):
+    total_count = graphene.Int()
     class Meta:
         node = StoryTranslationNode
 
+    def resolve_total_count(root, info):
+        return len(root.iterable)  
 
 class StoryTranslationUpdateStatusResponseDTO(graphene.ObjectType):
     id = graphene.Int(required=True)

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -102,11 +102,13 @@ class StoryTranslationNode(graphene.ObjectType):
 
 class StoryTranslationConnection(graphene.relay.Connection):
     total_count = graphene.Int()
+
     class Meta:
         node = StoryTranslationNode
 
     def resolve_total_count(root, info):
-        return len(root.iterable)  
+        return len(root.iterable)
+
 
 class StoryTranslationUpdateStatusResponseDTO(graphene.ObjectType):
     id = graphene.Int(required=True)

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -78,6 +78,28 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
     translator_name = graphene.String()
     reviewer_name = graphene.String()
 
+class StoryTranslationNode(graphene.ObjectType):
+    story_translation_id = graphene.Int(required=True)
+    language = graphene.String(required=True)
+    stage = graphene.Field(StageEnum, required=True)
+    translation_contents = graphene.List(StoryTranslationContentResponseDTO)
+    translator_id = graphene.Int()
+    reviewer_id = graphene.Int()
+    story_id = graphene.Int(required=True)
+    title = graphene.String(required=True)
+    description = graphene.String(required=True)
+    youtube_link = graphene.String(required=True)
+    level = graphene.Int(required=True)
+    num_translated_lines = graphene.Int()
+    num_approved_lines = graphene.Int()
+    translator_name = graphene.String()
+    reviewer_name = graphene.String()
+    class Meta:
+        interfaces = (graphene.relay.Node,)
+
+class StoryTranslationConnection(graphene.relay.Connection):
+    class Meta:
+        node = StoryTranslationNode 
 
 class StoryTranslationUpdateStatusResponseDTO(graphene.ObjectType):
     id = graphene.Int(required=True)

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -189,6 +189,7 @@ class StoryService(IStoryService):
                     {
                         **story.to_dict(),
                         **story_translation.to_dict(include_relationships=True),
+                        "story_translation_id": story_translation.id,
                         "translator_name": (
                             f"{translator.first_name} {translator.last_name}"
                             if translator

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -64,8 +64,8 @@ class IStoryService(ABC):
         :param story_title: story_title of story translations to filter by
         likeness and return
         :param role_filter: filter to get story_translations by user_id/role
-        :return: list of StoryTranslationResponseDTO's
-        :rtype: list of StoryTranslationResponseDTO's
+        :return: list of StoryTranslationNode's
+        :rtype: list of StoryTranslationNode's
         """
         pass
 


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Paginate getStoryTranslations](https://www.notion.so/uwblueprintexecs/Paginate-getStoryTranslations-d86ce7ed0c904d469226b785af549c98)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Used graphene relay to add pagination by creating a Connection and modifying the `story_translations` query in `schema.py`
- Created a new object type called `StoryTranslationNode` that represents the returned object for a story translation

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Using the Altair client, using the following mutation to log in, then copy the access token and set the authorization header:
```
mutation Login {
  login (email:"planetread+angelamerkel@uwblueprint.org", password:".") {
    accessToken
    refreshToken
    id
  }
}
```

2. Fetch all story translations using 
```
query StoryTranslations {
  storyTranslations(first: 13) {
    edges {
      cursor
      node {
        storyTranslationId
        title
        language
        stage
      }
    }
    pageInfo {
      endCursor
      hasNextPage
    }
  }
}
```

the `hasNextPage` value should be false, indicating that there are no more story translations left.

3. Run the same query as above except using `first: 2`, verify that two results are returned. Copy the `endCursor` string.
4. Run the query using `first: 2, after: cursor` where cursor is the copied value, verify that the next two story translations are returned.
5. Play around with the combination of filters and the pagination arguments, verify that the appropriate results are returned.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?
- Do the filters work properly with the pagination
- Does the pagination behave properly

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
