### PR TITLE
Fix comment creation behaviour for replies

### DIFF
--- a/frontend/src/APIClients/mutations/CommentMutations.ts
+++ b/frontend/src/APIClients/mutations/CommentMutations.ts
@@ -12,6 +12,7 @@ export const CREATE_COMMMENT = gql`
         resolved
         content
         lineIndex
+        storyTranslationContentId
       }
     }
   }
@@ -27,6 +28,7 @@ export type CreateCommentResponse = {
     resolved: boolean;
     content: string;
     lineIndex: number;
+    storyTranslationContentId: number;
   };
 };
 

--- a/frontend/src/APIClients/queries/CommentQueries.ts
+++ b/frontend/src/APIClients/queries/CommentQueries.ts
@@ -19,6 +19,7 @@ export type CommentResponse = {
   resolved: boolean;
   content: string;
   lineIndex: number;
+  storyTranslationContentId: number;
 };
 
 export const buildCommentsQuery = (

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -27,7 +27,6 @@ const ExistingComment = ({
   setTranslatedStoryLines,
   comments,
   translatedStoryLines,
-  WIPLineIndex,
 }: ExistingCommentProps) => {
   const {
     id,
@@ -36,13 +35,16 @@ const ExistingComment = ({
     time,
     lineIndex: storyContentId,
     commentIndex,
+    storyTranslationContentId: stcId,
   } = comment;
   const handleError = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
     alert(errorMessage);
   };
 
-  const [reply, setReply] = useState(0);
+  const [reply, setReply] = useState(-1);
+  const [storyTranslationContentId, setStoryTranslationContentId] =
+    useState(stcId);
 
   const { authenticatedUser } = useContext(AuthContext);
   const [updateComment] = useMutation<{
@@ -74,6 +76,11 @@ const ExistingComment = ({
     ${authenticatedUser!!.firstName}
     ${authenticatedUser!!.lastName}`;
 
+  const handleReply = () => {
+    setStoryTranslationContentId(storyTranslationContentId);
+    setReply(storyContentId);
+  };
+
   return (
     <Flex
       backgroundColor="transparent"
@@ -97,17 +104,19 @@ const ExistingComment = ({
         {content}
       </Text>
       <Flex>
-        <Button onClick={() => setReply(1)} variant="commentLabel">
-          Reply
-        </Button>
+        {!commentIndex && (
+          <Button onClick={() => handleReply()} variant="commentLabel">
+            Reply
+          </Button>
+        )}
         <Button onClick={resolveExistingComment} variant="commentLabel">
           Resolve
         </Button>
       </Flex>
-      {reply > 0 && WIPLineIndex > -1 && (
+      {reply > -1 && (
         <WIPComment
-          WIPLineIndex={WIPLineIndex}
-          storyTranslationContentId={storyContentId}
+          WIPLineIndex={reply + 1}
+          storyTranslationContentId={storyTranslationContentId}
           setCommentLine={setReply}
           comments={comments}
           setComments={setComments}

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -52,7 +52,7 @@ const WIPComment = ({
       });
       if (result.data?.createComment.ok) {
         setText("");
-        setCommentLine(0);
+        setCommentLine(-1);
         setComments([...comments, result.data.createComment.comment]);
         const updatedStoryLines = [...translatedStoryLines];
         updatedStoryLines[WIPLineIndex - 1].status =
@@ -100,7 +100,7 @@ const WIPComment = ({
         <Button
           size="secondary"
           variant="blueOutline"
-          onClick={() => setCommentLine(0)}
+          onClick={() => setCommentLine(-1)}
         >
           Cancel
         </Button>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Correct comment creation behaviour for replies](https://www.notion.so/uwblueprintexecs/Correct-comment-creation-behaviour-for-replies-84eae6e9151d4051b7ec8ee5416c93d4)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- storyTranslationContentId wasn't getting passed in correctly 
- commenting state was also weird (right now the blue comment flow should be separate from the reply flow)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to http://localhost:3000/translation/6/13 as Carl Sagan
2. Without clicking on the big blue comment button, click on Reply for any of the existing comments and try to comment
3. Now click on the big blue comment button
4. Click on line numbers, check that commenting works 

Note: the ordering of comments is strange, probably needs to be addressed in future PR. 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does the commenting work as expected? 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
