### PR TITLE
Display reviewer and translator names on manage story translation page

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -215,6 +215,10 @@ class StoryService(IStoryService):
 
     def get_story_translation(self, id):
         try:
+
+            translator = aliased(User)
+            reviewer = aliased(User)
+
             story_details = (
                 db.session.query(
                     Story.id.label("story_id"),
@@ -233,11 +237,23 @@ class StoryService(IStoryService):
                     StoryTranslationContent.translation_content.label(
                         "translation_content"
                     ),
+                    (translator.first_name + " " + translator.last_name).label("translator_name"),
+                    (reviewer.first_name + " " + reviewer.last_name).label("reviewer_name"),
                 )
                 .join(StoryTranslation, Story.id == StoryTranslation.story_id)
                 .join(
                     StoryTranslationContent,
                     StoryTranslationContent.story_translation_id == StoryTranslation.id,
+                )
+                .join(
+                    translator,
+                    StoryTranslation.translator_id == translator.id,
+                    isouter=True,
+                )
+                .join(
+                    reviewer,
+                    StoryTranslation.reviewer_id == reviewer.id,
+                    isouter=True,
                 )
                 .filter(StoryTranslation.id == id)
                 .all()

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -237,8 +237,12 @@ class StoryService(IStoryService):
                     StoryTranslationContent.translation_content.label(
                         "translation_content"
                     ),
-                    (translator.first_name + " " + translator.last_name).label("translator_name"),
-                    (reviewer.first_name + " " + reviewer.last_name).label("reviewer_name"),
+                    (translator.first_name + " " + translator.last_name).label(
+                        "translator_name"
+                    ),
+                    (reviewer.first_name + " " + reviewer.last_name).label(
+                        "reviewer_name"
+                    ),
                 )
                 .join(StoryTranslation, Story.id == StoryTranslation.story_id)
                 .join(

--- a/frontend/src/components/pages/ManageStoryTranslationPage.tsx
+++ b/frontend/src/components/pages/ManageStoryTranslationPage.tsx
@@ -176,14 +176,12 @@ const ManageStoryTranslationPage = () => {
           {/* TODO: Use translatorName and reviewerName */}
           <Heading size="sm">Translator</Heading>
           <Link isExternal href={`/user/${translatorId}`}>
-            {translatorId}
             {translatorName}
           </Link>
           {reviewerId && (
             <>
               <Heading size="sm">Reviewer</Heading>
               <Link isExternal href={`/user/${reviewerId}`}>
-                {reviewerId}
                 {reviewerName}
               </Link>
             </>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Display translatorName and reviewerName in ManageStoryTranslationPage](https://www.notion.so/uwblueprintexecs/Display-translatorName-and-reviewerName-in-ManageStoryTranslationPage-62793d5d5d874586b0be692f2cda6f57)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Modified get_story_translation query
- Minor fix for frontend (removed id so it only displays the name)
![image](https://user-images.githubusercontent.com/32991028/143796266-f8ba9edd-a365-492d-a7e7-9d64e78f8ab8.png)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. View Manage Story Translation page

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- format of names in the query itself

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
