### PR TITLE
Bug/make timefield on existing comment readable

### DIFF
--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -111,9 +111,9 @@ const CommentsPanel = ({
     <Box
       backgroundColor="gray.100"
       float="right"
-      width="450px"
-      padding="20px"
       overflow="auto"
+      padding="20px"
+      width="450px"
     >
       <Flex marginBottom="50px">
         <Tooltip hasArrow label={tooltipLabel} isDisabled={!disabled}>

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -81,6 +81,8 @@ const ExistingComment = ({
     setReply(storyContentId);
   };
 
+  const newDate = new Date(time);
+
   return (
     <Flex
       backgroundColor="transparent"
@@ -98,7 +100,15 @@ const ExistingComment = ({
       )}
       <Flex justify="space-between" marginBottom="10px">
         <p>{name}</p>
-        <p>{time}</p>
+        <p>
+          {newDate.toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+            hour: "numeric",
+            minute: "numeric",
+            hour12: true,
+          })}
+        </p>
       </Flex>
       <Text fontSize="sm" marginBottom="5px">
         {content}


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Display more readable time field on Existing Comment component](https://www.notion.so/uwblueprintexecs/Dev-Tasks-ebe211395a364645a115234ddf1c887f?p=5204a25cf612428d9ac2185ae28b5bc6)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Create datetime object and specify options to format it
![image](https://user-images.githubusercontent.com/32991028/142557738-14af0b01-146e-44fd-a441-df7de61aa78e.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Look at timestamp on any existing comment

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Whether the year should also be included in the timestamp (very quick fix)
- Whether Today/Yesterday should be displayed
- Whether the am/pm part needs to be lowercase and have no whitespace separation from the time itself like it is in the figma design (would require some Regex to fix)
![image](https://user-images.githubusercontent.com/32991028/142557945-9e69e13b-6303-47c2-94fe-f1ac9df828d3.png)

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
