### PR TITLE
Add empty table response

### DIFF
--- a/frontend/src/components/admin/EmptyTable.tsx
+++ b/frontend/src/components/admin/EmptyTable.tsx
@@ -8,31 +8,31 @@ export type EmptyTableProps = {
 
 const EmptyTable = ({ filters }: EmptyTableProps) => {
   const clearFilters = () => {
-    filters.forEach((f) => {
-      f(null);
+    filters.forEach((setFilter) => {
+      setFilter(null);
     });
   };
   return (
     <Tr>
-      <Td colspan="100%" background="white !important">
+      <Td background="white !important" colspan="100%">
         <Flex
-          direction="column"
           alignItems="center"
+          direction="column"
           height="50vh"
-          minWidth="100%"
           justify="center"
+          minWidth="100%"
         >
           <Flex
             alignItems="center"
-            justify="space-between"
             direction="column"
             height="150px"
+            justify="space-between"
           >
             <Heading variant="light">
               We can&apos;t seem to find a match :(
             </Heading>
             <Text>Would you like to clear up some filters?</Text>
-            <Button size="secondary" colorScheme="blue" onClick={clearFilters}>
+            <Button colorScheme="blue" onClick={clearFilters} size="secondary">
               Clear Filters
             </Button>
           </Flex>

--- a/frontend/src/components/admin/EmptyTable.tsx
+++ b/frontend/src/components/admin/EmptyTable.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+import { Button, Flex, Heading, Text, Tr, Td } from "@chakra-ui/react";
+
+export type EmptyTableProps = {
+  filters: { (data: string | null): void }[];
+};
+
+const EmptyTable = ({ filters }: EmptyTableProps) => {
+  const clearFilters = () => {
+    filters.forEach((f) => {
+      f(null);
+    });
+  };
+  return (
+    <Tr>
+      <Td colspan="100%" background="white !important">
+        <Flex
+          direction="column"
+          alignItems="center"
+          height="50vh"
+          minWidth="100%"
+          justify="center"
+        >
+          <Flex
+            alignItems="center"
+            justify="space-between"
+            direction="column"
+            height="150px"
+          >
+            <Heading variant="light">
+              We can&apos;t seem to find a match :(
+            </Heading>
+            <Text>Would you like to clear up some filters?</Text>
+            <Button size="secondary" colorScheme="blue" onClick={clearFilters}>
+              Clear Filters
+            </Button>
+          </Flex>
+        </Flex>
+      </Td>
+    </Tr>
+  );
+};
+
+export default EmptyTable;

--- a/frontend/src/components/admin/ManageStoryTranslations.tsx
+++ b/frontend/src/components/admin/ManageStoryTranslations.tsx
@@ -58,6 +58,7 @@ const ManageStoryTranslations = () => {
       <StoryTranslationsTable
         storyTranslationSlice={pageResults}
         paginator={paginator}
+        filters={[setLanguage, setLevel, setStage, setSearchText]}
       />
     </Box>
   );

--- a/frontend/src/components/admin/ManageStoryTranslations.tsx
+++ b/frontend/src/components/admin/ManageStoryTranslations.tsx
@@ -26,7 +26,7 @@ const ManageStoryTranslations = () => {
     searchText || "",
   );
 
-  const { pageResults, paginator } = usePagination<StoryTranslation>(
+  const { loading, pageResults, paginator } = usePagination<StoryTranslation>(
     query.string,
     query.fieldName,
     ITEMS_PER_PAGE,
@@ -56,6 +56,7 @@ const ManageStoryTranslations = () => {
         useStage
       />
       <StoryTranslationsTable
+        loading={loading}
         storyTranslationSlice={pageResults}
         paginator={paginator}
         filters={[setLanguage, setLevel, setStage, setSearchText]}

--- a/frontend/src/components/admin/ManageUsers.tsx
+++ b/frontend/src/components/admin/ManageUsers.tsx
@@ -23,14 +23,15 @@ const ManageUsers = ({ isTranslators }: ManageUsersProps) => {
     searchText || "",
   );
 
-  useQuery(query.string, {
+  const { loading, data } = useQuery(query.string, {
     fetchPolicy: "cache-and-network",
-    onCompleted: (data) => {
+    onCompleted: () => {
       const newUsers = [...data[query.fieldName]];
       newUsers.sort(alphabeticalCompare);
       setUsers(newUsers);
     },
   });
+
   return (
     <Box textAlign="center">
       <Flex>
@@ -50,6 +51,7 @@ const ManageUsers = ({ isTranslators }: ManageUsersProps) => {
         searchBarPlaceholder={USER_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER}
       />
       <UsersTable
+        loading={loading}
         isTranslators={isTranslators}
         users={users}
         setUsers={setUsers}

--- a/frontend/src/components/admin/ManageUsers.tsx
+++ b/frontend/src/components/admin/ManageUsers.tsx
@@ -53,6 +53,7 @@ const ManageUsers = ({ isTranslators }: ManageUsersProps) => {
         isTranslators={isTranslators}
         users={users}
         setUsers={setUsers}
+        filters={[setLanguage, setLevel, setSearchText]}
       />
     </Box>
   );

--- a/frontend/src/components/admin/StoryTranslationsTable.tsx
+++ b/frontend/src/components/admin/StoryTranslationsTable.tsx
@@ -33,12 +33,14 @@ export type StoryTranslationsTableProps = {
   storyTranslationSlice: StoryTranslation[];
   paginator: ReactNode;
   filters: { (data: string | null): void }[];
+  loading: Boolean;
 };
 
 const StoryTranslationsTable = ({
   storyTranslationSlice,
   paginator,
   filters,
+  loading,
 }: StoryTranslationsTableProps) => {
   const [confirmDeleteTranslation, setConfirmDeleteTranslation] =
     useState(false);
@@ -145,7 +147,7 @@ const StoryTranslationsTable = ({
         </Tr>
       </Thead>
       <Tbody>
-        {storyTranslationSlice.length === 0 ? (
+        {storyTranslationSlice.length === 0 && !loading ? (
           <EmptyTable filters={filters} />
         ) : (
           tableBody

--- a/frontend/src/components/admin/StoryTranslationsTable.tsx
+++ b/frontend/src/components/admin/StoryTranslationsTable.tsx
@@ -27,15 +27,18 @@ import {
   MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_BUTTON,
   MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_CONFIRMATION,
 } from "../../utils/Copy";
+import EmptyTable from "./EmptyTable";
 
 export type StoryTranslationsTableProps = {
   storyTranslationSlice: StoryTranslation[];
   paginator: ReactNode;
+  filters: { (data: string | null): void }[];
 };
 
 const StoryTranslationsTable = ({
   storyTranslationSlice,
   paginator,
+  filters,
 }: StoryTranslationsTableProps) => {
   const [confirmDeleteTranslation, setConfirmDeleteTranslation] =
     useState(false);
@@ -141,7 +144,13 @@ const StoryTranslationsTable = ({
           <Th>ACTION</Th>
         </Tr>
       </Thead>
-      <Tbody>{tableBody}</Tbody>
+      <Tbody>
+        {storyTranslationSlice.length === 0 ? (
+          <EmptyTable filters={filters} />
+        ) : (
+          tableBody
+        )}
+      </Tbody>
       {confirmDeleteTranslation && (
         <ConfirmationModal
           confirmation={confirmDeleteTranslation}

--- a/frontend/src/components/admin/UsersTable.tsx
+++ b/frontend/src/components/admin/UsersTable.tsx
@@ -33,6 +33,7 @@ export type UsersTableProps = {
   users: User[];
   setUsers: (newState: User[]) => void;
   filters: { (data: string | null): void }[];
+  loading: Boolean;
 };
 
 const getFullName = (user: User) => `${user?.firstName} ${user?.lastName}`;
@@ -44,6 +45,7 @@ const UsersTable = ({
   users,
   filters,
   setUsers,
+  loading,
 }: UsersTableProps) => {
   const [isAscending, setIsAscending] = useState(true);
   const [confirmDeleteUser, setConfirmDeleteUser] = useState(false);
@@ -151,7 +153,11 @@ const UsersTable = ({
         </Tr>
       </Thead>
       <Tbody>
-        {users.length === 0 ? <EmptyTable filters={filters} /> : tableBody}
+        {users.length === 0 && !loading ? (
+          <EmptyTable filters={filters} />
+        ) : (
+          tableBody
+        )}
       </Tbody>
       {confirmDeleteUser && (
         <ConfirmationModal

--- a/frontend/src/components/admin/UsersTable.tsx
+++ b/frontend/src/components/admin/UsersTable.tsx
@@ -26,11 +26,13 @@ import {
   SOFT_DELETE_USER,
 } from "../../APIClients/mutations/UserMutations";
 import { parseApprovedLanguages } from "../../utils/Utils";
+import EmptyTable from "./EmptyTable";
 
 export type UsersTableProps = {
   isTranslators?: boolean;
   users: User[];
   setUsers: (newState: User[]) => void;
+  filters: { (data: string | null): void }[];
 };
 
 const getFullName = (user: User) => `${user?.firstName} ${user?.lastName}`;
@@ -40,6 +42,7 @@ export const alphabeticalCompare = (u1: User, u2: User) =>
 const UsersTable = ({
   isTranslators = false,
   users,
+  filters,
   setUsers,
 }: UsersTableProps) => {
   const [isAscending, setIsAscending] = useState(true);
@@ -123,6 +126,7 @@ const UsersTable = ({
       </Td>
     </Tr>
   ));
+
   return (
     <Table
       borderRadius="12px"
@@ -146,7 +150,9 @@ const UsersTable = ({
           <Th>ACTION</Th>
         </Tr>
       </Thead>
-      <Tbody>{tableBody}</Tbody>
+      <Tbody>
+        {users.length === 0 ? <EmptyTable filters={filters} /> : tableBody}
+      </Tbody>
       {confirmDeleteUser && (
         <ConfirmationModal
           confirmation={confirmDeleteUser}

--- a/frontend/src/theme/components/Heading.ts
+++ b/frontend/src/theme/components/Heading.ts
@@ -10,5 +10,10 @@ const Heading = {
       fontSize: "24px",
     },
   },
+  variants: {
+    light: {
+      fontWeight: "400",
+    },
+  },
 };
 export default Heading;

--- a/frontend/src/utils/hooks/usePagination.tsx
+++ b/frontend/src/utils/hooks/usePagination.tsx
@@ -111,7 +111,7 @@ function usePagination<ResultType>(
 
   const pageResults = results.slice(startIndex, endIndex + 1);
 
-  return { pageResults, paginator };
+  return { loading, pageResults, paginator };
 }
 
 export default usePagination;


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add empty columns table response to UsersTable and StoryTranslationsTable](https://www.notion.so/uwblueprintexecs/Add-empty-columns-table-response-to-UsersTable-and-StoryTranslationsTable-eed664e5b725466da3611c54e0a564bb)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added a new empty table respone component, accepts array of filters to be set to null

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to http://localhost:3000/admin as angela merkel
2. Add some filters until there aren't any rows
3. See that the component shows up
4. Check that it clears the filters!
5. Try other combinations of filters 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Is it safe to assume that the filters can all be set to null? 
- Does it work ok?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
