### PR TITLE
Make CommentsPanel scrollable

### DIFF
--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -114,7 +114,13 @@ const CommentsPanel = ({
     : TRANSLATION_PAGE_TOOL_TIP_COPY;
 
   return (
-    <Box backgroundColor="gray.100" float="right" width="350px" padding="20px">
+    <Box
+      backgroundColor="gray.100"
+      float="right"
+      width="450px"
+      padding="20px"
+      overflow="auto"
+    >
       <Flex marginBottom="50px">
         <Tooltip hasArrow label={tooltipLabel} isDisabled={!disabled}>
           <Box>

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -81,7 +81,7 @@ const ExistingComment = ({
       borderColor="blue.50"
       borderRadius="8"
       direction="column"
-      padding="14px 15px"
+      padding="14px 14px"
       width="320px"
     >
       <Text fontWeight="bold" marginBottom="15px">

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -78,8 +78,8 @@ const WIPComment = ({
       borderColor="blue.50"
       borderRadius={8}
       direction="column"
-      padding="14px 15px"
-      width="320px"
+      padding="14px 14px"
+      width="300px"
     >
       <b>Line {lineIndex}</b>
       <p>{name}</p>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Make the Comments Panel scrollable](https://www.notion.so/uwblueprintexecs/Dev-Tasks-ebe211395a364645a115234ddf1c887f?p=e2a6e60e8c454556aa5c5cc3fe807ba0)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Minor css changes to make the comments panel vertically scrollable

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. View comments panel on translation page

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- If the user presses the reply button, the indented WIPComment makes the panel horizontally scrollable as well since the comment is slightly outside the margins. Should I increase the width of the panel to account for this? (Note: I already increased the width so increasing the width further might look a bit strange)

![image](https://user-images.githubusercontent.com/32991028/140663456-31e8dc98-445d-4f0c-9dfb-1ae0ffc26cf5.png)
vs
![image](https://user-images.githubusercontent.com/32991028/140663477-4d573c17-2852-471e-9ff2-2b48f5e762e2.png)

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
