### PR TITLE
Remove user from story translation

### DIFF
--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -69,6 +69,24 @@ class AssignUserAsReviewer(graphene.Mutation):
             raise Exception(error_message if error_message else str(e))
 
 
+class RemoveReviewerFromStoryTranslation(graphene.Mutation):
+    class Arguments:
+        story_translation_id = graphene.ID(required=True)
+
+    ok = graphene.Boolean()
+
+    def mutate(root, info, story_translation_id):
+        try:
+            story_translation = services["story"].get_story_translation(
+                story_translation_id
+            )
+            services["story"].remove_reviewer_from_story_translation(story_translation)
+            return RemoveReviewerFromStoryTranslation(ok=True)
+        except Exception as e:
+            error_message = getattr(e, "message", None)
+            raise Exception(error_message if error_message else str(e))
+
+
 class UpdateStoryTranslationContents(graphene.Mutation):
     class Arguments:
         story_translation_contents = graphene.List(StoryTranslationContentRequestDTO)

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -15,6 +15,7 @@ from .mutations.story_mutation import (
     AssignUserAsReviewer,
     CreateStory,
     CreateStoryTranslation,
+    RemoveReviewerFromStoryTranslation,
     RemoveUserFromStoryTranslation,
     SoftDeleteStoryTranslation,
     UpdateStory,
@@ -66,6 +67,7 @@ class Mutation(graphene.ObjectType):
     signup = SignUp.Field()
     refresh = Refresh.Field()
     assign_user_as_reviewer = AssignUserAsReviewer.Field()
+    remove_reviewer_from_story_translation = RemoveReviewerFromStoryTranslation.Field()
     update_comment_by_id = UpdateCommentById.Field()
     update_comments = UpdateComments.Field()
     update_story = UpdateStory.Field()

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -321,6 +321,20 @@ class StoryService(IStoryService):
             self.logger.error("User can't be assigned as a reviewer")
             raise Exception("User can't be assigned as a reviewer")
 
+    def remove_reviewer_from_story_translation(self, story_translation):
+        try:
+            story_translation = StoryTranslation.query.get(story_translation["id"])
+            story_translation.reviewer_id = None
+            db.session.commit()
+        except Exception as error:
+            reason = getattr(error, "message", None)
+            self.logger.error(
+                "Failed to remove reviewer from story translation. Reason = {reason}".format(
+                    reason=(reason if reason else str(error))
+                )
+            )
+            raise error
+
     def update_story(self, story_id, title, description, youtube_link):
         try:
             story = Story.query.get(story_id)

--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -79,6 +79,18 @@ export const ASSIGN_REVIEWER = gql`
 // TODO: update mutation to retrieve story translation fields
 export type AssignReviewerResponse = { ok: boolean };
 
+export const UNASSIGN_REVIEWER = gql`
+  mutation UnassignReviewer($storyTranslationId: ID!) {
+    removeReviewerFromStoryTranslation(
+      storyTranslationId: $storyTranslationId
+    ) {
+      ok
+    }
+  }
+`;
+
+export type UnassignReviewerResponse = { ok: boolean };
+
 export const UPDATE_STORY_TRANSLATION_STAGE = gql`
   mutation UpdateStoryTranslationStage(
     $storyTranslationData: UpdateStoryTranslationStageRequestDTO!

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -54,3 +54,12 @@ export const ASSIGN_STORY_CONFIRMATION =
   "By assigning a story to the user, other users can no longer assign themselves to the same role for this story.";
 
 export const ASSIGN_STORY_BUTTON = "I'm sure, assign story";
+
+export const UNASSIGN_TRANSLATOR_FROM_STORY_TRANSLATION_CONFIRMATION =
+  "By removing the translator from this story translation, this story translation will be deleted. This action cannot be undone.";
+
+export const UNASSIGN_REVIEWER_FROM_STORY_TRANSLATION_CONFIRMATION =
+  "By removing the reviewer from this story translation, the user will not be able to access this translation. The translation will need a new reviewer. This action cannot be undone.";
+
+export const UNASSIGN_USER_FROM_STORY_TRANSLATION_BUTTON =
+  "I'm sure, remove user";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket](https://www.notion.so/uwblueprintexecs/Remove-user-from-story-translation-on-Assigned-Story-Translations-Table-120f15751a3b40248c1bbe4c8fdc389f)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- added gql mutation to remove a reviewer from a story translation
- if the user is a translator, soft delete story translation - otherwise unassign user as reviewer

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Log in as angela merkel
2. Go to any `/user/:id`
3. In the "Assigned Story Translations" table, click the delete icon on any row (try both Translator and Reviewer rows)
4. After confirming, verify that the page reloads and the row is gone

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does the delete flow work for both Translator and Reviewer rows?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
