### PR TITLE
Delete users on UserTable

### DIFF
--- a/frontend/src/APIClients/mutations/UserMutations.ts
+++ b/frontend/src/APIClients/mutations/UserMutations.ts
@@ -1,0 +1,10 @@
+import { gql } from "@apollo/client";
+
+export const SOFT_DELETE_USER = gql`
+  mutation SoftDeleteUser($id: Int!) {
+    softDeleteUser(id: $id) {
+      ok
+    }
+  }
+`;
+export type SoftDeleteUserResponse = { ok: boolean };

--- a/frontend/src/components/admin/UsersTable.tsx
+++ b/frontend/src/components/admin/UsersTable.tsx
@@ -12,6 +12,7 @@ import {
   Td,
   IconButton,
 } from "@chakra-ui/react";
+import { useMutation } from "@apollo/client";
 import { User } from "../../APIClients/queries/UserQueries";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 import { getLevelVariant } from "../../utils/StatusUtils";
@@ -20,7 +21,6 @@ import {
   MANAGE_USERS_TABLE_DELETE_USER_CONFIRMATION,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
-import { useMutation } from "@apollo/client";
 import {
   SoftDeleteUserResponse,
   SOFT_DELETE_USER,
@@ -118,7 +118,7 @@ const UsersTable = ({
           background="transparent"
           icon={<Icon as={MdDelete} />}
           width="fit-content"
-          onClick={() => openModal(parseInt(userObj?.id!))}
+          onClick={() => openModal(parseInt(userObj?.id!, 10))}
         />
       </Td>
     </Tr>

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -44,3 +44,8 @@ export const USER_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER =
 
 export const STORY_TRANSLATION_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER =
   "Search by story title";
+
+export const MANAGE_USERS_TABLE_DELETE_USER_CONFIRMATION =
+  "By deleting the user, all their data will be removed from the database. The user will not be able to access this platform, and this action cannot be undone.";
+
+export const MANAGE_USERS_TABLE_DELETE_USER_BUTTON = "I'm sure, delete user";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Delete users on UserTable](https://www.notion.so/uwblueprintexecs/Delete-users-on-UserTable-50448562dd97467d96bd11b2ce677b9a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- make soft delete call in `UsersTable.tsx`
- basically the same changes as: https://github.com/uwblueprint/planet-read/pull/148

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login using `planetread+angelamerkel@uwblueprint.org`
2. Go to `/admin` and click on "Manage Translators" or "Manage Reviewers"
3. Try to delete any user
4. Verify that the user doesn't appear in the table anymore 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does the deletion work?
- Currently the behaviour for both `StoryTranslationsTable` and `UsersTable` is to reload the window after deletion, but the page will get reset to the `StoryTranslationsTable` page - is this something we want to handle or should we leave it as is?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
