### PR TITLE
Use UpdateStory mutation on clicking the Save Changes button in Manag…

### DIFF
--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -94,3 +94,22 @@ export const SOFT_DELETE_STORY_TRANSLATION = gql`
   }
 `;
 export type SoftDeleteStoryTranslationResponse = { ok: boolean };
+
+export const UPDATE_STORY = gql`
+  mutation UpdateStory(
+    $storyId: Int!
+    $title: String!
+    $description: String!
+    $youtubeLink: String!
+  ) {
+    updateStory(
+      storyId: $storyId
+      title: $title
+      description: $description
+      youtubeLink: $youtubeLink
+    ) {
+      ok
+    }
+  }
+`;
+export type UpdateStoryResponse = { ok: boolean };

--- a/frontend/src/components/pages/ManageStoryTranslationPage.tsx
+++ b/frontend/src/components/pages/ManageStoryTranslationPage.tsx
@@ -133,23 +133,17 @@ const ManageStoryTranslationPage = () => {
   };
 
   const callUpdateStoryMutation = async () => {
-    if (
-      title !== tempTitle ||
-      description !== tempDescription ||
-      youtubeLink !== tempYoutubeLink
-    ) {
-      setTitle(tempTitle);
-      setDescription(tempDescription);
-      setYoutubeLink(tempYoutubeLink);
-      await updateStory({
-        variables: {
-          storyId: storyIdParam,
-          title: tempTitle,
-          description: tempDescription,
-          youtubeLink: tempYoutubeLink,
-        },
-      });
-    }
+    await updateStory({
+      variables: {
+        storyId: storyIdParam,
+        title: tempTitle,
+        description: tempDescription,
+        youtubeLink: tempYoutubeLink,
+      },
+    });
+    setTitle(tempTitle);
+    setDescription(tempDescription);
+    setYoutubeLink(tempYoutubeLink);
   };
 
   const cancelChanges = () => {
@@ -195,25 +189,25 @@ const ManageStoryTranslationPage = () => {
               Title
             </Heading>
             <Input
+              onChange={(event) => setTempTitle(event.target.value)}
               type="title"
               value={tempTitle || ""}
-              onChange={(event) => setTempTitle(event.target.value)}
             />
             <Heading size="sm" marginTop="24px" marginBottom="18px">
               Description
             </Heading>
             <Textarea
+              onChange={(event) => setTempDescription(event.target.value)}
               type="description"
               value={tempDescription || ""}
-              onChange={(event) => setTempDescription(event.target.value)}
             />
             <Heading size="sm" marginTop="24px" marginBottom="18px">
               YouTube Link
             </Heading>
             <Input
+              onChange={(event) => setTempYoutubeLink(event.target.value)}
               type="youtubeLink"
               value={tempYoutubeLink}
-              onChange={(event) => setTempYoutubeLink(event.target.value)}
             />
           </FormControl>
           <Heading size="sm" marginTop="24px">
@@ -223,7 +217,6 @@ const ManageStoryTranslationPage = () => {
             Permanently delete this story translation and all data associated
             with it.
           </Text>
-          {/* TODO: Use outline variant after hard coded outline variant is removed */}
           <Button
             colorScheme="red"
             margin="10px 0px"
@@ -264,7 +257,6 @@ const ManageStoryTranslationPage = () => {
         padding="20px 30px"
       >
         <Flex direction="row">
-          {/* TODO: Get total number of lines to calculate progress */}
           <ProgressBar
             percentageComplete={(numTranslatedLines / numContentLines) * 100}
             type="Translation"
@@ -277,12 +269,25 @@ const ManageStoryTranslationPage = () => {
         <Box>
           <Button
             colorScheme="blue"
-            variant="blueOutline"
+            isDisabled={
+              title === tempTitle &&
+              description === tempDescription &&
+              youtubeLink === tempYoutubeLink
+            }
             onClick={cancelChanges}
+            variant="blueOutline"
           >
             Cancel
           </Button>
-          <Button colorScheme="blue" onClick={callUpdateStoryMutation}>
+          <Button
+            colorScheme="blue"
+            isDisabled={
+              title === tempTitle &&
+              description === tempDescription &&
+              youtubeLink === tempYoutubeLink
+            }
+            onClick={callUpdateStoryMutation}
+          >
             Save Changes
           </Button>
         </Box>

--- a/frontend/src/components/pages/ManageStoryTranslationPage.tsx
+++ b/frontend/src/components/pages/ManageStoryTranslationPage.tsx
@@ -133,17 +133,23 @@ const ManageStoryTranslationPage = () => {
   };
 
   const callUpdateStoryMutation = async () => {
-    await updateStory({
-      variables: {
-        storyId: storyIdParam,
-        title: tempTitle,
-        description: tempDescription,
-        youtubeLink: tempYoutubeLink,
-      },
-    });
-    setTitle(tempTitle);
-    setDescription(tempDescription);
-    setYoutubeLink(tempYoutubeLink);
+    if (
+      title !== tempTitle ||
+      description !== tempDescription ||
+      youtubeLink !== tempYoutubeLink
+    ) {
+      await updateStory({
+        variables: {
+          storyId: storyIdParam,
+          title: tempTitle,
+          description: tempDescription,
+          youtubeLink: tempYoutubeLink,
+        },
+      });
+      setTitle(tempTitle);
+      setDescription(tempDescription);
+      setYoutubeLink(tempYoutubeLink);
+    }
   };
 
   const cancelChanges = () => {

--- a/frontend/src/components/pages/ManageStoryTranslationPage.tsx
+++ b/frontend/src/components/pages/ManageStoryTranslationPage.tsx
@@ -19,6 +19,8 @@ import { GET_STORY_TRANSLATION } from "../../APIClients/queries/StoryQueries";
 import {
   SOFT_DELETE_STORY_TRANSLATION,
   SoftDeleteStoryTranslationResponse,
+  UPDATE_STORY,
+  UpdateStoryResponse,
 } from "../../APIClients/mutations/StoryMutations";
 import Header from "../navigation/Header";
 import ProgressBar from "../utils/ProgressBar";
@@ -68,6 +70,9 @@ const ManageStoryTranslationPage = () => {
   const [numTranslatedLines, setNumTranslatedLines] = useState<number>(0);
   const [numApprovedLines, setNumApprovedLines] = useState<number>(0);
   const [numContentLines, setNumContentLines] = useState<number>(0);
+  const [tempTitle, setTempTitle] = useState<string>("");
+  const [tempDescription, setTempDescription] = useState<string>("");
+  const [tempYoutubeLink, setTempYoutubeLink] = useState<string>("");
 
   const [confirmDeleteTranslation, setConfirmDeleteTranslation] =
     useState(false);
@@ -93,6 +98,9 @@ const ManageStoryTranslationPage = () => {
       setNumTranslatedLines(data.storyTranslationById.numTranslatedLines);
       setNumApprovedLines(data.storyTranslationById.numApprovedLines);
       setNumContentLines(data.storyTranslationById.numContentLines);
+      setTempTitle(data.storyTranslationById.title);
+      setTempDescription(data.storyTranslationById.description);
+      setTempYoutubeLink(data.storyTranslationById.youtubeLink);
     },
     onError: () => {
       history.push("/404");
@@ -101,6 +109,10 @@ const ManageStoryTranslationPage = () => {
   const [deleteStoryTranslation] = useMutation<{
     response: SoftDeleteStoryTranslationResponse;
   }>(SOFT_DELETE_STORY_TRANSLATION);
+
+  const [updateStory] = useMutation<{
+    response: UpdateStoryResponse;
+  }>(UPDATE_STORY);
 
   const closeModal = () => {
     setConfirmDeleteTranslation(false);
@@ -118,6 +130,27 @@ const ManageStoryTranslationPage = () => {
     });
     closeModal();
     history.push("/");
+  };
+
+  const callUpdateStoryMutation = async () => {
+    console.log(storyIdParam, title, description, youtubeLink);
+    setTitle(tempTitle);
+    setDescription(tempDescription);
+    setYoutubeLink(tempYoutubeLink);
+    await updateStory({
+      variables: {
+        storyId: storyIdParam,
+        title: tempTitle,
+        description: tempDescription,
+        youtubeLink: tempYoutubeLink,
+      },
+    });
+  };
+
+  const cancelChanges = () => {
+    setTempTitle(title);
+    setTempDescription(description);
+    setTempYoutubeLink(youtubeLink);
   };
 
   const filterStyle = useStyleConfig("Filter");
@@ -156,15 +189,27 @@ const ManageStoryTranslationPage = () => {
             <Heading size="sm" marginTop="24px" marginBottom="18px">
               Title
             </Heading>
-            <Input type="title" value={title || ""} />
+            <Input
+              type="title"
+              value={tempTitle || ""}
+              onChange={(event) => setTempTitle(event.target.value)}
+            />
             <Heading size="sm" marginTop="24px" marginBottom="18px">
               Description
             </Heading>
-            <Textarea type="description" value={description || ""} />
+            <Textarea
+              type="description"
+              value={tempDescription || ""}
+              onChange={(event) => setTempDescription(event.target.value)}
+            />
             <Heading size="sm" marginTop="24px" marginBottom="18px">
               YouTube Link
             </Heading>
-            <Input type="youtubeLink" value={youtubeLink} />
+            <Input
+              type="youtubeLink"
+              value={tempYoutubeLink}
+              onChange={(event) => setTempYoutubeLink(event.target.value)}
+            />
           </FormControl>
           <Heading size="sm" marginTop="24px">
             Delete Story Translation
@@ -225,11 +270,17 @@ const ManageStoryTranslationPage = () => {
           />
         </Flex>
         <Box>
-          <Button colorScheme="blue" variant="blueOutline">
+          <Button
+            colorScheme="blue"
+            variant="blueOutline"
+            onClick={cancelChanges}
+          >
             Cancel
           </Button>
           {/* TODO: use UpdateStoryTranslation mutation. Disable button if no local changes. */}
-          <Button colorScheme="blue">Save Changes</Button>
+          <Button colorScheme="blue" onClick={callUpdateStoryMutation}>
+            Save Changes
+          </Button>
         </Box>
       </Flex>
       {confirmDeleteTranslation && (

--- a/frontend/src/components/pages/ManageStoryTranslationPage.tsx
+++ b/frontend/src/components/pages/ManageStoryTranslationPage.tsx
@@ -133,18 +133,23 @@ const ManageStoryTranslationPage = () => {
   };
 
   const callUpdateStoryMutation = async () => {
-    console.log(storyIdParam, title, description, youtubeLink);
-    setTitle(tempTitle);
-    setDescription(tempDescription);
-    setYoutubeLink(tempYoutubeLink);
-    await updateStory({
-      variables: {
-        storyId: storyIdParam,
-        title: tempTitle,
-        description: tempDescription,
-        youtubeLink: tempYoutubeLink,
-      },
-    });
+    if (
+      title !== tempTitle ||
+      description !== tempDescription ||
+      youtubeLink !== tempYoutubeLink
+    ) {
+      setTitle(tempTitle);
+      setDescription(tempDescription);
+      setYoutubeLink(tempYoutubeLink);
+      await updateStory({
+        variables: {
+          storyId: storyIdParam,
+          title: tempTitle,
+          description: tempDescription,
+          youtubeLink: tempYoutubeLink,
+        },
+      });
+    }
   };
 
   const cancelChanges = () => {
@@ -277,7 +282,6 @@ const ManageStoryTranslationPage = () => {
           >
             Cancel
           </Button>
-          {/* TODO: use UpdateStoryTranslation mutation. Disable button if no local changes. */}
           <Button colorScheme="blue" onClick={callUpdateStoryMutation}>
             Save Changes
           </Button>


### PR DESCRIPTION
…eStoryTranslationPage

## Notion ticket link

<!-- Please replace with your ticket's URL -->

[use UpdateStoryTranslation mutation on clicking the Save Changes button in ManageStoryTranslationPage](https://www.notion.so/uwblueprintexecs/use-UpdateStoryTranslation-mutation-on-clicking-the-Save-Changes-button-in-ManageStoryTranslationPag-3c5a738c8e10490f86e165b9537c6ecd)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Used UpdateStory mutation to save changes when "Save Changes" is pressed
- Keeping changes in temporary variables, which are discarded when "Cancel" is pressed

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Angela Merkel
2. Go to http://localhost:3000/admin
3. Click on any story translation
4. Edit title/description/youtube link
5. Click save changes
6. Refresh page (or close and reopen page), and check that changes remain
7. Edit title/description/youtube link
8. Click cancel
9. Changes should be reverted
10. Refresh page (or close and reopen page), and check that changes were reverted

New steps after changes:
11. Check that cancel and save buttons are disabled when no changes have been made
12. Make changes
13. Check that cancel and save buttons are enabled when changes have been made
14. Save changes, check that buttons are disabled
15. Make changes, check that buttons are enabled
16. Cancel changes, check that buttons are disabled

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work as expected?
- Are features implemented as expected?
- Is code readable?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
