### PR TITLE
Implement dummy approved languages table

### DIFF
--- a/frontend/src/components/admin/ApprovedLanguagesTable.tsx
+++ b/frontend/src/components/admin/ApprovedLanguagesTable.tsx
@@ -12,6 +12,7 @@ import {
   SliderTrack,
   SliderFilledTrack,
   SliderThumb,
+  SliderMark,
 } from "@chakra-ui/react";
 import { ApprovedLanguagesMap, generateSortFn } from "../../utils/Utils";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
@@ -33,6 +34,7 @@ type ApprovedLanguage = {
   language: string;
   level: number;
   role: string;
+  sliderValue: number;
 };
 
 const ApprovedLanguagesTable = ({
@@ -64,7 +66,6 @@ const ApprovedLanguagesTable = ({
     const { sortFn, isAscending, setIsAscending } = fieldSortDict[field];
     setIsAscending(!isAscending);
     newApprovedLanguages.sort(sortFn);
-    console.log(newApprovedLanguages);
     setApprovedLanguages(newApprovedLanguages);
   };
 
@@ -73,11 +74,11 @@ const ApprovedLanguagesTable = ({
       const translationLanguages = Object.entries(
         approvedLanguagesTranslation,
       ).map(([language, level]) => {
-        return { language, level, role: "Translator" };
+        return { language, level, role: "Translator", sliderValue: level };
       });
-      const reviewLanguages = Object.entries(approvedLanguagesTranslation).map(
+      const reviewLanguages = Object.entries(approvedLanguagesReview).map(
         ([language, level]) => {
-          return { language, level, role: "Reviewer" };
+          return { language, level, role: "Reviewer", sliderValue: level };
         },
       );
       const combined = translationLanguages.concat(reviewLanguages);
@@ -85,6 +86,12 @@ const ApprovedLanguagesTable = ({
       setApprovedLanguages(combined);
     }
   }, [approvedLanguagesTranslation, approvedLanguagesReview]);
+
+  const onSliderValueChange = (index: number, newValue: number) => {
+    const newApprovedLanguages = [...approvedLanguages];
+    newApprovedLanguages[index].sliderValue = newValue;
+    setApprovedLanguages(newApprovedLanguages);
+  };
 
   const tableBody = approvedLanguages.map(
     (approvedLanguage: ApprovedLanguage, index: number) => (
@@ -98,18 +105,29 @@ const ApprovedLanguagesTable = ({
         <Td>{approvedLanguage.role}</Td>
         <Td colSpan={4} align="center">
           <Slider
-            defaultValue={1}
+            defaultValue={approvedLanguage.level}
             min={1}
             max={4}
             step={1}
             marginLeft="20px"
             size="lg"
             width="79%"
+            onChange={(val) => onSliderValueChange(index, val)}
           >
             <SliderTrack height="6px">
               <SliderFilledTrack bg="blue.500" />
             </SliderTrack>
             <SliderThumb />
+            {[1, 2, 3, 4].map((val) => (
+              <SliderMark
+                key={val}
+                value={val}
+                height="6px"
+                width="4px"
+                marginTop="-3px"
+                bg={approvedLanguage.sliderValue > val ? "#64A1CD" : "#ECF1F4"}
+              />
+            ))}
           </Slider>
         </Td>
       </Tr>

--- a/frontend/src/components/admin/ApprovedLanguagesTable.tsx
+++ b/frontend/src/components/admin/ApprovedLanguagesTable.tsx
@@ -1,0 +1,164 @@
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+import {
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Tfoot,
+  Button,
+  Slider,
+  SliderTrack,
+  SliderFilledTrack,
+  SliderThumb,
+} from "@chakra-ui/react";
+import { ApprovedLanguagesMap, generateSortFn } from "../../utils/Utils";
+import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
+
+type ApprovedLanguagesTableProps = {
+  approvedLanguagesTranslation: ApprovedLanguagesMap | undefined;
+  approvedLanguagesReview: ApprovedLanguagesMap | undefined;
+};
+
+interface ApprovedLanguageFieldSortDict {
+  [field: string]: {
+    sortFn: (a: ApprovedLanguage, b: ApprovedLanguage) => number;
+    isAscending: boolean;
+    setIsAscending: Dispatch<SetStateAction<boolean>>;
+  };
+}
+
+type ApprovedLanguage = {
+  language: string;
+  level: number;
+  role: string;
+};
+
+const ApprovedLanguagesTable = ({
+  approvedLanguagesTranslation,
+  approvedLanguagesReview,
+}: ApprovedLanguagesTableProps) => {
+  const [approvedLanguages, setApprovedLanguages] = useState<
+    ApprovedLanguage[]
+  >([]);
+
+  const [isAscendingLanguage, setIsAscendingLanguage] = useState(true);
+  const [isAscendingRole, setIsAscendingRole] = useState(true);
+
+  const fieldSortDict: ApprovedLanguageFieldSortDict = {
+    language: {
+      sortFn: generateSortFn<ApprovedLanguage>("language", isAscendingLanguage),
+      isAscending: isAscendingLanguage,
+      setIsAscending: setIsAscendingLanguage,
+    },
+    role: {
+      sortFn: generateSortFn<ApprovedLanguage>("role", isAscendingRole),
+      isAscending: isAscendingRole,
+      setIsAscending: setIsAscendingRole,
+    },
+  };
+
+  const sortApprovedLanguages = (field: string) => {
+    const newApprovedLanguages = [...approvedLanguages];
+    const { sortFn, isAscending, setIsAscending } = fieldSortDict[field];
+    setIsAscending(!isAscending);
+    newApprovedLanguages.sort(sortFn);
+    console.log(newApprovedLanguages);
+    setApprovedLanguages(newApprovedLanguages);
+  };
+
+  useEffect(() => {
+    if (approvedLanguagesTranslation && approvedLanguagesReview) {
+      const translationLanguages = Object.entries(
+        approvedLanguagesTranslation,
+      ).map(([language, level]) => {
+        return { language, level, role: "Translator" };
+      });
+      const reviewLanguages = Object.entries(approvedLanguagesTranslation).map(
+        ([language, level]) => {
+          return { language, level, role: "Reviewer" };
+        },
+      );
+      const combined = translationLanguages.concat(reviewLanguages);
+      sortApprovedLanguages("language");
+      setApprovedLanguages(combined);
+    }
+  }, [approvedLanguagesTranslation, approvedLanguagesReview]);
+
+  const tableBody = approvedLanguages.map(
+    (approvedLanguage: ApprovedLanguage, index: number) => (
+      <Tr
+        borderBottom={
+          index === approvedLanguages.length - 1 ? "1px solid gray" : ""
+        }
+        key={`${approvedLanguage.language}/${approvedLanguage.role}`}
+      >
+        <Td>{convertLanguageTitleCase(approvedLanguage.language)}</Td>
+        <Td>{approvedLanguage.role}</Td>
+        <Td colSpan={4} align="center">
+          <Slider
+            defaultValue={1}
+            min={1}
+            max={4}
+            step={1}
+            marginLeft="20px"
+            size="lg"
+            width="79%"
+          >
+            <SliderTrack height="6px">
+              <SliderFilledTrack bg="blue.500" />
+            </SliderTrack>
+            <SliderThumb />
+          </Slider>
+        </Td>
+      </Tr>
+    ),
+  );
+
+  return (
+    <Table
+      borderRadius="12px"
+      boxShadow="0px 0px 2px grey"
+      theme="gray"
+      variant="striped"
+      width="100%"
+    >
+      <Thead>
+        <Tr
+          borderTop="1em solid transparent"
+          borderBottom="0.5em solid transparent"
+        >
+          <Th
+            cursor="pointer"
+            onClick={() => sortApprovedLanguages("language")}
+            width="12%"
+          >
+            {`LANGUAGE ${isAscendingLanguage ? "↑" : "↓"}`}
+          </Th>
+          <Th
+            cursor="pointer"
+            onClick={() => sortApprovedLanguages("role")}
+            width="12%"
+          >{`ROLE ${isAscendingRole ? "↑" : "↓"}`}</Th>
+          {["LEVEL 1", "LEVEL 2", "LEVEL 3", "LEVEL 4"].map((level) => (
+            <Th key={level}>{level}</Th>
+          ))}
+        </Tr>
+      </Thead>
+      <Tbody>{tableBody}</Tbody>
+      <Tfoot padding="12px">
+        <Button
+          margin="16px 0px 16px 12px"
+          size="secondary"
+          variant="blueOutline"
+          width="254px"
+        >
+          Approve New Language/Level
+        </Button>
+      </Tfoot>
+    </Table>
+  );
+};
+
+export default ApprovedLanguagesTable;

--- a/frontend/src/components/admin/ApprovedLanguagesTable.tsx
+++ b/frontend/src/components/admin/ApprovedLanguagesTable.tsx
@@ -87,6 +87,7 @@ const ApprovedLanguagesTable = ({
     }
   }, [approvedLanguagesTranslation, approvedLanguagesReview]);
 
+  // TODO: call gql mutation to update the level
   const onSliderValueChange = (index: number, newValue: number) => {
     const newApprovedLanguages = [...approvedLanguages];
     newApprovedLanguages[index].sliderValue = newValue;
@@ -125,6 +126,7 @@ const ApprovedLanguagesTable = ({
                 height="6px"
                 width="4px"
                 marginTop="-3px"
+                // #64A1CD is light blue, #ECF1F4 is light gray
                 bg={approvedLanguage.sliderValue > val ? "#64A1CD" : "#ECF1F4"}
               />
             ))}

--- a/frontend/src/components/admin/AssignedStoryTranslationsTable.tsx
+++ b/frontend/src/components/admin/AssignedStoryTranslationsTable.tsx
@@ -126,7 +126,6 @@ const AssignedStoryTranslationsTable = ({
     <Table
       borderRadius="12px"
       boxShadow="0px 0px 2px grey"
-      size="sm"
       theme="gray"
       variant="striped"
       width="100%"

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -24,6 +24,7 @@ import {
   ApprovedLanguagesMap,
   parseApprovedLanguages,
 } from "../../utils/Utils";
+import ApprovedLanguagesTable from "../admin/ApprovedLanguagesTable";
 
 type UserProfilePageProps = {
   userId: string;
@@ -37,8 +38,6 @@ const UserProfilePage = () => {
   const [role, setRole] = useState<string>("");
   const [confirmDeleteUser, setConfirmDeleteUser] = useState(false);
 
-  // TODO: remove this when tables are implemented
-  /* eslint-disable */
   const [approvedLanguagesTranslation, setApprovedLanguagesTranslation] =
     useState<ApprovedLanguagesMap>();
   const [approvedLanguagesReview, setApprovedLanguagesReview] =
@@ -95,8 +94,6 @@ const UserProfilePage = () => {
   if (loading) return <div />;
   if (error) return <Redirect to="/404" />;
 
-  // TODO: make util function for parsing json
-
   return (
     <Flex direction="column" height="100vh">
       <Header />
@@ -120,11 +117,14 @@ const UserProfilePage = () => {
           </Heading>
           <Text>TODO</Text>
         </Flex>
-        <Flex direction="column" margin="40px">
-          <Heading size="lg" marginTop="40px">
+        <Flex direction="column" margin="40px" flex={1}>
+          <Heading size="lg" marginTop="40px" marginBottom="20px">
             Approved Languages & Levels
           </Heading>
-          <Text>TODO: table here</Text>
+          <ApprovedLanguagesTable
+            approvedLanguagesTranslation={approvedLanguagesTranslation}
+            approvedLanguagesReview={approvedLanguagesReview}
+          />
           <Heading size="lg" marginTop="56px">
             Assigned Story Translations
           </Heading>
@@ -158,7 +158,6 @@ const UserProfilePage = () => {
           <Button colorScheme="blue" variant="blueOutline">
             Cancel
           </Button>
-          {/* TODO: make this functional.*/}
           <Button colorScheme="blue" marginLeft="24px" marginRight="48px">
             Save Changes
           </Button>

--- a/frontend/src/utils/Utils.ts
+++ b/frontend/src/utils/Utils.ts
@@ -48,3 +48,10 @@ export const insertSortedComments = (
   ];
   return comments;
 };
+
+export const generateSortFn =
+  <T extends { [field: string]: any }>(field: string, isAscending: boolean) =>
+  (t1: T, t2: T) =>
+    isAscending
+      ? t1[field].localeCompare(t2[field])
+      : t2[field].localeCompare(t1[field]);


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Create-dummy-Approved-Languages-Levels-table-5de91af7e3064d70b10e6dade6133b6b

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Created new table component to display user's Approved Languages & Levels
- Created a dummy slider

![image](https://user-images.githubusercontent.com/45080644/143365098-3131357a-e787-4bff-a663-abfffdfa2bba.png)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login to angela merkel and go to any `/user/:id`
2. Ensure that the table looks correct

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does the slider look okay?
- Does the sorting work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
