### PR TITLE
call migration before running pytest for circleci

### DIFF
--- a/backend/python/app/conftest.py
+++ b/backend/python/app/conftest.py
@@ -38,11 +38,9 @@ def db(app):
     from .models.story_translation_content import StoryTranslationContent
     from .models.user import User
 
-    db.drop_all()
-    db.create_all()
-
     yield db
 
+    # TODO: delete databases between tests
     db.session.close()
 
 

--- a/backend/python/app/tests/graphql/mutations/test_story_mutation.py
+++ b/backend/python/app/tests/graphql/mutations/test_story_mutation.py
@@ -76,6 +76,10 @@ def test_create_story(app, db, client):
         assert test_db_obj_line_content["line_index"] == i
         assert test_db_obj_line_content["content"] == contents[i]
 
+    db.session.query(StoryContent).delete()
+    db.session.query(Story).delete()
+    assert db.session.commit() == None
+
 
 def test_create_story_translation(db, client):
     pass

--- a/backend/python/app/tests/graphql/queries/test_story_query.py
+++ b/backend/python/app/tests/graphql/queries/test_story_query.py
@@ -48,6 +48,10 @@ def test_stories(app, db, client):
             assert content_db.line_index == content_dict["lineIndex"]
             assert content_db.content == content_dict["content"]
 
+    db.session.query(StoryContent).delete()
+    db.session.query(Story).delete()
+    assert db.session.commit() == None
+
 
 def test_story_by_id(db, client):
     pass

--- a/backend/python/app/tests/services/test_story_service.py
+++ b/backend/python/app/tests/services/test_story_service.py
@@ -10,6 +10,9 @@ def test_get_story(app, db, services):
     resp = services["story"].get_story(obj.id)
     assert_story_equals_model(resp, obj, graphql_response=False)
 
+    db.session.query(Story).delete()
+    assert db.session.commit() == None
+
 
 def test_get_story_invalid_id():
     pass

--- a/backend/python/tools/migrate_and_pytest.sh
+++ b/backend/python/tools/migrate_and_pytest.sh
@@ -1,0 +1,2 @@
+flask db upgrade
+pytest 

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   py-backend:
-    command: /app/tools/wait-for-it.sh test-db:3306 -- pytest
+    command: /app/tools/wait-for-it.sh test-db:3306 -- ./tools/migrate_and_pytest.sh
     build:
       context: ./backend/python
       dockerfile: Dockerfile


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Apply DB migrations to test_db in before running pytest](https://www.notion.so/uwblueprintexecs/Apply-DB-migrations-to-test_db-in-before-running-pytest-9825824895354fdebd3762184486f219)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Change env variables for `DB_HOST` and `TEST_DB_HOST` in circleCI 
- Change command for test command in `docker-compose.testing.yml` 
- Call migrations before pytest 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Make sure there is a green check mark  ✔️ 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Changes make sense

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
