### PR TITLE
Write get_story and create_story unit tests

### DIFF
--- a/backend/python/app/tests/helpers/db_helpers.py
+++ b/backend/python/app/tests/helpers/db_helpers.py
@@ -1,0 +1,4 @@
+def db_session_add_commit_obj(db, obj):
+    db.session.add(obj)
+    assert db.session.commit() == None
+    return obj

--- a/backend/python/app/tests/helpers/story_helpers.py
+++ b/backend/python/app/tests/helpers/story_helpers.py
@@ -1,6 +1,22 @@
 from ...models.story import Story
 
 
+class StoryRequestDTO:
+    def __init__(
+        self,
+        title,
+        description,
+        youtube_link,
+        level,
+        translated_languages,
+    ):
+        self.title = title
+        self.description = description
+        self.youtube_link = youtube_link
+        self.level = level
+        self.translated_languages = translated_languages
+
+
 def assert_story_equals_model(story_response, story_model, graphql_response=True):
     assert story_response["title"] == story_model.title
     assert story_response["description"] == story_model.description

--- a/backend/python/app/tests/services/test_story_service.py
+++ b/backend/python/app/tests/services/test_story_service.py
@@ -1,5 +1,8 @@
+import pytest
+
 from ...models.story import Story
-from ..helpers.story_helpers import assert_story_equals_model
+from ...models.story_content import StoryContent
+from ..helpers.story_helpers import StoryRequestDTO, assert_story_equals_model
 
 
 def test_get_story(app, db, services):
@@ -11,23 +14,51 @@ def test_get_story(app, db, services):
     assert_story_equals_model(resp, obj, graphql_response=False)
 
 
-def test_get_story_invalid_id():
-    pass
+def test_get_story_invalid_id(app, db, services):
+    with pytest.raises(Exception) as e:
+        _ = services["story"].get_story(-1)
+        assert "Invalid id" in str(e.value)
+
+    obj = Story(title="title", description="description", youtube_link="", level=1)
+    db.session.add(obj)
+    assert db.session.commit() == None
+
+    with pytest.raises(Exception) as e:
+        _ = services["story"].get_story(obj.id + 1)
+        assert "Invalid id" in str(e.value)
 
 
-def test_get_stories():
-    pass
+def test_get_stories(app, db, services):
+    obj = Story(title="title", description="description", youtube_link="", level=1)
+    db.session.add(obj)
+    assert db.session.commit() == None
+
+    obj_1 = Story(
+        title="title_1", description="description_1", youtube_link="", level=2
+    )
+    db.session.add(obj_1)
+    assert db.session.commit() == None
+
+    resp = services["story"].get_stories()
+    assert_story_equals_model(resp[0], obj, graphql_response=False)
+    assert_story_equals_model(resp[1], obj_1, graphql_response=False)
 
 
-def test_create_story():
-    pass
-
-
-def test_create_story_raises_error_if_story_commit_fails_and_nothing_saved():
-    pass
-
-
-def test_create_story_raises_error_if_story_content_commit_fails_and_nothing_saved():
+def test_create_story(app, db, services):
+    story = StoryRequestDTO(
+        title="title",
+        description="description",
+        youtube_link="",
+        level=1,
+        translated_languages=[],
+    )
+    content = ["line1", "line2", "line3"]
+    resp = services["story"].create_story(story, content)
+    story_obj = Story.query.get(resp.id)
+    assert resp == story_obj
+    content_objs = StoryContent.query.filter_by(story_id=resp.id).all()
+    for content_obj, resp_content in zip(content_objs, resp.contents):
+        assert content_obj == resp_content
     pass
 
 


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Write-get_story-get_stories-create_story-tests-in-test_story_service-py-6dd88eabe56b4579a1766da332d607ea

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- write unit test
- make dummy StoryResponseDTO class in story_helper

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. observe that circle ci test pass 😎 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- is it readable?
- what do you think about the dummy StoryResponseDTO class living in story_helper?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
