### PR TITLE
create dummy assigned story_translations_table (Taylor's version)

### DIFF
--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -212,3 +212,19 @@ export const buildStoriesQuery = (
     `,
   };
 };
+
+export const GET_STORY_TRANSLATIONS_BY_USER = (userId: number) => gql`
+  query GetStoryTranslationsByUser{
+    storyTranslationsByUser(
+      userId: ${userId},
+    ) {
+      storyId
+      storyTranslationId: id
+      translatorId
+      reviewerId
+      language
+      ${STORY_FIELDS}
+      stage
+    }
+  }
+`;

--- a/frontend/src/components/admin/AssignedStoryTranslationsTable.tsx
+++ b/frontend/src/components/admin/AssignedStoryTranslationsTable.tsx
@@ -1,0 +1,176 @@
+import React, { useState } from "react";
+import { Icon } from "@chakra-ui/icon";
+import { MdDelete } from "react-icons/md";
+import {
+  Badge,
+  Button,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  IconButton,
+} from "@chakra-ui/react";
+import { StoryTranslation } from "../../APIClients/queries/StoryQueries";
+import { getLevelVariant } from "../../utils/StatusUtils";
+import convertStageTitleCase from "../../utils/StageUtils";
+import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
+
+export type AssignedStoryTranslationsTableProps = {
+  storyTranslations: StoryTranslation[];
+  setStoryTranslations: (newStoryTranslations: StoryTranslation[]) => void;
+  userId: number;
+};
+
+const AssignedStoryTranslationsTable = ({
+  storyTranslations,
+  setStoryTranslations,
+  userId,
+}: AssignedStoryTranslationsTableProps) => {
+  const [isAscendingTitle, setIsAscendingTitle] = useState(true);
+  const [isAscendingRole, setIsAscendingRole] = useState(true);
+  const [isAscendingLanguage, setIsAscendingLanguage] = useState(true);
+  const [isAscendingStage, setIsAscendingStage] = useState(true);
+
+  const getRole = (translation: StoryTranslation) => {
+    if (userId === translation.translatorId) {
+      return "Translator";
+    }
+    if (userId === translation.reviewerId) {
+      return "Reviewer";
+    }
+    return "Error";
+  };
+
+  const titleSort = (t1: StoryTranslation, t2: StoryTranslation) =>
+    isAscendingTitle
+      ? t1.title.localeCompare(t2.title)
+      : t2.title.localeCompare(t1.title);
+
+  const roleSort = (t1: StoryTranslation, t2: StoryTranslation) =>
+    isAscendingRole
+      ? getRole(t1).localeCompare(getRole(t2))
+      : getRole(t2).localeCompare(getRole(t1));
+
+  const languageSort = (t1: StoryTranslation, t2: StoryTranslation) =>
+    isAscendingLanguage
+      ? t1.language.localeCompare(t2.language)
+      : t2.language.localeCompare(t1.language);
+
+  const stageSort = (t1: StoryTranslation, t2: StoryTranslation) =>
+    isAscendingStage
+      ? t1.stage.localeCompare(t2.stage)
+      : t2.stage.localeCompare(t1.stage);
+
+  const sort = (field: String) => {
+    const newStoryTranslations = [...storyTranslations];
+    switch (field) {
+      case "title": {
+        setIsAscendingTitle(!isAscendingTitle);
+
+        newStoryTranslations.sort(titleSort);
+        break;
+      }
+      case "role": {
+        setIsAscendingRole(!isAscendingRole);
+
+        newStoryTranslations.sort(roleSort);
+        break;
+      }
+      case "language": {
+        setIsAscendingLanguage(!isAscendingLanguage);
+
+        newStoryTranslations.sort(languageSort);
+        break;
+      }
+      case "stage": {
+        setIsAscendingStage(!isAscendingStage);
+
+        newStoryTranslations.sort(stageSort);
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+    setStoryTranslations(newStoryTranslations);
+  };
+
+  const tableBody = storyTranslations.map(
+    (translation: StoryTranslation, index: number) => (
+      <Tr
+        borderBottom={
+          index === storyTranslations.length - 1 ? "1em solid transparent" : ""
+        }
+        key={`${translation?.storyTranslationId}`}
+      >
+        <Td>{translation.title}</Td>
+        <Td>{getRole(translation)}</Td>
+        <Td>
+          <Badge
+            background={getLevelVariant(translation.level)}
+            marginBottom="3px"
+            marginTop="3px"
+          >{`${convertLanguageTitleCase(translation.language)} | Level ${
+            translation.level
+          }`}</Badge>
+        </Td>
+        <Td>{convertStageTitleCase(translation.stage)}</Td>
+        <Td>
+          <IconButton
+            aria-label={`Delete story translation for ${translation.title}`}
+            background="transparent"
+            icon={<Icon as={MdDelete} />}
+            width="fit-content"
+          />
+        </Td>
+      </Tr>
+    ),
+  );
+  return (
+    <Table
+      borderRadius="12px"
+      boxShadow="0px 0px 2px grey"
+      size="sm"
+      theme="gray"
+      variant="striped"
+      width="100%"
+    >
+      <Thead>
+        <Tr
+          borderTop="1em solid transparent"
+          borderBottom="0.5em solid transparent"
+        >
+          <Th cursor="pointer" onClick={() => sort("title")}>
+            {`BOOK TITLE ${isAscendingTitle ? "↑" : "↓"}`}{" "}
+          </Th>
+          <Th cursor="pointer" onClick={() => sort("role")}>{`ROLE ${
+            isAscendingRole ? "↑" : "↓"
+          }`}</Th>
+          <Th
+            cursor="pointer"
+            onClick={() => sort("language")}
+          >{`LANGUAGE & LEVEL ${isAscendingLanguage ? "↑" : "↓"}`}</Th>
+          <Th cursor="pointer" onClick={() => sort("stage")}>{`PROGRESS ${
+            isAscendingStage ? "↑" : "↓"
+          }`}</Th>
+          <Th>ACTION</Th>
+        </Tr>
+      </Thead>
+      <Tbody>{tableBody}</Tbody>
+      {/* <hr marginTop="-10px"/>  How do I add a horizontal line lol */}
+      <Button
+        variant="blueOutline"
+        size="secondary"
+        margin="5px 0px 15px 10px"
+        width="200px"
+        border="2px"
+      >
+        ASSIGN NEW STORY
+      </Button>
+    </Table>
+  );
+};
+
+export default AssignedStoryTranslationsTable;

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -21,9 +21,14 @@ import {
 import ConfirmationModal from "../utils/ConfirmationModal";
 import { GET_USER, User } from "../../APIClients/queries/UserQueries";
 import {
+  GET_STORY_TRANSLATIONS_BY_USER,
+  StoryTranslation,
+} from "../../APIClients/queries/StoryQueries";
+import {
   ApprovedLanguagesMap,
   parseApprovedLanguages,
 } from "../../utils/Utils";
+import AssignedStoryTranslationsTable from "../admin/AssignedStoryTranslationsTable";
 
 type UserProfilePageProps = {
   userId: string;
@@ -36,6 +41,9 @@ const UserProfilePage = () => {
   const [email, setEmail] = useState<string>("");
   const [role, setRole] = useState<string>("");
   const [confirmDeleteUser, setConfirmDeleteUser] = useState(false);
+  const [storyTranslations, setStoryTranslations] = useState<
+    StoryTranslation[]
+  >([]);
 
   // TODO: remove this when tables are implemented
   /* eslint-disable */
@@ -65,6 +73,13 @@ const UserProfilePage = () => {
           Object.keys(reviewLanguages).length > 0 ? "& Reviewer" : ""
         }`,
       );
+    },
+  });
+
+  useQuery(GET_STORY_TRANSLATIONS_BY_USER(parseInt(userId, 10)), {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      setStoryTranslations(data.storyTranslationsByUser);
     },
   });
 
