### PR TITLE
Update User Profile

### DIFF
--- a/backend/python/app/graphql/mutations/user_mutation.py
+++ b/backend/python/app/graphql/mutations/user_mutation.py
@@ -101,12 +101,3 @@ class SoftDeleteUser(graphene.Mutation):
         except Exception as e:
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))
-
-
-"""
-TODO mutations:
- UpdateUserByID(id: ID!, user: UpdateUserDTO!): UserDTO!
- deleteUserById(id: ID!): ID
- deleteUserByEmail(email: String!): IDdeleteUserById
- deleteUserByEmail
-"""

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -24,8 +24,9 @@ from .mutations.story_mutation import (
 from .mutations.user_mutation import (
     CreateUser,
     SoftDeleteUser,
-    UpdateUser,
+    UpdateMe,
     UpdateUserApprovedLanguages,
+    UpdateUserByID,
 )
 from .queries.comment_query import resolve_comments_by_story_translation
 from .queries.file_query import resolve_file_by_id
@@ -56,7 +57,8 @@ class Mutation(graphene.ObjectType):
     create_user = CreateUser.Field()
     create_story_translation = CreateStoryTranslation.Field()
     reset_password = ResetPassword.Field()
-    update_user = UpdateUser.Field()
+    update_me = UpdateMe.Field()
+    update_user_by_id = UpdateUserByID.Field()
     login = Login.Field()
     login_with_google = LoginWithGoogle.Field()
     logout = Logout.Field()

--- a/backend/python/app/graphql/types/user_type.py
+++ b/backend/python/app/graphql/types/user_type.py
@@ -49,7 +49,7 @@ class CreateUserWithGoogleDTO(graphene.InputObjectType):
 class UpdateUserDTO(graphene.InputObjectType):
     first_name = graphene.String(required=True)
     last_name = graphene.String(required=True)
-    role = graphene.Argument(RoleEnum, required=True)
+    role = graphene.Argument(RoleEnum)
     email = graphene.String(required=True)
     resume = graphene.Int(required=False, default=None)
     profile_pic = graphene.Int(required=False, default=None)

--- a/backend/python/app/services/implementations/user_service.py
+++ b/backend/python/app/services/implementations/user_service.py
@@ -290,7 +290,7 @@ class UserService(IUserService):
                 )
             )
             raise e
-        
+
         return UserService.get_user_by_id(self, user_id)
 
     def update_user_by_id(self, user_id, user):


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add gql mutation to update user profile ](https://www.notion.so/uwblueprintexecs/Add-gql-mutation-to-update-user-profile-3bb87ef76ece4c1c94fa6550b238a14f)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- added a new gql for users to update their own profiles 
   - Currently getting the user id in the graphql stage and passing, since importing the auth middleware into user_service creates a circular dependency -- would there be a better way to do this?
- require authentication for the update user by ID mutation (for admin)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to altair / or some other graphql gui 
2. Login as a [User](http://localhost:5000/graphql?variables=null&operationName=undefined&query=%0Amutation%20%7B%0A%20%20login%20(email%3A%22planetread%2Bmiroslavklose%40uwblueprint.org%22%2C%20password%3A%22dolphins_are_cool%22)%20%7B%0A%20%20%20%20accessToken%0A%20%20%20%20refreshToken%0A%20%20%20%20id%0A%20%20%7D%0A%7D) and set the header 
3. Try different mutations ([example](http://localhost:5000/graphql?variables=null&operationName=updateMe&query=mutation%20updateMe%20%7B%0A%20%20updateMe(user%3A%7BfirstName%3A%22miroslav%22%2C%20lastName%3A%22klose%22%2C%20role%3AUser%2C%20email%3A%20%22planetread%2Bmiro%40uwblueprint.org%22%7D)%7B%0A%20%20%20%20user%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20firstName%0A%20%20%20%20%20%20lastName%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)) by adding different fields -- users should not be able to update role and approved languages on the updateMe mutation 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
