### PR TITLE
Modify updateStoryTranslationContents for grading

### DIFF
--- a/backend/python/app/middlewares/auth.py
+++ b/backend/python/app/middlewares/auth.py
@@ -179,6 +179,12 @@ def require_authorization_as_story_user_by_role(as_translator):
         def wrapper(root, info, *args, **kwargs):
             access_token = get_access_token(info.context)
 
+            authorized_as_admin = auth_service.is_authorized_by_role(
+                access_token, {"Admin"}
+            )
+            if authorized_as_admin:
+                return api_func(root, info, *args, **kwargs)
+
             authorized = False
             if "story_translation_id" in kwargs:
                 authorized = (

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -536,6 +536,17 @@ class StoryService(IStoryService):
             ).first()
 
             if story_translation.stage == "REVIEW":
+                if story_translation.is_test:
+                    if not "TEST_" in status:
+                        raise Exception(
+                            "Error. Story Translation Test cannot have non-test statuses on story translation content."
+                        )
+                else:
+                    if "TEST_" in status:
+                        raise Exception(
+                            "Error. Story Translation cannot have test statuses on story translation content."
+                        )
+
                 story_translation_content.status = status
                 db.session.commit()
             else:

--- a/backend/python/migrations/versions/04653332ed3a_add_story_test_changes.py
+++ b/backend/python/migrations/versions/04653332ed3a_add_story_test_changes.py
@@ -36,6 +36,10 @@ def upgrade():
         "story_translations_all", sa.Column("test_result", sa.JSON(), nullable=True)
     )
 
+    op.execute(
+        "ALTER TABLE story_translation_contents_all MODIFY COLUMN status ENUM('DEFAULT', 'ACTION_REQUIRED', 'APPROVED', 'TEST_CORRECT', 'TEST_PARTIALLY_CORRECT', 'TEST_INCORRECT') NOT NULL;"
+    )
+
     active_translations_view = """
         CREATE OR REPLACE VIEW story_translations
         AS        
@@ -54,4 +58,12 @@ def downgrade():
     op.drop_column("story_translations_all", "test_feedback")
     op.drop_column("story_translations_all", "is_test")
     op.drop_column("stories", "is_test")
+
+    active_translations_view = """
+        CREATE OR REPLACE VIEW story_translations
+        AS        
+        SELECT * from story_translations_all
+        WHERE is_deleted=0;
+    """
+    op.execute(active_translations_view)
     # ### end Alembic commands ###


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Modify updateStoryTranslationContents to enable story test grading ](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=c01b210ef2cd410688ba5d15669c5080)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- modified update_story_translation_content_status
- modified require_authorization_as_story_user_by_role to always authorize admins. IMO makes sense to give them full control of story translations. this also allows them to grade freely
- found a bug in the migrations - the status column enum wasnt getting updated. added a fix

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test
set up
1. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data erase"`
2. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data"`
3. [make a new story test](http://localhost:5000/graphql?query=mutation%20%7B%0A%20%20createStoryTranslationTest(userId%3A%201%2C%20level%3A2%2C%20language%3A%22FRENCH%22)%7B%0A%20%20%20%20story%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20translatorId%0A%20%20%20%20%20%20storyId%0A%20%20%20%20%20%20language%0A%20%20%20%20%20%20stage%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=undefined)
4. move the stage to review:  `update story_translations_all set stage = 'REVIEW' where id = 14;`
5. [login as admin](http://localhost:5000/graphql?query=%0Amutation%20%7B%0A%20%20login%20(email%3A%22planetread%2Bangelamerkel%40uwblueprint.org%22%2C%20password%3A%22.%22)%20%7B%0A%20%20%20%20accessToken%0A%20%20%20%20refreshToken%0A%20%20%20%20id%0A%20%20%7D%0A%7D&operationName=undefined) and head over to altair

the actual mutation 
1. make requests as admin. [observe that updating to a test status works on story test](http://localhost:5000/graphql?query=%0Amutation%20%7B%0A%20%20%20%20updateStoryTranslationContentStatus(%0A%20%20%20%20%20%20storyTranslationContentId%3A%20132%20%0A%20%20%20%20%20%20status%3A%20%22TEST_CORRECT%22%0A%20%20%20%20)%20%7B%0A%20%20%20%20%20%20story%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D&operationName=undefined)
2. [observe that updating to a non-test status does not work on story test](http://localhost:5000/graphql?query=%0Amutation%20%7B%0A%20%20%20%20updateStoryTranslationContentStatus(%0A%20%20%20%20%20%20storyTranslationContentId%3A%20132%20%0A%20%20%20%20%20%20status%3A%20%22TEST_CORRECT%22%0A%20%20%20%20)%20%7B%0A%20%20%20%20%20%20story%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D&operationName=undefined)
3. move the stage to review:  `update story_translations_all set stage = 'REVIEW' where id = 13;`
4. [observe that updating to a test status does not work on non-test story translation](http://localhost:5000/graphql?query=%0Amutation%20%7B%0A%20%20%20%20updateStoryTranslationContentStatus(%0A%20%20%20%20%20%20storyTranslationContentId%3A%2059%0A%20%20%20%20%20%20status%3A%20%22TEST_CORRECT%22%0A%20%20%20%20)%20%7B%0A%20%20%20%20%20%20story%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D&operationName=undefined)
5. [observe that updating to a non-test status works on non-test story translation](http://localhost:5000/graphql?query=%0Amutation%20%7B%0A%20%20%20%20updateStoryTranslationContentStatus(%0A%20%20%20%20%20%20storyTranslationContentId%3A%2059%0A%20%20%20%20%20%20status%3A%20%22APPROVED%22%0A%20%20%20%20)%20%7B%0A%20%20%20%20%20%20story%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D&operationName=undefined)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work? 
- what do you think about require_authorization_as_story_user_by_role 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
