### PR TITLE
Move clearing tables to fixture teardown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: Create env file
           command: touch .env # empty .env file needed to build containers
       - run:
-          name: Build backend and frontend images 
+          name: Build backend and frontend images
           command: |
             set -x
             echo "Build images"
@@ -52,7 +52,6 @@ jobs:
             echo "Checking import order..."
             isort --profile black backend/python/app/ -c
             echo "Code properly linted!"
-
 
 workflows:
   version: 2

--- a/backend/python/app/conftest.py
+++ b/backend/python/app/conftest.py
@@ -24,24 +24,33 @@ def app():
     return my_app
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def db(app):
     """
     Yields db instance
     """
     from .models import db
-    from .models.comment import Comment
-    from .models.file import File
+    from .models.comment_all import CommentAll
     from .models.story import Story
     from .models.story_content import StoryContent
-    from .models.story_translation import StoryTranslation
-    from .models.story_translation_content import StoryTranslationContent
-    from .models.user import User
+    from .models.story_translation_all import StoryTranslationAll
+    from .models.story_translation_content_all import StoryTranslationContentAll
+    from .models.user_all import UserAll
 
     yield db
 
-    # TODO: delete databases between tests
-    db.session.close()
+    db.session.query(CommentAll).delete()
+    db.session.commit()
+    db.session.query(StoryTranslationContentAll).delete()
+    db.session.commit()
+    db.session.query(StoryContent).delete()
+    db.session.commit()
+    db.session.query(StoryTranslationAll).delete()
+    db.session.commit()
+    db.session.query(Story).delete()
+    db.session.commit()
+    db.session.query(UserAll).delete()
+    db.session.commit()
 
 
 @pytest.fixture(scope="session")

--- a/backend/python/app/conftest.py
+++ b/backend/python/app/conftest.py
@@ -51,6 +51,7 @@ def db(app):
     db.session.commit()
     db.session.query(UserAll).delete()
     db.session.commit()
+    db.session.close()
 
 
 @pytest.fixture(scope="session")

--- a/backend/python/app/tests/graphql/mutations/test_story_mutation.py
+++ b/backend/python/app/tests/graphql/mutations/test_story_mutation.py
@@ -76,10 +76,6 @@ def test_create_story(app, db, client):
         assert test_db_obj_line_content["line_index"] == i
         assert test_db_obj_line_content["content"] == contents[i]
 
-    db.session.query(StoryContent).delete()
-    db.session.query(Story).delete()
-    assert db.session.commit() == None
-
 
 def test_create_story_translation(db, client):
     pass

--- a/backend/python/app/tests/graphql/queries/test_story_query.py
+++ b/backend/python/app/tests/graphql/queries/test_story_query.py
@@ -48,10 +48,6 @@ def test_stories(app, db, client):
             assert content_db.line_index == content_dict["lineIndex"]
             assert content_db.content == content_dict["content"]
 
-    db.session.query(StoryContent).delete()
-    db.session.query(Story).delete()
-    assert db.session.commit() == None
-
 
 def test_story_by_id(db, client):
     pass

--- a/backend/python/app/tests/services/test_story_service.py
+++ b/backend/python/app/tests/services/test_story_service.py
@@ -10,9 +10,6 @@ def test_get_story(app, db, services):
     resp = services["story"].get_story(obj.id)
     assert_story_equals_model(resp, obj, graphql_response=False)
 
-    db.session.query(Story).delete()
-    assert db.session.commit() == None
-
 
 def test_get_story_invalid_id():
     pass

--- a/backend/python/tools/insert_test_data.py
+++ b/backend/python/tools/insert_test_data.py
@@ -175,9 +175,9 @@ def erase_db():
     db.session.commit()
     db.session.query(StoryTranslationAll).delete()
     db.session.commit()
-    db.session.query(UserAll).delete()
-    db.session.commit()
     db.session.query(Story).delete()
+    db.session.commit()
+    db.session.query(UserAll).delete()
     db.session.commit()
 
 


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[move clearing tables from unit tests to conftest.py db fixture](https://www.notion.so/uwblueprintexecs/move-clearing-tables-from-unit-tests-to-conftest-py-db-fixture-de088e2008144ccb84dfc75b7d304ab8)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- move delete steps to db teardown in `conftest.py`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Verify CircleCI tests pass!

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- `conftest.py`

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
