### PR TITLE
Fix getStoryTranslation query on frontend

### DIFF
--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -121,7 +121,7 @@ export const buildHomePageStoriesQuery = (
 };
 
 export type StoryTranslation = {
-  id: number;
+  storyTranslationId: number;
   language: string;
   stage: string;
   translatorId: number;
@@ -137,6 +137,11 @@ export type StoryTranslation = {
   numApprovedLines: number;
 };
 
+export type StoryTranslationEdge = {
+  cursor: string;
+  node: StoryTranslation;
+};
+
 export const buildStoriesQuery = () => {
   // TODO: build out when filters added
   return {
@@ -144,20 +149,29 @@ export const buildStoriesQuery = () => {
     string: gql`
       query StoryTranslations {
         storyTranslations {
-          id
-          language
-          stage
-          translatorId
-          reviewerId
-          storyId
-          title
-          description
-          youtubeLink
-          level
-          translatorName
-          reviewerName
-          numTranslatedLines
-          numApprovedLines
+          edges {
+            cursor
+            node {
+              storyTranslationId
+              language
+              stage
+              translatorId
+              reviewerId
+              storyId
+              title
+              description
+              youtubeLink
+              level
+              translatorName
+              reviewerName
+              numTranslatedLines
+              numApprovedLines
+            }
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
         }
       }
     `,

--- a/frontend/src/components/admin/ManageStoryTranslations.tsx
+++ b/frontend/src/components/admin/ManageStoryTranslations.tsx
@@ -5,6 +5,7 @@ import StoryTranslationsTable from "./StoryTranslationsTable";
 import {
   buildStoriesQuery,
   StoryTranslation,
+  StoryTranslationEdge,
 } from "../../APIClients/queries/StoryQueries";
 
 const ManageStoryTranslations = () => {
@@ -14,8 +15,11 @@ const ManageStoryTranslations = () => {
   >([]);
   useQuery(query.string, {
     fetchPolicy: "cache-and-network",
-    onCompleted: (data) => {
-      setStoryTranslations(data[query.fieldName]);
+    onCompleted: (data: {
+      storyTranslations: { edges: StoryTranslationEdge[] };
+    }) => {
+      const translations = data.storyTranslations.edges.map((e) => e.node);
+      setStoryTranslations(translations);
     },
   });
 

--- a/frontend/src/components/admin/StoryTranslationsTable.tsx
+++ b/frontend/src/components/admin/StoryTranslationsTable.tsx
@@ -65,7 +65,7 @@ const StoryTranslationsTable = ({
   const tableBody = storyTranslations.map(
     (storyTranslationObj: StoryTranslation, index: number) => (
       <Tr
-        key={`${storyTranslationObj?.storyId}${storyTranslationObj?.id}`}
+        key={`${storyTranslationObj?.storyId}${storyTranslationObj?.storyTranslationId}`}
         borderBottom={
           index === storyTranslations.length - 1 ? "1em solid transparent" : ""
         }
@@ -73,7 +73,7 @@ const StoryTranslationsTable = ({
         <Td>
           <Link
             isExternal
-            href={`/story/${storyTranslationObj?.storyId}/${storyTranslationObj?.id}`}
+            href={`/story/${storyTranslationObj?.storyId}/${storyTranslationObj?.storyTranslationId}`}
           >
             {storyTranslationObj?.title}
           </Link>
@@ -102,11 +102,11 @@ const StoryTranslationsTable = ({
         </Td>
         <Td>
           <IconButton
-            aria-label={`Delete story translation ${storyTranslationObj?.id} for story ${storyTranslationObj?.title}`}
+            aria-label={`Delete story translation ${storyTranslationObj?.storyTranslationId} for story ${storyTranslationObj?.title}`}
             background="transparent"
             icon={<Icon as={MdDelete} />}
             width="fit-content"
-            onClick={() => openModal(storyTranslationObj?.id)}
+            onClick={() => openModal(storyTranslationObj?.storyTranslationId)}
           />
         </Td>
       </Tr>


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

- Fixed the shape of the `storyTranslations` query and how it's parsed in `ManageStoryTranslations.tsx`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Log into the admin account: `planetread+angelamerkel@uwblueprint.org`
2. Go to `/admin` and verify that the story translations appear in the table

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Verifying that the story translations are fetched and show up

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
