### PR TITLE
Use git ftp push instead of init

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
             git config git-ftp.url ${HOST}
             git config git-ftp.user ${USERNAME}
             git config git-ftp.password ${PASSWORD}
-            git ftp init --insecure --syncroot frontend/build
+            git ftp push --insecure --syncroot frontend/build
             echo "Frontend deployed!"
       - run:
           name: Deploy backend
@@ -92,7 +92,7 @@ jobs:
             git config git-ftp.url "${HOST}/~/backend/"
             git config git-ftp.user ${USERNAME}
             git config git-ftp.password ${PASSWORD}
-            git ftp init --insecure --syncroot backend/python
+            git ftp push --insecure --syncroot backend/python
             echo "Backend deployed!"
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Code is pushed to the server on each new release. Releases should be tagged as `
 1. Follow [this link](https://github.com/uwblueprint/planet-read/releases/new) to create a new release
 2. Create a new tag based on the major minor versioning scheme above (i.e. `v1.X.Y`). Ensure the target branch is set to `main`
 3. Enter the release title: `v1.X.Y`
-4. In the description, highlight key features/tickets included in the release
+4. In the description, highlight key features/tickets included in the release, and click the button to `Auto-generate release notes`
 5. Click `Publish Release` and verify the CircleCI deploy job passes!
 
 You can view all releases [here](https://github.com/uwblueprint/planet-read/releases), and all tags [here](https://github.com/uwblueprint/planet-read/tags).


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Change command to `git ftp push ...` instead of `git ftp init`, as a follow up to #158 
- This was necessary to sync the git log file on the server with the main branch commit's 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Does this pass https://app.circleci.com/pipelines/github/uwblueprint/planet-read/1242/workflows/c72ec32d-ebea-494b-b101-d989d6c7fcd5

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
