### PR TITLE
Fix slider contrast

### DIFF
--- a/frontend/src/components/admin/ApprovedLanguagesTable.tsx
+++ b/frontend/src/components/admin/ApprovedLanguagesTable.tsx
@@ -118,7 +118,7 @@ const ApprovedLanguagesTable = ({
             <SliderTrack height="6px">
               <SliderFilledTrack bg="blue.500" />
             </SliderTrack>
-            <SliderThumb />
+            <SliderThumb boxShadow="0px 0px 3px black" />
             {[1, 2, 3, 4].map((val) => (
               <SliderMark
                 key={val}

--- a/frontend/src/components/translation/FontSizeSlider.tsx
+++ b/frontend/src/components/translation/FontSizeSlider.tsx
@@ -49,7 +49,7 @@ const FontSizeSlider = ({ setFontSize }: FontSizeSliderProps) => {
           <Box position="relative" right={10} />
           <SliderFilledTrack />
         </SliderTrack>
-        <SliderThumb boxSize={3} />
+        <SliderThumb boxSize={3} boxShadow="0px 0px 2px black" />
       </Slider>
     </Box>
   );


### PR DESCRIPTION

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- fix slider button contrast for approved languages table and font size slider

### before
![image](https://user-images.githubusercontent.com/45080644/143375013-e86fde17-539d-43fb-9da0-002606f4f435.png)

### after
![image](https://user-images.githubusercontent.com/45080644/143375088-f5a98a2a-6e14-4f3c-977f-7d15d3b66d4c.png)
![image](https://user-images.githubusercontent.com/45080644/143375220-6a758f02-4cd4-4dd2-a726-0137d609b83f.png)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
