### PR TITLE
Indent existing comment replies

### DIFF
--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -76,6 +76,7 @@ const CommentsPanel = ({
               resolved={comment.resolved}
               content={comment.content}
               time={comment.time}
+              commentIndex={comment.commentIndex}
               commentStoryTranslationContentId={
                 commentStoryTranslationContentId
               }

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -15,6 +15,7 @@ export type ExistingCommentProps = {
   resolved: boolean;
   content: string;
   time: string;
+  commentIndex: number;
   commentStoryTranslationContentId: number;
   lineIndex: number;
   updateCommentsAsResolved: (index: number) => void;
@@ -36,6 +37,7 @@ const ExistingComment = ({
   setTranslatedStoryLines,
   comments,
   translatedStoryLines,
+  commentIndex,
 }: ExistingCommentProps) => {
   const handleError = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
@@ -77,16 +79,17 @@ const ExistingComment = ({
   return (
     <Flex
       backgroundColor="transparent"
-      border="1px solid"
-      borderColor="blue.50"
       borderRadius="8"
       direction="column"
       padding="14px 14px"
-      width="320px"
+      width={`${commentIndex ? 300 : 320}px`}
+      margin={`${commentIndex ? 20 : 0}px`}
     >
-      <Text fontWeight="bold" marginBottom="15px">
-        Line {lineIndex}
-      </Text>
+      {commentIndex < 2 && (
+        <Text fontWeight="bold" marginBottom="15px">
+          {commentIndex === 1 && "Replies to "}Line {lineIndex}
+        </Text>
+      )}
       <Flex justify="space-between" marginBottom="10px">
         <p>{name}</p>
         <p>{time}</p>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Indent existing comment replies](https://www.notion.so/uwblueprintexecs/Indent-existing-comment-replies-24b764f717434bc79347a4bc6194e88c)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Indent if the comment index is not 0 and add copy "Replies to" 

<img width="367" alt="Screen Shot 2021-11-14 at 6 43 39 PM" src="https://user-images.githubusercontent.com/37675216/141703544-d8acb597-7ca2-40f0-a332-747b2828d526.png">

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl Sagan
2. Go to http://localhost:3000/translation/6/13 
3. See that the comments are indented 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work and look right?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
