### PR TITLE
Sort comments by line and comment index

### DIFF
--- a/backend/python/app/services/implementations/comment_service.py
+++ b/backend/python/app/services/implementations/comment_service.py
@@ -116,6 +116,7 @@ class CommentService(ICommentService):
                     == story_translation_id,
                     Comment.resolved == resolved if resolved is not None else True,
                 )
+                .order_by(StoryTranslationContent.line_index)
                 .all()
             )
 

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -9,6 +9,7 @@ import {
 import { CommentResponse } from "../../APIClients/queries/CommentQueries";
 import { StoryLine } from "../translation/Autosave";
 import { convertStatusTitleCase } from "../../utils/StatusUtils";
+import { insertSortedComments } from "../../utils/Utils";
 
 export type WIPCommentProps = {
   storyTranslationContentId: number;
@@ -53,7 +54,9 @@ const WIPComment = ({
       if (result.data?.createComment.ok) {
         setText("");
         setCommentLine(-1);
-        setComments([...comments, result.data.createComment.comment]);
+        setComments(
+          insertSortedComments(comments, result.data.createComment.comment),
+        );
         const updatedStoryLines = [...translatedStoryLines];
         updatedStoryLines[WIPLineIndex - 1].status =
           convertStatusTitleCase("ACTION_REQUIRED");

--- a/frontend/src/utils/Utils.ts
+++ b/frontend/src/utils/Utils.ts
@@ -1,3 +1,5 @@
+import { CommentResponse } from "../APIClients/queries/CommentQueries";
+
 export const convertStringTitleCase = (s: string) =>
   s[0] + s.substring(1).toLowerCase();
 
@@ -20,4 +22,28 @@ export const embedLink = (originalYoutubeLink: string): string => {
   */
 
   return originalYoutubeLink.replace("watch?v=", "embed/");
+};
+
+export const insertSortedComments = (
+  existingComments: CommentResponse[],
+  newComment: CommentResponse,
+): CommentResponse[] => {
+  let i = 0;
+  while (i < existingComments.length) {
+    if (existingComments[i].lineIndex > newComment.lineIndex) break;
+    i += 1;
+    if (
+      existingComments[i].lineIndex === newComment.lineIndex &&
+      existingComments[i].commentIndex === newComment.commentIndex - 1
+    ) {
+      break;
+    }
+  }
+
+  const comments = [
+    ...existingComments.slice(0, i),
+    newComment,
+    ...existingComments.slice(i),
+  ];
+  return comments;
 };


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Correct Comment ordering](https://www.notion.so/uwblueprintexecs/Correct-Comment-ordering-6f8dd1161e334fbe9bbd6d821e098c95)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Sort comments when retrieving from DB 
- Insert new comments sorted on frontend 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to http://localhost:3000/translation/6/13 as carl sagan 
2. Add comments and check that they show up correctly
3. Try inserting at the beginning, replying, at the end
4. Might need to delete the existing comments on Line 1 to check beginning (`delete from comments where story_translation_content_id = 51;`)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
