### PR TITLE
Implement base Story Translation page

### DIFF
--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -2,7 +2,7 @@ import { DocumentNode, gql } from "@apollo/client";
 
 export const GET_STORY_TRANSLATION = (id: number) =>
   gql`
-      query GetStoryTranslations {
+      query GetStoryTranslation {
         storyTranslationById(
           id: ${id}
         ) {

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -1,5 +1,27 @@
 import { DocumentNode, gql } from "@apollo/client";
 
+export const GET_STORY_TRANSLATION = (id: number) =>
+  gql`
+      query GetStoryTranslations {
+        storyTranslationById(
+          id: ${id}
+        ) {
+          title
+          description
+          youtubeLink
+          level
+          language
+          stage
+          translatorId
+          translatorName
+          reviewerId
+          reviewerName
+          numTranslatedLines
+          numApprovedLines
+        }
+      }
+    `;
+
 export const GET_STORY_CONTENTS = (id: number) =>
   gql`
       query GetStoryContents {

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -14,6 +14,8 @@ import AuthContext from "../../contexts/AuthContext";
 import PreviewModal from "./PreviewModal";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 import { getLevelVariant } from "../../utils/StatusUtils";
+import { embedLink } from "../../utils/Utils";
+
 import {
   ASSIGN_REVIEWER,
   AssignReviewerResponse,
@@ -47,18 +49,7 @@ const StoryCard = ({
 }: StoryCardProps) => {
   const { authenticatedUser } = useContext(AuthContext);
   const history = useHistory();
-  const embedLink = (originalYoutubeLink: string): string => {
-    /*
-    Transforms originalYoutubeLink into embed link appropriate for iframe.
-      If already given link in the embed version, does nothing.
 
-    Example:
-    - Real link: https://www.youtube.com/watch?v=_OBlgSz8sSM
-    - Embed link: https://www.youtube.com/embed/_OBlgSz8sSM
-    */
-
-    return originalYoutubeLink.replace("watch?v=", "embed/");
-  };
   const handleError = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
     alert(errorMessage);

--- a/frontend/src/components/pages/ManageStoryTranslationPage.tsx
+++ b/frontend/src/components/pages/ManageStoryTranslationPage.tsx
@@ -164,24 +164,26 @@ const ManageStoryTranslationPage = () => {
             <Input type="youtubeLink" value={youtubeLink} />
           </FormControl>
           <Heading size="sm" marginTop="24px">
-            Delete Story Translatoin
+            Delete Story Translation
           </Heading>
           <Text>
             Permanently delete this story translation and all data associated
             with it.
           </Text>
+          {/* TODO: Use outline variant after hard coded outline variant is removed */}
           <Button
             colorScheme="red"
             margin="10px 0px"
             width="250px"
             onClick={() => openModal()}
           >
-            Delete Story translation
+            Delete Story Translation
           </Button>
         </Flex>
         <Box
           css={{
             borderRadius: "8px",
+            height: "200px",
             margin: "40px",
             MozBorderRadius: "8px",
             overflow: "hidden",
@@ -189,6 +191,7 @@ const ManageStoryTranslationPage = () => {
           }}
         >
           <iframe
+            height="200px"
             width="100%"
             src={embedLink(youtubeLink)}
             title="YouTube video player"

--- a/frontend/src/components/pages/ManageStoryTranslationPage.tsx
+++ b/frontend/src/components/pages/ManageStoryTranslationPage.tsx
@@ -1,22 +1,241 @@
-import React from "react";
-import { useParams } from "react-router-dom";
-import { Box } from "@chakra-ui/react";
+import React, { useState } from "react";
+import { useParams, useHistory } from "react-router-dom";
+import { useQuery, useMutation } from "@apollo/client";
+import {
+  Box,
+  Button,
+  Flex,
+  FormControl,
+  Input,
+  Heading,
+  Link,
+  Text,
+  Textarea,
+  useStyleConfig,
+} from "@chakra-ui/react";
+import { embedLink } from "../../utils/Utils";
+
+import { GET_STORY_TRANSLATION } from "../../APIClients/queries/StoryQueries";
+import {
+  SOFT_DELETE_STORY_TRANSLATION,
+  SoftDeleteStoryTranslationResponse,
+} from "../../APIClients/mutations/StoryMutations";
+import Header from "../navigation/Header";
+import ProgressBar from "../utils/ProgressBar";
+import ConfirmationModal from "../utils/ConfirmationModal";
+import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
+import convertStageTitleCase from "../../utils/StageUtils";
+import {
+  MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_BUTTON,
+  MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_CONFIRMATION,
+} from "../../utils/Copy";
 
 type ManageStoryTranslationPageProps = {
-  storyIdParam: string | undefined;
-  storyTranslationIdParam: string | undefined;
+  storyIdParam: string;
+  storyTranslationIdParam: string;
+};
+
+type StoryTranslation = {
+  title: string;
+  description: string;
+  youtubeLink: string;
+  level: number;
+  language: string;
+  stage: string;
+  translatorId: number;
+  translatorName: string;
+  reviewerId: number;
+  reviewerName: string;
+  numTranslatedLines: number;
+  numApprovedLines: number;
 };
 
 const ManageStoryTranslationPage = () => {
   const { storyIdParam, storyTranslationIdParam } =
     useParams<ManageStoryTranslationPageProps>();
 
+  const [title, setTitle] = useState<string>("");
+  const [description, setDescription] = useState<string>("");
+  const [youtubeLink, setYoutubeLink] = useState<string>("");
+  const [level, setLevel] = useState<number>(0);
+  const [language, setLanguage] = useState<string>("");
+  const [stage, setStage] = useState<string>("");
+  const [translatorId, setTranslatorId] = useState<number>(0);
+  const [translatorName, setTranslatorName] = useState<string>("");
+  const [reviewerId, setReviewerId] = useState<number>(0);
+  const [reviewerName, setReviewerName] = useState<string>("");
+  const [numTranslatedLines, setNumTranslatedLines] = useState<number>(0);
+  const [numApprovedLines, setNumApprovedLines] = useState<number>(0);
+
+  const [confirmDeleteTranslation, setConfirmDeleteTranslation] =
+    useState(false);
+
+  const history = useHistory();
+
+  useQuery(GET_STORY_TRANSLATION(parseInt(storyTranslationIdParam, 10)), {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data: {
+      storyTranslationById: StoryTranslation;
+      errors: any;
+    }) => {
+      setTitle(data.storyTranslationById.title);
+      setDescription(data.storyTranslationById.description);
+      setYoutubeLink(data.storyTranslationById.youtubeLink);
+      setLevel(data.storyTranslationById.level);
+      setLanguage(data.storyTranslationById.language);
+      setStage(data.storyTranslationById.stage);
+      setTranslatorId(data.storyTranslationById.translatorId);
+      setTranslatorName(data.storyTranslationById.translatorName);
+      setReviewerId(data.storyTranslationById.reviewerId);
+      setReviewerName(data.storyTranslationById.reviewerName);
+      setNumTranslatedLines(data.storyTranslationById.numTranslatedLines);
+      setNumApprovedLines(data.storyTranslationById.numApprovedLines);
+    },
+    onError: () => {
+      history.push("/404");
+    },
+  });
+  const [deleteStoryTranslation] = useMutation<{
+    response: SoftDeleteStoryTranslationResponse;
+  }>(SOFT_DELETE_STORY_TRANSLATION);
+
+  const closeModal = () => {
+    setConfirmDeleteTranslation(false);
+  };
+
+  const openModal = () => {
+    setConfirmDeleteTranslation(true);
+  };
+
+  const callSoftDeleteStoryTranslationMutation = async () => {
+    await deleteStoryTranslation({
+      variables: {
+        id: storyTranslationIdParam,
+      },
+    });
+    closeModal();
+    history.push("/");
+  };
+
+  const filterStyle = useStyleConfig("Filter");
   return (
-    <Box textAlign="center">
-      <h1>
-        Manage story translation {storyIdParam} {storyTranslationIdParam} :)
-      </h1>
-    </Box>
+    <Flex direction="column" height="100vh">
+      <Header title="Manage Story Translation" />
+      <Flex direction="row" flex={1}>
+        <Flex sx={filterStyle} maxWidth="292px">
+          <Heading size="lg">{title}</Heading>
+          <Heading size="sm">Story ID</Heading>
+          <Text>{storyIdParam}</Text>
+          <Heading size="sm">Translation Language</Heading>
+          <Text>{convertLanguageTitleCase(language)}</Text>
+          <Heading size="sm">Level</Heading>
+          <Text>{level}</Text>
+          <Heading size="sm">Stage</Heading>
+          <Text>{convertStageTitleCase(stage)}</Text>
+          {/* TODO: Use translatorName and reviewerName */}
+          <Heading size="sm">Translator</Heading>
+          <Link isExternal href={`/user/${translatorId}`}>
+            {translatorId}
+            {translatorName}
+          </Link>
+          {reviewerId && (
+            <>
+              <Heading size="sm">Reviewer</Heading>
+              <Link isExternal href={`/user/${reviewerId}`}>
+                {reviewerId}
+                {reviewerName}
+              </Link>
+            </>
+          )}
+        </Flex>
+        <Flex direction="column" margin="40px" width="50%">
+          <FormControl id="email">
+            <Heading size="sm" marginTop="24px" marginBottom="18px">
+              Title
+            </Heading>
+            <Input type="title" value={title || ""} />
+            <Heading size="sm" marginTop="24px" marginBottom="18px">
+              Description
+            </Heading>
+            <Textarea type="description" value={description || ""} />
+            <Heading size="sm" marginTop="24px" marginBottom="18px">
+              YouTube Link
+            </Heading>
+            <Input type="youtubeLink" value={youtubeLink} />
+          </FormControl>
+          <Heading size="sm" marginTop="24px">
+            Delete Story Translatoin
+          </Heading>
+          <Text>
+            Permanently delete this story translation and all data associated
+            with it.
+          </Text>
+          <Button
+            colorScheme="red"
+            margin="10px 0px"
+            width="250px"
+            onClick={() => openModal()}
+          >
+            Delete Story translation
+          </Button>
+        </Flex>
+        <Box
+          css={{
+            borderRadius: "8px",
+            margin: "40px",
+            MozBorderRadius: "8px",
+            overflow: "hidden",
+            webkitBorderRadius: "8px",
+          }}
+        >
+          <iframe
+            width="100%"
+            src={embedLink(youtubeLink)}
+            title="YouTube video player"
+            frameBorder="0"
+            allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+        </Box>
+      </Flex>
+      <Flex
+        alignItems="center"
+        boxShadow="0 0 12px -9px rgba(0, 0, 0, 0.7)"
+        direction="row"
+        height="90px"
+        justify="space-between"
+        padding="20px 30px"
+      >
+        <Flex direction="row">
+          {/* TODO: Get total number of lines to calculate progress */}
+          <ProgressBar
+            percentageComplete={numTranslatedLines}
+            type="Translation"
+          />
+          <ProgressBar percentageComplete={numApprovedLines} type="Review" />
+        </Flex>
+        <Box>
+          <Button colorScheme="blue" variant="outline">
+            Cancel
+          </Button>
+          {/* TODO: use UpdateStoryTranslation mutation. Disable button if no local changes. */}
+          <Button colorScheme="blue">Save Changes</Button>
+        </Box>
+      </Flex>
+      {confirmDeleteTranslation && (
+        <ConfirmationModal
+          confirmation={confirmDeleteTranslation}
+          onClose={closeModal}
+          onConfirmationClick={callSoftDeleteStoryTranslationMutation}
+          confirmationMessage={
+            MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_CONFIRMATION
+          }
+          buttonMessage={
+            MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_BUTTON
+          }
+        />
+      )}
+    </Flex>
   );
 };
 

--- a/frontend/src/utils/LanguageUtils.ts
+++ b/frontend/src/utils/LanguageUtils.ts
@@ -1,4 +1,4 @@
-import convertStringTitleCase from "./Utils";
+import { convertStringTitleCase } from "./Utils";
 
 // Change language string to title case
 function convertLanguageTitleCase(language: string) {

--- a/frontend/src/utils/StageUtils.ts
+++ b/frontend/src/utils/StageUtils.ts
@@ -1,4 +1,4 @@
-import convertStringTitleCase from "./Utils";
+import { convertStringTitleCase } from "./Utils";
 
 function convertStageTitleCase(stage: string) {
   switch (stage) {

--- a/frontend/src/utils/Utils.ts
+++ b/frontend/src/utils/Utils.ts
@@ -1,5 +1,15 @@
-function convertStringTitleCase(s: string) {
-  return s[0] + s.substring(1).toLowerCase();
-}
+export const convertStringTitleCase = (s: string) =>
+  s[0] + s.substring(1).toLowerCase();
 
-export { convertStringTitleCase as default };
+export const embedLink = (originalYoutubeLink: string): string => {
+  /*
+  Transforms originalYoutubeLink into embed link appropriate for iframe.
+    If already given link in the embed version, does nothing.
+
+  Example:
+  - Real link: https://www.youtube.com/watch?v=_OBlgSz8sSM
+  - Embed link: https://www.youtube.com/embed/_OBlgSz8sSM
+  */
+
+  return originalYoutubeLink.replace("watch?v=", "embed/");
+};


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket Name](https://www.notion.so/uwblueprintexecs/Implement-dumb-admin-story-translation-page-731159c382c5406ea3ea3fb619465d16)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- implement side bar 
  - backend needs to be modified to return the translator/reviewer names and the total number of lines
- implemented form 
  - making a dumb non functioning form for now
- implemented bottom footer  
  - buttons are non functioning
- using default nav for now   

tldr, only functioning thing is the delete button

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as angela merkel
2. go to http://localhost:3000/story/1/1
3. modify the last number in the url to see different story translations
4. attempt to delete translation 
5. observe redirect to homepage
6. attempt to open the last url. observe the 404

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
