### PR TITLE
Generalize filter component and create story translations filter 

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -131,12 +131,15 @@ class StoryService(IStoryService):
         )
 
     def get_story_translations(
-        self, language=None, level=None, stage=None, story_title=None, role_filter=None
+        self,
+        language=None,
+        level=None,
+        stage=None,
+        story_title=None,
+        role_filter=None,
     ):
         try:
             filters = []
-            if role_filter is not None:
-                filters.append(role_filter)
             if language is not None:
                 filters.append(StoryTranslation.language == language)
             if stage is not None:
@@ -145,6 +148,8 @@ class StoryService(IStoryService):
                 filters.append(Story.level == level)
             if story_title is not None:
                 filters.append(Story.title.like(f"%{story_title}%"))
+            if role_filter is not None:
+                filters.append(role_filter)
 
             stories = (
                 Story.query.join(

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -142,13 +142,23 @@ export type StoryTranslationEdge = {
   node: StoryTranslation;
 };
 
-export const buildStoriesQuery = () => {
-  // TODO: build out when filters added
+export const buildStoriesQuery = (
+  language?: string,
+  level?: number,
+  stage?: string,
+  storyTitle?: string,
+) => {
+  let queryParams = language ? `language: "${language}", ` : "";
+  queryParams += level ? `level: ${level}, ` : "";
+  queryParams += stage ? `stage: "${stage}", ` : "";
+  queryParams += storyTitle ? `storyTitle: "${storyTitle}", ` : "";
+  queryParams = queryParams === "" ? queryParams : `( ${queryParams} )`;
+
   return {
     fieldName: "storyTranslations",
     string: gql`
       query StoryTranslations {
-        storyTranslations {
+        storyTranslations ${queryParams} {
           edges {
             cursor
             node {

--- a/frontend/src/components/admin/ManageStoryTranslations.tsx
+++ b/frontend/src/components/admin/ManageStoryTranslations.tsx
@@ -1,15 +1,28 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
-import { Box, Heading } from "@chakra-ui/react";
+import { Box, Heading, Flex } from "@chakra-ui/react";
 import StoryTranslationsTable from "./StoryTranslationsTable";
+import TableFilter from "./TableFilter";
 import {
   buildStoriesQuery,
   StoryTranslation,
   StoryTranslationEdge,
 } from "../../APIClients/queries/StoryQueries";
+import { convertTitleCaseToLanguage } from "../../utils/LanguageUtils";
+import { convertTitleCaseToStage } from "../../utils/StageUtils";
+import { STORY_TRANSLATION_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER } from "../../utils/Copy";
 
 const ManageStoryTranslations = () => {
-  const query = buildStoriesQuery();
+  const [language, setLanguage] = useState<string | null>(null);
+  const [level, setLevel] = useState<string | null>(null);
+  const [stage, setStage] = useState<string | null>(null);
+  const [searchText, setSearchText] = useState<string | null>(null);
+  const query = buildStoriesQuery(
+    convertTitleCaseToLanguage(language || ""),
+    parseInt(level || "", 10) || 0,
+    convertTitleCaseToStage(stage || ""),
+    searchText || "",
+  );
   const [storyTranslations, setStoryTranslations] = useState<
     StoryTranslation[]
   >([]);
@@ -25,9 +38,27 @@ const ManageStoryTranslations = () => {
 
   return (
     <Box textAlign="center">
-      <Heading float="left" margin="20px 30px" size="lg">
-        Manage Story Translations
-      </Heading>
+      <Flex>
+        <Heading float="left" margin="20px 30px" size="lg">
+          Manage Story Translations
+        </Heading>
+      </Flex>
+      <TableFilter
+        language={language}
+        setLanguage={setLanguage}
+        level={level}
+        setLevel={setLevel}
+        stage={stage}
+        setStage={setStage}
+        searchText={searchText}
+        setSearchText={setSearchText}
+        searchBarPlaceholder={
+          STORY_TRANSLATION_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER
+        }
+        useLanguage
+        useLevel
+        useStage
+      />
       <StoryTranslationsTable storyTranslations={storyTranslations} />
     </Box>
   );

--- a/frontend/src/components/admin/ManageUsers.tsx
+++ b/frontend/src/components/admin/ManageUsers.tsx
@@ -3,8 +3,9 @@ import { useQuery } from "@apollo/client";
 import { Box, Flex, Heading } from "@chakra-ui/react";
 import UsersTable, { alphabeticalCompare } from "./UsersTable";
 import { buildUsersQuery, User } from "../../APIClients/queries/UserQueries";
-import UsersTableFilter from "./UsersTableFilter";
+import TableFilter from "./TableFilter";
 import { convertTitleCaseToLanguage } from "../../utils/LanguageUtils";
+import { USER_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER } from "../../utils/Copy";
 
 export type ManageUsersProps = {
   isTranslators: boolean;
@@ -37,13 +38,16 @@ const ManageUsers = ({ isTranslators }: ManageUsersProps) => {
           {`Manage ${isTranslators ? "Translators" : "Reviewers"}`}
         </Heading>
       </Flex>
-      <UsersTableFilter
+      <TableFilter
         language={language}
         setLanguage={setLanguage}
         level={level}
         setLevel={setLevel}
         searchText={searchText}
         setSearchText={setSearchText}
+        useLevel
+        useLanguage
+        searchBarPlaceholder={USER_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER}
       />
       <UsersTable
         isTranslators={isTranslators}

--- a/frontend/src/components/admin/TableFilter.tsx
+++ b/frontend/src/components/admin/TableFilter.tsx
@@ -15,16 +15,23 @@ import {
 } from "@chakra-ui/react";
 import { languageOptions } from "../../constants/Languages";
 import { levelOptions } from "../../constants/Levels";
+import { stageOptions } from "../../constants/Stage";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
-import { USER_TABLE_FILTER_TOOL_TIP_COPY } from "../../utils/Copy";
+import { FILTER_TOOL_TIP_COPY } from "../../utils/Copy";
 
-export type UserTableFilterProps = {
+export type TableFilterProps = {
   language: string | null;
   setLanguage: (newLang: string | null) => void;
   level: string | null;
   setLevel: (newLevel: string | null) => void;
+  stage?: string | null;
+  setStage?: (newStage: string | null) => void;
   searchText: string | null;
   setSearchText: (newText: string | null) => void;
+  useLevel?: boolean;
+  useLanguage?: boolean;
+  useStage?: boolean;
+  searchBarPlaceholder?: string;
 };
 
 export type FilterBadgesProps = {
@@ -74,14 +81,20 @@ const colourStyles: StylesConfig = {
   placeholder: (styles) => ({ ...styles, color: "black" }),
 };
 
-const UsersTableFilter = ({
+const TableFilter = ({
   language,
   level,
+  stage,
   searchText,
   setLanguage,
   setLevel,
+  setStage,
   setSearchText,
-}: UserTableFilterProps) => {
+  useLevel = false,
+  useLanguage = false,
+  useStage = false,
+  searchBarPlaceholder = "",
+}: TableFilterProps) => {
   return (
     <Flex direction="column">
       <Flex
@@ -90,44 +103,68 @@ const UsersTableFilter = ({
         border="1px solid white"
         margin="20px auto 10px"
       >
-        <Tooltip
-          hasArrow
-          label={USER_TABLE_FILTER_TOOL_TIP_COPY}
-          isDisabled={language == null}
-        >
-          <Box flex={1}>
-            <Select
-              isDisabled={language != null}
-              placeholder="Language"
-              options={languageOptions}
-              onChange={(option: any) => setLanguage(option?.value || "")}
-              getOptionLabel={(option: any) => `
+        {useLanguage && (
+          <Tooltip
+            hasArrow
+            label={FILTER_TOOL_TIP_COPY}
+            isDisabled={language == null}
+          >
+            <Box flex={1}>
+              <Select
+                isDisabled={language != null}
+                placeholder="Language"
+                options={languageOptions}
+                onChange={(option: any) => setLanguage(option?.value || "")}
+                getOptionLabel={(option: any) => `
                 ${convertLanguageTitleCase(option.value || "")}
               `}
-              value={language ? { value: language } : null}
-              styles={colourStyles}
-              components={{ DropdownIndicator }}
-            />
-          </Box>
-        </Tooltip>
-        <Tooltip
-          hasArrow
-          label={USER_TABLE_FILTER_TOOL_TIP_COPY}
-          isDisabled={level == null}
-        >
-          <Box flex={1} margin="0 15px">
-            <Select
-              placeholder="Level"
-              options={levelOptions}
-              onChange={(option: any) => setLevel(option?.value || "")}
-              getOptionLabel={(option: any) => `Level ${option.value}`}
-              value={level ? { value: level } : null}
-              styles={colourStyles}
-              components={{ DropdownIndicator }}
-              isDisabled={level != null}
-            />
-          </Box>
-        </Tooltip>
+                value={language ? { value: language } : null}
+                styles={colourStyles}
+                components={{ DropdownIndicator }}
+              />
+            </Box>
+          </Tooltip>
+        )}
+        {useLevel && (
+          <Tooltip
+            hasArrow
+            label={FILTER_TOOL_TIP_COPY}
+            isDisabled={level == null}
+          >
+            <Box flex={1} margin="0 15px">
+              <Select
+                placeholder="Level"
+                options={levelOptions}
+                onChange={(option: any) => setLevel(option?.value || "")}
+                getOptionLabel={(option: any) => `Level ${option.value}`}
+                value={level ? { value: level } : null}
+                styles={colourStyles}
+                components={{ DropdownIndicator }}
+                isDisabled={level != null}
+              />
+            </Box>
+          </Tooltip>
+        )}
+        {useStage && setStage && (
+          <Tooltip
+            hasArrow
+            label={FILTER_TOOL_TIP_COPY}
+            isDisabled={stage == null}
+          >
+            <Box flex={1} margin="0 15px">
+              <Select
+                placeholder="Progress"
+                options={stageOptions}
+                onChange={(option: any) => setStage(option?.value || "")}
+                getOptionLabel={(option: any) => `${option.value}`}
+                value={stage ? { value: stage } : null}
+                styles={colourStyles}
+                components={{ DropdownIndicator }}
+                isDisabled={stage != null}
+              />
+            </Box>
+          </Tooltip>
+        )}
         <Box flex={2} colorScheme="blue" size="secondary">
           <Stack spacing={4}>
             <InputGroup>
@@ -135,7 +172,7 @@ const UsersTableFilter = ({
                 <Icon as={MdSearch} />
               </InputLeftElement>
               <Input
-                placeholder="Search by name or email"
+                placeholder={searchBarPlaceholder}
                 value={searchText || ""}
                 onChange={(e) => setSearchText(e.target.value)}
               />
@@ -170,6 +207,9 @@ const UsersTableFilter = ({
             setFilterValue={setLevel}
           />
         )}
+        {stage && setStage && (
+          <FilterBadges filterValue={`${stage}`} setFilterValue={setStage} />
+        )}
         {searchText && (
           <FilterBadges
             filterValue={searchText}
@@ -181,4 +221,4 @@ const UsersTableFilter = ({
   );
 };
 
-export default UsersTableFilter;
+export default TableFilter;

--- a/frontend/src/constants/Stage.ts
+++ b/frontend/src/constants/Stage.ts
@@ -1,0 +1,6 @@
+/* eslint-disable import/prefer-default-export */
+export const stageOptions = [
+  { value: "In Translation" },
+  { value: "In Review" },
+  { value: "Completed" },
+];

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -30,7 +30,7 @@ export const REVIEW_PAGE_RETURN_TO_TRANSLATOR_CONFIRMATION =
 export const REVIEW_PAGE_SUBMIT_TRANSLATION_CONFIRMATION =
   "By clicking this button, your review session will end and the story translation will be officially submitted to PlanetRead.";
 
-export const USER_TABLE_FILTER_TOOL_TIP_COPY =
+export const FILTER_TOOL_TIP_COPY =
   "This category already has a filter applied.";
 
 export const MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_CONFIRMATION =
@@ -38,3 +38,9 @@ export const MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_CONFIRMATION =
 
 export const MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_BUTTON =
   "I'm sure, delete story translation";
+
+export const USER_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER =
+  "Search by name or email";
+
+export const STORY_TRANSLATION_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER =
+  "Search by story title";

--- a/frontend/src/utils/StageUtils.ts
+++ b/frontend/src/utils/StageUtils.ts
@@ -13,4 +13,16 @@ function convertStageTitleCase(stage: string) {
   }
 }
 
-export { convertStageTitleCase as default };
+function convertTitleCaseToStage(stage: string) {
+  switch (stage) {
+    case "In Translation":
+      return "TRANSLATE";
+    case "In Review":
+      return "REVIEW";
+    case "Completed":
+      return "PUBLISH";
+    default:
+      return stage;
+  }
+}
+export { convertStageTitleCase as default, convertTitleCaseToStage };


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Create Story Translations filters](https://www.notion.so/uwblueprintexecs/Create-Story-Translations-filters-263b6b271ede47bda3b1fc7bbb506b9e)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Generalize the filter component so that it can be used for both the User table and Story Translation table 
- Modify `buildStoriesQuery` in `frontend\src\APIClients\queries\StoryQueries.ts` to take in filter parameters 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to the Manage  Story Translations section of the admin page and make sure filtered queries return as expected 
2. Go to the Manage Translators and Manage Reviewers page as well to make sure nothing has broken after the filter component has been generalized 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- None of the filters are broken 
- Try some different combinations of filters 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
