### PR TITLE
Modify translation page to accommodate story tests

### DIFF
--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -54,6 +54,9 @@ const TranslationPage = () => {
   const [language, setLanguage] = useState<string>("");
   const [stage, setStage] = useState<string>("");
 
+  // TODO: remove eslint comment when setIsTest is used
+  const [isTest, setIsTest] = useState(false);  // eslint-disable-line
+
   // AutoSave
   const [changedStoryLines, setChangedStoryLines] = useState<
     Map<number, StoryLine>
@@ -173,6 +176,9 @@ const TranslationPage = () => {
         setTitle(data.storyById.title);
         setNumTranslatedLines(data.storyTranslationById.numTranslatedLines);
 
+        // TODO: uncomment when query is updated
+        // setIsTest(data.storyById.isTest);
+
         const contentArray: StoryLine[] = [];
         storyContent.forEach(({ content, lineIndex }: Content) => {
           contentArray.push({
@@ -225,7 +231,7 @@ const TranslationPage = () => {
   if (+authenticatedUser!!.id !== translatorId) return <Redirect to="/404" />;
 
   return (
-    <Flex height="100vh" direction="column" position="absolute">
+    <Flex height="100vh" width="100%" direction="column" position="absolute">
       <Header title={title} />
       <Divider />
       <Flex justify="space-between" flex={1} minHeight={0}>
@@ -269,6 +275,7 @@ const TranslationPage = () => {
               translator
               setTranslatedStoryLines={setTranslatedStoryLines}
               changedStoryLines={changedStoryLines.size}
+              isTest={isTest}
             />
           </Flex>
           <Flex margin="20px 30px" justify="space-between" alignItems="center">
@@ -297,15 +304,17 @@ const TranslationPage = () => {
             </Tooltip>
           </Flex>
         </Flex>
-        <CommentsPanel
-          disabled={!editable}
-          storyTranslationContentId={storyTranslationContentId}
-          commentLine={commentLine}
-          storyTranslationId={storyTranslationId}
-          setCommentLine={setCommentLine}
-          setTranslatedStoryLines={setTranslatedStoryLines}
-          translatedStoryLines={translatedStoryLines}
-        />
+        {!isTest && (
+          <CommentsPanel
+            disabled={!editable}
+            storyTranslationContentId={storyTranslationContentId}
+            commentLine={commentLine}
+            storyTranslationId={storyTranslationId}
+            setCommentLine={setCommentLine}
+            setTranslatedStoryLines={setTranslatedStoryLines}
+            translatedStoryLines={translatedStoryLines}
+          />
+        )}
       </Flex>
       <Autosave
         storylines={Array.from(changedStoryLines.values())}

--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -32,6 +32,7 @@ export type TranslationTableProps = {
   changedStoryLines?: number;
   isReviewable?: boolean;
   reviewPage?: boolean;
+  isTest?: boolean;
 };
 
 const TranslationTable = ({
@@ -52,6 +53,7 @@ const TranslationTable = ({
   changedStoryLines,
   isReviewable = false,
   reviewPage = false,
+  isTest = false,
 }: TranslationTableProps) => {
   const handleCommentButton = (
     displayLineNumber: number,
@@ -99,47 +101,61 @@ const TranslationTable = ({
             </Flex>
           </Tooltip>
         )}
-        <Flex direction="column" width="140px" margin="5px">
-          {isReviewable ? (
-            <StatusBadge
-              translatedStoryLines={translatedStoryLines}
-              setTranslatedStoryLines={setTranslatedStoryLines}
-              storyLine={storyLine}
-              numApprovedLines={numApprovedLines!!}
-              setNumApprovedLines={setNumApprovedLines!!}
-            />
-          ) : (
-            <Tooltip
-              hasArrow
-              label={REVIEW_PAGE_TOOL_TIP_COPY}
-              isDisabled={editable || !reviewPage}
-            >
-              <Badge
-                textTransform="capitalize"
-                variant={getStatusVariant(storyLine.status)}
-                marginBottom="10px"
+        {!isTest && (
+          <Flex direction="column" width="140px" margin="5px">
+            {isReviewable ? (
+              <StatusBadge
+                translatedStoryLines={translatedStoryLines}
+                setTranslatedStoryLines={setTranslatedStoryLines}
+                storyLine={storyLine}
+                numApprovedLines={numApprovedLines!!}
+                setNumApprovedLines={setNumApprovedLines!!}
+              />
+            ) : (
+              <Tooltip
+                hasArrow
+                label={REVIEW_PAGE_TOOL_TIP_COPY}
+                isDisabled={editable || !reviewPage}
               >
-                {storyLine.status}
-              </Badge>
-            </Tooltip>
-          )}
-          {commentLine > -1 && (
-            <Button
-              variant="addComment"
-              onClick={() =>
-                handleCommentButton(
-                  displayLineNumber,
-                  storyLine.storyTranslationContentId!!,
-                )
-              }
-            >
-              Comment
-            </Button>
-          )}
-        </Flex>
+                <Badge
+                  textTransform="capitalize"
+                  variant={getStatusVariant(storyLine.status)}
+                  marginBottom="10px"
+                >
+                  {storyLine.status}
+                </Badge>
+              </Tooltip>
+            )}
+            {commentLine > -1 && (
+              <Button
+                variant="addComment"
+                onClick={() =>
+                  handleCommentButton(
+                    displayLineNumber,
+                    storyLine.storyTranslationContentId!!,
+                  )
+                }
+              >
+                Comment
+              </Button>
+            )}
+          </Flex>
+        )}
       </Flex>
     );
   });
+
+  const statusHeader = isReviewable ? (
+    <ApproveAll
+      numApprovedLines={numApprovedLines!}
+      setNumApprovedLines={setNumApprovedLines!!}
+      totalLines={translatedStoryLines.length}
+      storyTranslationId={storyTranslationId}
+    />
+  ) : (
+    <Text variant="statusHeader">Status</Text>
+  );
+
   return (
     <Flex direction="column">
       <Flex alignItems="flex-start" direction="row">
@@ -161,16 +177,7 @@ const TranslationTable = ({
             )}
           </Text>
         </Flex>
-        {isReviewable ? (
-          <ApproveAll
-            numApprovedLines={numApprovedLines!}
-            setNumApprovedLines={setNumApprovedLines!!}
-            totalLines={translatedStoryLines.length}
-            storyTranslationId={storyTranslationId}
-          />
-        ) : (
-          <Text variant="statusHeader">Status</Text>
-        )}
+        {!isTest && statusHeader}
       </Flex>
       {storyCells}
     </Flex>

--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -63,6 +63,8 @@ const TranslationTable = ({
     setStoryTranslationContentId(storyTranslationContentId);
   };
 
+  const showStatusColumn = !isTest || isReviewable;
+
   const storyCells = translatedStoryLines.map((storyLine: StoryLine) => {
     const displayLineNumber = storyLine.lineIndex + 1;
     return (
@@ -101,7 +103,7 @@ const TranslationTable = ({
             </Flex>
           </Tooltip>
         )}
-        {!isTest && (
+        {showStatusColumn && (
           <Flex direction="column" width="140px" margin="5px">
             {isReviewable ? (
               <StatusBadge
@@ -145,16 +147,17 @@ const TranslationTable = ({
     );
   });
 
-  const statusHeader = isReviewable ? (
-    <ApproveAll
-      numApprovedLines={numApprovedLines!}
-      setNumApprovedLines={setNumApprovedLines!!}
-      totalLines={translatedStoryLines.length}
-      storyTranslationId={storyTranslationId}
-    />
-  ) : (
-    <Text variant="statusHeader">Status</Text>
-  );
+  const StatusHeader = () =>
+    isReviewable ? (
+      <ApproveAll
+        numApprovedLines={numApprovedLines!}
+        setNumApprovedLines={setNumApprovedLines!!}
+        totalLines={translatedStoryLines.length} // eslint-disable-line
+        storyTranslationId={storyTranslationId}
+      />
+    ) : (
+      <Text variant="statusHeader">Status</Text>
+    );
 
   return (
     <Flex direction="column">
@@ -177,7 +180,7 @@ const TranslationTable = ({
             )}
           </Text>
         </Flex>
-        {!isTest && statusHeader}
+        {showStatusColumn && <StatusHeader />}
       </Flex>
       {storyCells}
     </Flex>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket](https://www.notion.so/uwblueprintexecs/Modify-translation-platform-to-accommodate-story-translation-tests-909f4e2dd1ad49c286f79fa956e021ab)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- added `isTest` state to toggle comment panel and status column in `TranslationPage.tsx`

![not story test](https://user-images.githubusercontent.com/45080644/145743894-34ff1576-dbba-47ba-8b5a-5a5b4c894caa.PNG)

![story test](https://user-images.githubusercontent.com/45080644/145743885-324e1104-00bc-49ec-adad-f60094f49b7e.PNG)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to `translation/1/1`
2. Verify that the translation page looks as usual
3. Change [this line](https://github.com/uwblueprint/planet-read/blob/3942e826245627b790b221b038934e92e6011452/frontend/src/components/pages/TranslationPage.tsx#L58) to `useState(true)`
4. Verify that the comment panel and status column are gone 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it look okay?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
