### PR TITLE
Display the correct line number on existing comments

### DIFF
--- a/backend/python/app/graphql/types/comment_type.py
+++ b/backend/python/app/graphql/types/comment_type.py
@@ -20,6 +20,7 @@ class CommentResponseDTO(graphene.ObjectType):
     time = graphene.DateTime(required=True)
     resolved = graphene.Boolean(required=True)
     content = graphene.String(required=True)
+    line_index = graphene.Int()
 
 
 class UpdateCommentResponseDTO(graphene.ObjectType):

--- a/backend/python/app/services/implementations/comment_service.py
+++ b/backend/python/app/services/implementations/comment_service.py
@@ -80,13 +80,13 @@ class CommentService(ICommentService):
                 StoryTranslationContentStatus.ACTION_REQUIRED
             )
             db.session.commit()
-            
+
             stc = StoryTranslationContent.query.filter_by(
                 id=new_comment.story_translation_content_id
             ).first()
 
             new_comment.line_index = stc.line_index
-            
+
             return new_comment
         elif story_translation_stage == "TRANSLATE" and is_reviewer:
             raise Exception(

--- a/frontend/src/APIClients/mutations/CommentMutations.ts
+++ b/frontend/src/APIClients/mutations/CommentMutations.ts
@@ -11,6 +11,7 @@ export const CREATE_COMMMENT = gql`
         time
         resolved
         content
+        lineIndex
       }
     }
   }
@@ -25,6 +26,7 @@ export type CreateCommentResponse = {
     time: string;
     resolved: boolean;
     content: string;
+    lineIndex: number;
   };
 };
 

--- a/frontend/src/APIClients/queries/CommentQueries.ts
+++ b/frontend/src/APIClients/queries/CommentQueries.ts
@@ -8,6 +8,7 @@ const COMMENT_FIELDS = `
     storyTranslationContentId
     resolved
     time
+    lineIndex
     `;
 
 export type CommentResponse = {
@@ -17,6 +18,7 @@ export type CommentResponse = {
   time: string;
   resolved: boolean;
   content: string;
+  lineIndex: number;
 };
 
 export const buildCommentsQuery = (

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -75,10 +75,8 @@ const ReviewPage = () => {
     setSubmitTranslation(true);
   };
 
-  const [
-    commentStoryTranslationContentId,
-    setCommentStoryTranslationContentId,
-  ] = useState<number>(-1);
+  const [storyTranslationContentId, setStoryTranslationContentId] =
+    useState<number>(-1);
 
   const handleFontSizeChange = (val: string) => {
     setFontSize(val);
@@ -182,9 +180,7 @@ const ReviewPage = () => {
               translatedLanguage={convertLanguageTitleCase(language)}
               commentLine={commentLine}
               setCommentLine={setCommentLine}
-              setCommentStoryTranslationContentId={
-                setCommentStoryTranslationContentId
-              }
+              setStoryTranslationContentId={setStoryTranslationContentId}
               translator={false}
               setTranslatedStoryLines={setTranslatedStoryLines}
               numApprovedLines={numApprovedLines}
@@ -236,7 +232,7 @@ const ReviewPage = () => {
         </Flex>
         <CommentsPanel
           disabled={stage === "TRANSLATE"}
-          commentStoryTranslationContentId={commentStoryTranslationContentId}
+          storyTranslationContentId={storyTranslationContentId}
           commentLine={commentLine}
           storyTranslationId={storyTranslationId}
           setCommentLine={setCommentLine}

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -75,10 +75,8 @@ const TranslationPage = () => {
 
   const editable = stage === "TRANSLATE";
   const [commentLine, setCommentLine] = useState(-1);
-  const [
-    commentStoryTranslationContentId,
-    setCommentStoryTranslationContentId,
-  ] = useState<number>(-1);
+  const [storyTranslationContentId, setStoryTranslationContentId] =
+    useState<number>(-1);
 
   const handleFontSizeChange = (val: string) => {
     setFontSize(val);
@@ -267,9 +265,7 @@ const TranslationPage = () => {
               translatedLanguage={convertLanguageTitleCase(language)}
               commentLine={commentLine}
               setCommentLine={setCommentLine}
-              setCommentStoryTranslationContentId={
-                setCommentStoryTranslationContentId
-              }
+              setStoryTranslationContentId={setStoryTranslationContentId}
               translator
               setTranslatedStoryLines={setTranslatedStoryLines}
               changedStoryLines={changedStoryLines.size}
@@ -303,7 +299,7 @@ const TranslationPage = () => {
         </Flex>
         <CommentsPanel
           disabled={!editable}
-          commentStoryTranslationContentId={commentStoryTranslationContentId}
+          storyTranslationContentId={storyTranslationContentId}
           commentLine={commentLine}
           storyTranslationId={storyTranslationId}
           setCommentLine={setCommentLine}

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -72,15 +72,8 @@ const CommentsPanel = ({
           {comments.map((comment: CommentResponse) => (
             <ExistingComment
               key={comment.id}
-              id={comment.id}
-              resolved={comment.resolved}
-              content={comment.content}
-              time={comment.time}
-              commentIndex={comment.commentIndex}
-              commentStoryTranslationContentId={
-                commentStoryTranslationContentId
-              }
-              lineIndex={commentLine}
+              comment={comment}
+              WIPLineIndex={commentLine}
               updateCommentsAsResolved={updateCommentsAsResolved}
               comments={comments}
               setComments={setComments}
@@ -150,7 +143,7 @@ const CommentsPanel = ({
       </Flex>
       {commentLine > 0 && (
         <WIPComment
-          lineIndex={commentLine}
+          WIPLineIndex={commentLine}
           commentStoryTranslationContentId={commentStoryTranslationContentId}
           setCommentLine={setCommentLine}
           comments={comments}

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -17,7 +17,7 @@ export type CommentPanelProps = {
   storyTranslationId: number;
   commentLine: number;
   setCommentLine: (line: number) => void;
-  commentStoryTranslationContentId: number;
+  storyTranslationContentId: number;
   disabled: boolean;
   setTranslatedStoryLines: (storyLines: StoryLine[]) => void;
   translatedStoryLines: StoryLine[];
@@ -27,7 +27,7 @@ export type CommentPanelProps = {
 const CommentsPanel = ({
   storyTranslationId,
   commentLine,
-  commentStoryTranslationContentId,
+  storyTranslationContentId,
   setCommentLine,
   disabled,
   setTranslatedStoryLines,
@@ -144,7 +144,7 @@ const CommentsPanel = ({
       {commentLine > 0 && (
         <WIPComment
           WIPLineIndex={commentLine}
-          commentStoryTranslationContentId={commentStoryTranslationContentId}
+          storyTranslationContentId={storyTranslationContentId}
           setCommentLine={setCommentLine}
           comments={comments}
           setComments={setComments}

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -11,34 +11,25 @@ import { CommentResponse } from "../../APIClients/queries/CommentQueries";
 import { StoryLine } from "../translation/Autosave";
 
 export type ExistingCommentProps = {
-  id: number;
-  resolved: boolean;
-  content: string;
-  time: string;
-  commentIndex: number;
-  commentStoryTranslationContentId: number;
-  lineIndex: number;
+  comment: CommentResponse;
   updateCommentsAsResolved: (index: number) => void;
   comments: CommentResponse[];
   setComments: (comments: CommentResponse[]) => void;
   translatedStoryLines: StoryLine[];
   setTranslatedStoryLines: (storyLines: StoryLine[]) => void;
+  WIPLineIndex: number;
 };
 
 const ExistingComment = ({
-  id,
-  resolved,
-  content,
-  time,
-  commentStoryTranslationContentId,
-  lineIndex,
+  comment,
   updateCommentsAsResolved,
   setComments,
   setTranslatedStoryLines,
   comments,
   translatedStoryLines,
-  commentIndex,
+  WIPLineIndex,
 }: ExistingCommentProps) => {
+  const { id, resolved, content, time, lineIndex, commentIndex } = comment;
   const handleError = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
     alert(errorMessage);
@@ -87,7 +78,8 @@ const ExistingComment = ({
     >
       {commentIndex < 2 && (
         <Text fontWeight="bold" marginBottom="15px">
-          {commentIndex === 1 && "Replies to "}Line {lineIndex}
+          {commentIndex === 1 && "Replies to "}
+          Line {lineIndex + 1}
         </Text>
       )}
       <Flex justify="space-between" marginBottom="10px">
@@ -105,10 +97,10 @@ const ExistingComment = ({
           Resolve
         </Button>
       </Flex>
-      {reply > 0 && lineIndex > -1 && (
+      {reply > 0 && WIPLineIndex > -1 && (
         <WIPComment
-          lineIndex={lineIndex}
-          commentStoryTranslationContentId={commentStoryTranslationContentId}
+          WIPLineIndex={WIPLineIndex}
+          commentStoryTranslationContentId={lineIndex}
           setCommentLine={setReply}
           comments={comments}
           setComments={setComments}

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -29,7 +29,14 @@ const ExistingComment = ({
   translatedStoryLines,
   WIPLineIndex,
 }: ExistingCommentProps) => {
-  const { id, resolved, content, time, lineIndex, commentIndex } = comment;
+  const {
+    id,
+    resolved,
+    content,
+    time,
+    lineIndex: storyContentId,
+    commentIndex,
+  } = comment;
   const handleError = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
     alert(errorMessage);
@@ -79,7 +86,7 @@ const ExistingComment = ({
       {commentIndex < 2 && (
         <Text fontWeight="bold" marginBottom="15px">
           {commentIndex === 1 && "Replies to "}
-          Line {lineIndex + 1}
+          Line {storyContentId + 1}
         </Text>
       )}
       <Flex justify="space-between" marginBottom="10px">
@@ -100,7 +107,7 @@ const ExistingComment = ({
       {reply > 0 && WIPLineIndex > -1 && (
         <WIPComment
           WIPLineIndex={WIPLineIndex}
-          commentStoryTranslationContentId={lineIndex}
+          storyTranslationContentId={storyContentId}
           setCommentLine={setReply}
           comments={comments}
           setComments={setComments}

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -11,7 +11,7 @@ import { StoryLine } from "../translation/Autosave";
 import { convertStatusTitleCase } from "../../utils/StatusUtils";
 
 export type WIPCommentProps = {
-  commentStoryTranslationContentId: number;
+  storyTranslationContentId: number;
   WIPLineIndex: number;
   setCommentLine: (line: number) => void;
   comments: CommentResponse[];
@@ -21,7 +21,7 @@ export type WIPCommentProps = {
 };
 
 const WIPComment = ({
-  commentStoryTranslationContentId,
+  storyTranslationContentId,
   WIPLineIndex,
   setCommentLine,
   setComments,
@@ -44,7 +44,7 @@ const WIPComment = ({
   const createNewComment = async () => {
     try {
       const commentData = {
-        storyTranslationContentId: commentStoryTranslationContentId,
+        storyTranslationContentId,
         content: text,
       };
       const result = await createComment({

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -12,7 +12,7 @@ import { convertStatusTitleCase } from "../../utils/StatusUtils";
 
 export type WIPCommentProps = {
   commentStoryTranslationContentId: number;
-  lineIndex: number;
+  WIPLineIndex: number;
   setCommentLine: (line: number) => void;
   comments: CommentResponse[];
   setComments: (comments: CommentResponse[]) => void;
@@ -22,7 +22,7 @@ export type WIPCommentProps = {
 
 const WIPComment = ({
   commentStoryTranslationContentId,
-  lineIndex,
+  WIPLineIndex,
   setCommentLine,
   setComments,
   setTranslatedStoryLines,
@@ -53,10 +53,9 @@ const WIPComment = ({
       if (result.data?.createComment.ok) {
         setText("");
         setCommentLine(0);
-
         setComments([...comments, result.data.createComment.comment]);
         const updatedStoryLines = [...translatedStoryLines];
-        updatedStoryLines[lineIndex - 1].status =
+        updatedStoryLines[WIPLineIndex - 1].status =
           convertStatusTitleCase("ACTION_REQUIRED");
         setTranslatedStoryLines(updatedStoryLines);
       }
@@ -81,7 +80,7 @@ const WIPComment = ({
       padding="14px 14px"
       width="300px"
     >
-      <b>Line {lineIndex}</b>
+      <b>Line {WIPLineIndex}</b>
       <p>{name}</p>
       <Textarea
         value={text}

--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -26,7 +26,7 @@ export type TranslationTableProps = {
   setTranslatedStoryLines: (storyLines: StoryLine[]) => void;
   commentLine: number;
   setCommentLine: (line: number) => void;
-  setCommentStoryTranslationContentId: (id: number) => void;
+  setStoryTranslationContentId: (id: number) => void;
   numApprovedLines?: number;
   setNumApprovedLines?: (numLines: number) => void;
   changedStoryLines?: number;
@@ -45,7 +45,7 @@ const TranslationTable = ({
   setTranslatedStoryLines,
   commentLine,
   setCommentLine,
-  setCommentStoryTranslationContentId,
+  setStoryTranslationContentId,
   translator,
   numApprovedLines,
   setNumApprovedLines,
@@ -58,7 +58,7 @@ const TranslationTable = ({
     storyTranslationContentId: number,
   ) => {
     setCommentLine(displayLineNumber);
-    setCommentStoryTranslationContentId(storyTranslationContentId);
+    setStoryTranslationContentId(storyTranslationContentId);
   };
 
   const storyCells = translatedStoryLines.map((storyLine: StoryLine) => {


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Display the correct line number on existing comments](https://www.notion.so/uwblueprintexecs/Display-the-correct-line-number-on-existing-comments-4a8316cf49bd4c6fa8fa488e457f2991)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Fetch the line number from the StoryTranslationContent in backend, 
- *I think there was some confusion around the naming with regards to comment index which led to the bugs*, renamed them to hopefully be clearer (?):
  - `commentIndex` and `WIPCommentIndex` refer to the comment number for a specific thread (the first comment in any thread will have commentIndex=0, the first reply to that comment will be commentIndex=1)
  - `lineIndex` is the specific StoryTranslationContent line number that the comment refers to 
  
<img width="378" alt="Screen Shot 2021-11-16 at 10 14 48 PM" src="https://user-images.githubusercontent.com/37675216/142128085-5e86b372-5a59-467e-a6a2-bae2881f1697.png">


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Log in as carl sagan and go to http://localhost:3000/translation/6/13 
2. Check that the comment indices are correct

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work? 
- Does the naming make sense?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
