### PR TITLE
Prevent Dark Mode in chakraui

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.16",
     "@chakra-ui/icon": "^1.1.11",
-    "@chakra-ui/react": "^1.6.5",
+    "@chakra-ui/react": "^1.7.1",
     "@chakra-ui/theme": "^1.9.2",
     "@chakra-ui/theme-tools": "^1.1.8",
     "@emotion/react": "^11",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import "bootstrap/dist/css/bootstrap.min.css";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
-import { ChakraProvider } from "@chakra-ui/react";
+import { ChakraProvider, useColorMode } from "@chakra-ui/react";
 import { ApolloProvider } from "@apollo/client";
 
 import Login from "./components/auth/Login";
@@ -21,6 +21,22 @@ import client from "./APIClients/BaseGQLClient";
 
 import { getLocalStorageObj } from "./utils/LocalStorageUtils";
 
+/*
+ * https://github.com/chakra-ui/chakra-ui/issues/4987#issuecomment-965575708
+ * Light mode shouldn't have to be forced in chakra-ui/react 1.7.1
+ * but it's stil buggy on Kristy's windows 10 with default app mode set to dark
+ */
+function ForceLightMode(props: { children: JSX.Element }) {
+  const { colorMode, toggleColorMode } = useColorMode();
+
+  useEffect(() => {
+    if (colorMode === "light") return;
+    toggleColorMode();
+  }, [colorMode]);
+
+  return props.children;
+}
+
 const App = () => {
   const currentUser: AuthenticatedUser = getLocalStorageObj(
     AUTHENTICATED_USER_KEY,
@@ -31,41 +47,43 @@ const App = () => {
 
   return (
     <ChakraProvider theme={customTheme}>
-      <ApolloProvider client={client}>
-        <AuthContext.Provider
-          value={{ authenticatedUser, setAuthenticatedUser }}
-        >
-          <Router>
-            <Switch>
-              <Route exact path="/login" component={Login} />
-              <PrivateRoute exact path="/" component={HomePage} />
-              <PrivateRoute
-                exact
-                path="/user/:userId"
-                component={UserProfilePage}
-              />
-              <PrivateRoute exact path="/admin" component={AdminPage} />
-              <PrivateRoute
-                exact
-                path="/translation/:storyIdParam/:storyTranslationIdParam"
-                component={TranslationPage}
-              />
-              <PrivateRoute
-                exact
-                path="/review/:storyIdParam/:storyTranslationIdParam"
-                component={ReviewPage}
-              />
-              <PrivateRoute
-                exact
-                path="/story/:storyIdParam/:storyTranslationIdParam"
-                component={ManageStoryTranslationPage}
-              />
-              <Route exact path="/404" component={NotFound} />
-              <Route exact path="*" component={NotFound} />
-            </Switch>
-          </Router>
-        </AuthContext.Provider>
-      </ApolloProvider>
+      <ForceLightMode>
+        <ApolloProvider client={client}>
+          <AuthContext.Provider
+            value={{ authenticatedUser, setAuthenticatedUser }}
+          >
+            <Router>
+              <Switch>
+                <Route exact path="/login" component={Login} />
+                <PrivateRoute exact path="/" component={HomePage} />
+                <PrivateRoute
+                  exact
+                  path="/user/:userId"
+                  component={UserProfilePage}
+                />
+                <PrivateRoute exact path="/admin" component={AdminPage} />
+                <PrivateRoute
+                  exact
+                  path="/translation/:storyIdParam/:storyTranslationIdParam"
+                  component={TranslationPage}
+                />
+                <PrivateRoute
+                  exact
+                  path="/review/:storyIdParam/:storyTranslationIdParam"
+                  component={ReviewPage}
+                />
+                <PrivateRoute
+                  exact
+                  path="/story/:storyIdParam/:storyTranslationIdParam"
+                  component={ManageStoryTranslationPage}
+                />
+                <Route exact path="/404" component={NotFound} />
+                <Route exact path="*" component={NotFound} />
+              </Switch>
+            </Router>
+          </AuthContext.Provider>
+        </ApolloProvider>
+      </ForceLightMode>
     </ChakraProvider>
   );
 };


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=bc5ded5818494010a5694eea80fbe9be

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- upped the chakra ui version. this fixed the issue for philips' windows system dark mode
- added code forcing charkaui to toggle to light mode. this fixed the issue for my windows system dark mode

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. open page
2. make sure it's light mode
3. toggle your system default app mode to dark
4. verify that the page is still in light mode
5. try turning your entire system to dark
6. verify that the page is still in light mode

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- is it l i g h t 💡 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
