### PR TITLE
make approved languages table functional

### DIFF
--- a/frontend/src/APIClients/mutations/UserMutations.ts
+++ b/frontend/src/APIClients/mutations/UserMutations.ts
@@ -8,3 +8,29 @@ export const SOFT_DELETE_USER = gql`
   }
 `;
 export type SoftDeleteUserResponse = { ok: boolean };
+
+export const UPDATE_USER_APPROVED_LANGUAGES = gql`
+  mutation UpdateUserApprovedLanguages(
+    $userId: ID!
+    $isTranslate: Boolean!
+    $language: String!
+    $level: Int!
+  ) {
+    updateUserApprovedLanguage(
+      userId: $userId
+      isTranslate: $isTranslate
+      language: $language
+      level: $level
+    ) {
+      user {
+        id
+      }
+    }
+  }
+`;
+
+export type UpdateUserApprovedLanguagesResponse = {
+  user: {
+    id: number;
+  };
+};

--- a/frontend/src/components/admin/ApprovedLanguagesTable.tsx
+++ b/frontend/src/components/admin/ApprovedLanguagesTable.tsx
@@ -43,6 +43,8 @@ type ApprovedLanguagesTableProps = {
   userId: number;
   setAlertText: (newText: string) => void;
   setAlert: (open: boolean) => void;
+  alertTimeout: number;
+  setAlertTimeout: (id: number) => void;
 };
 
 const ApprovedLanguagesTable = ({
@@ -51,6 +53,8 @@ const ApprovedLanguagesTable = ({
   userId,
   setAlertText,
   setAlert,
+  alertTimeout,
+  setAlertTimeout,
 }: ApprovedLanguagesTableProps) => {
   const [approvedLanguages, setApprovedLanguages] = useState<
     ApprovedLanguage[]
@@ -73,7 +77,7 @@ const ApprovedLanguagesTable = ({
       isTranslate ? "Translator" : "Reviewer"
     }'s approval for ${convertLanguageTitleCase(
       language,
-    )} has been updated to Level ${level} from Level ${oldLevel}.`;
+    )} has been updated: Level ${oldLevel} → Level ${level}.`;
   };
 
   const callUpdateUserApprovedLanguagesMutation = async (
@@ -94,6 +98,10 @@ const ApprovedLanguagesTable = ({
     if (result.data !== undefined) {
       setAlert(true);
       setAlertText(getAlertText(isTranslate, language, level, oldLevel));
+
+      window.clearTimeout(alertTimeout);
+      const timeout: number = window.setTimeout(() => setAlert(false), 5000);
+      setAlertTimeout(timeout);
     }
   };
 
@@ -148,7 +156,6 @@ const ApprovedLanguagesTable = ({
       newLevel,
       oldLevel,
     );
-    setTimeout(() => setAlert(false), 5000);
   };
 
   const tableBody = approvedLanguages.map(
@@ -207,6 +214,7 @@ const ApprovedLanguagesTable = ({
       theme="gray"
       variant="striped"
       width="100%"
+      marginTop="20px"
     >
       <Thead>
         <Tr

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -44,6 +44,8 @@ const UserProfilePage = () => {
   const [email, setEmail] = useState<string>("");
   const [role, setRole] = useState<string>("");
   const [confirmDeleteUser, setConfirmDeleteUser] = useState(false);
+  const [alertText, setAlertText] = useState<string>("");
+  const [alert, setAlert] = useState(false);
   const [storyTranslations, setStoryTranslations] = useState<
     StoryTranslation[]
   >([]);
@@ -139,12 +141,16 @@ const UserProfilePage = () => {
           <Text>TODO</Text>
         </Flex>
         <Flex direction="column" margin="40px" flex={1}>
+          {alert && <InfoAlert message={alertText} />}
           <Heading size="lg" marginTop="40px" marginBottom="20px">
             Approved Languages & Levels
           </Heading>
           <ApprovedLanguagesTable
             approvedLanguagesTranslation={approvedLanguagesTranslation}
             approvedLanguagesReview={approvedLanguagesReview}
+            userId={parseInt(userId, 10)}
+            setAlertText={setAlertText}
+            setAlert={setAlert}
           />
           <Heading size="lg" marginTop="56px" marginBottom="20px">
             Assigned Story Translations

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -46,6 +46,7 @@ const UserProfilePage = () => {
   const [confirmDeleteUser, setConfirmDeleteUser] = useState(false);
   const [alertText, setAlertText] = useState<string>("");
   const [alert, setAlert] = useState(false);
+  const [alertTimeout, setAlertTimeout] = useState(0);
   const [storyTranslations, setStoryTranslations] = useState<
     StoryTranslation[]
   >([]);
@@ -141,16 +142,22 @@ const UserProfilePage = () => {
           <Text>TODO</Text>
         </Flex>
         <Flex direction="column" margin="40px" flex={1}>
-          {alert && <InfoAlert message={alertText} />}
-          <Heading size="lg" marginTop="40px" marginBottom="20px">
+          <Heading size="lg" marginTop="40px" marginBottom="10px">
             Approved Languages & Levels
           </Heading>
+          {alert ? (
+            <InfoAlert message={alertText} colour="orange.50" />
+          ) : (
+            <Flex height="50px" />
+          )}
           <ApprovedLanguagesTable
             approvedLanguagesTranslation={approvedLanguagesTranslation}
             approvedLanguagesReview={approvedLanguagesReview}
             userId={parseInt(userId, 10)}
             setAlertText={setAlertText}
             setAlert={setAlert}
+            alertTimeout={alertTimeout}
+            setAlertTimeout={setAlertTimeout}
           />
           <Heading size="lg" marginTop="56px" marginBottom="20px">
             Assigned Story Translations

--- a/frontend/src/components/utils/InfoAlert.tsx
+++ b/frontend/src/components/utils/InfoAlert.tsx
@@ -2,19 +2,21 @@ import React from "react";
 import { Alert, AlertIcon } from "@chakra-ui/react";
 import { MdInfoOutline } from "react-icons/md";
 
-type AlertProps = {
+export type AlertProps = {
   message: string;
+  colour?: string;
 };
 
-const InfoAlert = ({ message }: AlertProps) => {
+const InfoAlert = ({ message, colour = "gray.200" }: AlertProps) => {
   return (
     <Alert
       status="info"
       borderRadius={8}
-      bg="gray.200"
+      bg={colour}
       justifyContent="center"
       textColor="black"
       opacity="60%"
+      height="50px"
     >
       <AlertIcon as={MdInfoOutline} color="black" />
       {message}


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[:3 ](https://www.notion.so/uwblueprintexecs/Make-Approved-Languages-Levels-table-functional-e772071c9f3c422584afa806bb680b1a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Make sliders functional by calling GQL mutation to update user approved language level 
- Add alert to indicate to admin that level for user has been updated 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate --> 

## Steps to test

1. Go to User Profile page 
2. Change the levels for that user 
3. Refresh page, ensure changes persist 
4. Ensure that alert pops up when a level gets updated and the alert disappears after a few 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Sliders functionality 
- Alerts show up when appropriate 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