@@ -120,15 +135,19 @@ const UserProfilePage = () => {
           </Heading>
           <Text>TODO</Text>
         </Flex>
-        <Flex direction="column" margin="40px">
+        <Flex direction="column" margin="40px" width="100%">
           <Heading size="lg" marginTop="40px">
             Approved Languages & Levels
           </Heading>
           <Text>TODO: table here</Text>
-          <Heading size="lg" marginTop="56px">
+          <Heading size="lg" marginTop="56px" marginBottom="20px">
             Assigned Story Translations
           </Heading>
-          <Text>TODO: table here</Text>
+          <AssignedStoryTranslationsTable
+            storyTranslations={storyTranslations}
+            setStoryTranslations={setStoryTranslations}
+            userId={parseInt(userId, 10)}
+          />
           <Heading size="sm" marginTop="56px">
             Delete user
           </Heading>

--- a/frontend/src/utils/Utils.ts
+++ b/frontend/src/utils/Utils.ts
@@ -48,3 +48,10 @@ export const insertSortedComments = (
   ];
   return comments;
 };
+
+export const generateSortFn =
+  <T extends { [field: string]: any }>(field: string, isAscending: boolean) =>
+  (t1: T, t2: T) =>
+    isAscending
+      ? t1[field].localeCompare(t2[field])
+      : t2[field].localeCompare(t1[field]);


### PR DESCRIPTION
build back better

## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Dummy Assigned Stories Table](https://www.notion.so/uwblueprintexecs/Create-dummy-Assigned-Story-Translations-table-7967d4c1605749498d1d4529dc0c3de0)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Create new table component to display Assigned Story Translations for a user on user page 
- Create new GQL query string to get story translations by user id 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to admin page and click on any user 
2. Ensure that their story translations / reviews are properly displayed 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Styling is correct, entries in table are correct 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
