### PR TITLE
Add user's personal user page

### DIFF
--- a/frontend/src/components/admin/ApprovedLanguagesTable.tsx
+++ b/frontend/src/components/admin/ApprovedLanguagesTable.tsx
@@ -4,6 +4,7 @@ import {
   Table,
   Thead,
   Tbody,
+  Tooltip,
   Tr,
   Th,
   Td,
@@ -37,7 +38,7 @@ type ApprovedLanguage = {
   sliderValue: number;
 };
 
-type ApprovedLanguagesTableProps = {
+export type ApprovedLanguagesTableProps = {
   approvedLanguagesTranslation: ApprovedLanguagesMap | undefined;
   approvedLanguagesReview: ApprovedLanguagesMap | undefined;
   userId: number;
@@ -45,6 +46,7 @@ type ApprovedLanguagesTableProps = {
   setAlert: (open: boolean) => void;
   alertTimeout: number;
   setAlertTimeout: (id: number) => void;
+  isAdmin?: boolean;
 };
 
 const ApprovedLanguagesTable = ({
@@ -55,6 +57,7 @@ const ApprovedLanguagesTable = ({
   setAlert,
   alertTimeout,
   setAlertTimeout,
+  isAdmin = false,
 }: ApprovedLanguagesTableProps) => {
   const [approvedLanguages, setApprovedLanguages] = useState<
     ApprovedLanguage[]
@@ -170,6 +173,7 @@ const ApprovedLanguagesTable = ({
         <Td>{approvedLanguage.role}</Td>
         <Td colSpan={4} align="center">
           <Slider
+            isDisabled={!isAdmin}
             defaultValue={approvedLanguage.level}
             min={1}
             max={4}
@@ -203,6 +207,26 @@ const ApprovedLanguagesTable = ({
             ))}
           </Slider>
         </Td>
+        {!isAdmin && (
+          <Tooltip
+            hasArrow
+            label="Currently at maximum language level."
+            isDisabled={approvedLanguage.level !== 4}
+          >
+            <Td>
+              <Button
+                aria-label="Level up approval language and level"
+                background="white"
+                size="sm"
+                width="103px"
+                variant="blueOutline"
+                isDisabled={approvedLanguage.level === 4}
+              >
+                Level Up
+              </Button>
+            </Td>
+          </Tooltip>
+        )}
       </Tr>
     ),
   );
@@ -236,6 +260,7 @@ const ApprovedLanguagesTable = ({
           {["LEVEL 1", "LEVEL 2", "LEVEL 3", "LEVEL 4"].map((level) => (
             <Th key={level}>{level}</Th>
           ))}
+          {!isAdmin && <Th width="7%">ACTION</Th>}
         </Tr>
       </Thead>
       <Tbody>{tableBody}</Tbody>
@@ -246,7 +271,7 @@ const ApprovedLanguagesTable = ({
           variant="blueOutline"
           width="254px"
         >
-          Approve New Language/Level
+          Add New Language
         </Button>
       </Tfoot>
     </Table>

--- a/frontend/src/components/pages/CompleteProfilePage.tsx
+++ b/frontend/src/components/pages/CompleteProfilePage.tsx
@@ -1,22 +1,7 @@
 import React from "react";
-import Select from "react-select";
-import {
-  Box,
-  Button,
-  Flex,
-  FormControl,
-  Input,
-  Heading,
-  IconButton,
-  Text,
-  Textarea,
-} from "@chakra-ui/react";
-import { Icon } from "@chakra-ui/icon";
-import { MdFolder } from "react-icons/md";
+import { Box, Button, Flex } from "@chakra-ui/react";
 import Header from "../navigation/Header";
-import DropdownIndicator from "../utils/DropdownIndicator";
-import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
-import { languageOptions } from "../../constants/Languages";
+import UserProfileForm from "../userProfile/UserProfileForm";
 
 const CompleteProfilePage = () => {
   const onSubmitClick = () => {
@@ -26,80 +11,8 @@ const CompleteProfilePage = () => {
   return (
     <Flex direction="column" height="100vh">
       <Header />
-      <Flex direction="row" flex={1} marginLeft="50px">
-        <Flex direction="column" margin="40px" flex={1} maxWidth="50%">
-          <Heading size="lg">Complete your profile!</Heading>
-          <Text marginBottom="20px">
-            For the purposes of this platform, please enter your details
-          </Text>
-          <FormControl>
-            <Heading marginTop="24px" size="sm">
-              Full name*
-            </Heading>
-            <Input type="name" />
-            <Heading marginTop="24px" size="sm">
-              Email*
-            </Heading>
-            <Input type="email" />
-            <Heading marginTop="24px" size="sm">
-              Educational qualifications*
-            </Heading>
-            <Textarea height="150px" type="qualifications" />
-            <Heading marginTop="24px" size="sm">
-              Language experience*
-            </Heading>
-            <Textarea height="150px" type="experience" />
-          </FormControl>
-          <Heading marginTop="24px" size="sm">
-            Select language*
-          </Heading>
-          <Text marginBottom="12px">
-            Select the language that you would like to start with. Additional
-            languages can be added after signing up.
-          </Text>
-          <Box width="60%" marginBottom="200px">
-            <Select
-              placeholder="Select language"
-              options={languageOptions}
-              getOptionLabel={(option: any) => `
-                ${convertLanguageTitleCase(option.value || "")}
-              `}
-              components={{ DropdownIndicator }}
-            />
-          </Box>
-        </Flex>
-        <Flex direction="column" flex={1} marginLeft="60px" marginTop="160px">
-          <Heading size="sm">Upload your CV (optional)</Heading>
-          <Flex
-            align="center"
-            background="#e8f0f6"
-            border="2px"
-            // this is blue.100 at 10% opacity
-            borderColor="rgba(29, 108, 165, 0.1)"
-            direction="column"
-            height="250px"
-            justify="center"
-            maxWidth="80%"
-            rounded="md"
-          >
-            <IconButton
-              aria-label="Folder icon"
-              background="transparent"
-              color="blue.100"
-              icon={<Icon as={MdFolder} width={16} height={16} />}
-              marginBottom="16px"
-              width="fit-content"
-            />
-            <Text>Drag & drop your files here (.PDF, .docx)</Text>
-            <Button colorScheme="blue" marginTop="16px" width="160px">
-              Browse Files
-            </Button>
-          </Flex>
-          <Heading marginTop="24px" size="sm">
-            Uploaded files
-          </Heading>
-          <Text>Drag & drop a file or browse files to upload a CV.</Text>
-        </Flex>
+      <Flex direction="row" flex={1} margin="40px" marginLeft="90px">
+        <UserProfileForm />
       </Flex>
       <Flex
         alignItems="center"

--- a/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
+++ b/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
@@ -55,6 +55,7 @@ export type AssignedStoryTranslationsTableProps = {
   approvedLanguagesTranslation: ApprovedLanguagesMap | undefined;
   approvedLanguagesReview: ApprovedLanguagesMap | undefined;
   setStoryAssignStage: (newStage: StoryAssignStage) => void;
+  isAdmin?: boolean;
 };
 
 const AssignedStoryTranslationsTable = ({
@@ -64,6 +65,7 @@ const AssignedStoryTranslationsTable = ({
   approvedLanguagesTranslation,
   approvedLanguagesReview,
   setStoryAssignStage,
+  isAdmin = false,
 }: AssignedStoryTranslationsTableProps) => {
   const [isAscendingTitle, setIsAscendingTitle] = useState(true);
   const [isAscendingRole, setIsAscendingRole] = useState(true);
@@ -262,13 +264,21 @@ const AssignedStoryTranslationsTable = ({
     }
   };
 
+  const generateStoryTranslationLink = (translation: StoryTranslation) => {
+    const suffix = `${translation.storyId}/${translation.storyTranslationId}`;
+    if (isAdmin) {
+      return `/story/${suffix}`;
+    }
+    if (getRole(translation) === "Translator") {
+      return `/translation/${suffix}`;
+    }
+    return `/review/${suffix}`;
+  };
+
   const tableBody = storyTranslations.map((translation: StoryTranslation) => (
     <Tr key={`${translation?.storyTranslationId}`}>
       <Td>
-        <Link
-          isExternal
-          href={`/story/${translation.storyId}/${translation.storyTranslationId}`}
-        >
+        <Link isExternal href={generateStoryTranslationLink(translation)}>
           {translation.title}
         </Link>
       </Td>
@@ -283,15 +293,17 @@ const AssignedStoryTranslationsTable = ({
         }`}</Badge>
       </Td>
       <Td>{convertStageTitleCase(translation.stage)}</Td>
-      <Td>
-        <IconButton
-          aria-label={`Delete story translation for ${translation.title}`}
-          background="transparent"
-          icon={<Icon as={MdDelete} />}
-          width="fit-content"
-          onClick={() => openConfirmUnassignUserModal(translation)}
-        />
-      </Td>
+      {isAdmin && (
+        <Td>
+          <IconButton
+            aria-label={`Delete story translation for ${translation.title}`}
+            background="transparent"
+            icon={<Icon as={MdDelete} />}
+            width="fit-content"
+            onClick={() => openConfirmUnassignUserModal(translation)}
+          />
+        </Td>
+      )}
     </Tr>
   ));
   return (
@@ -321,20 +333,22 @@ const AssignedStoryTranslationsTable = ({
             <Th cursor="pointer" onClick={() => sort("stage")}>{`PROGRESS ${
               isAscendingStage ? "↑" : "↓"
             }`}</Th>
-            <Th width="7%">ACTION</Th>
+            {isAdmin && <Th width="7%">ACTION</Th>}
           </Tr>
         </Thead>
         <Tbody>{tableBody}</Tbody>
-        <Button
-          border="2px"
-          margin="10px 0px 15px 10px"
-          size="secondary"
-          variant="blueOutline"
-          width="200px"
-          onClick={openAssignStoryModal}
-        >
-          ASSIGN NEW STORY
-        </Button>
+        {isAdmin && (
+          <Button
+            border="2px"
+            margin="10px 0px 15px 10px"
+            size="secondary"
+            variant="blueOutline"
+            width="200px"
+            onClick={openAssignStoryModal}
+          >
+            ASSIGN NEW STORY
+          </Button>
+        )}
       </Table>
       {assignStory && (
         <AssignStoryModal

--- a/frontend/src/components/userProfile/UserProfileForm.tsx
+++ b/frontend/src/components/userProfile/UserProfileForm.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import Select from "react-select";
+import {
+  Box,
+  Button,
+  Flex,
+  FormControl,
+  Input,
+  Heading,
+  IconButton,
+  Text,
+  Textarea,
+} from "@chakra-ui/react";
+import { Icon } from "@chakra-ui/icon";
+import { MdFolder } from "react-icons/md";
+import DropdownIndicator from "../utils/DropdownIndicator";
+import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
+import { languageOptions } from "../../constants/Languages";
+
+export type UserProfileFormProps = {
+  isSignup?: boolean;
+};
+
+const UserProfileForm = ({ isSignup = true }: UserProfileFormProps) => (
+  <Flex direction="row" flex={1}>
+    <Flex direction="column" flex={1} maxWidth="50%">
+      <Heading size="lg">
+        {isSignup ? "Complete your profile!" : "Personal Information"}
+      </Heading>
+      {isSignup && (
+        <Text marginBottom="20px">
+          For the purposes of this platform, please enter your details
+        </Text>
+      )}
+      <FormControl>
+        <Heading marginTop="24px" size="sm">
+          Full name*
+        </Heading>
+        <Input type="name" />
+        <Heading marginTop="24px" size="sm">
+          Email*
+        </Heading>
+        <Input type="email" />
+        <Heading marginTop="24px" size="sm">
+          Educational qualifications*
+        </Heading>
+        <Textarea height="150px" type="qualifications" />
+        <Heading marginTop="24px" size="sm">
+          Language experience*
+        </Heading>
+        <Textarea height="150px" type="experience" />
+      </FormControl>
+      {isSignup && (
+        <>
+          <Heading marginTop="24px" size="sm">
+            Select language*
+          </Heading>
+          <Text marginBottom="12px">
+            Select the language that you would like to start with. Additional
+            languages can be added after signing up.
+          </Text>
+          <Box width="60%" marginBottom="200px">
+            <Select
+              placeholder="Select language"
+              options={languageOptions}
+              getOptionLabel={(option: any) => `
+                ${convertLanguageTitleCase(option.value || "")}
+              `}
+              components={{ DropdownIndicator }}
+            />
+          </Box>
+        </>
+      )}
+    </Flex>
+    <Flex direction="column" flex={1} marginLeft="60px" marginTop="160px">
+      <Heading size="sm">Upload your CV (optional)</Heading>
+      <Flex
+        align="center"
+        background="#e8f0f6"
+        border="2px"
+        // this is blue.100 at 10% opacity
+        borderColor="rgba(29, 108, 165, 0.1)"
+        direction="column"
+        height="250px"
+        justify="center"
+        maxWidth="80%"
+        rounded="md"
+      >
+        <IconButton
+          aria-label="Folder icon"
+          background="transparent"
+          color="blue.100"
+          icon={<Icon as={MdFolder} width={16} height={16} />}
+          marginBottom="16px"
+          width="fit-content"
+        />
+        <Text>Drag & drop your files here (.PDF, .docx)</Text>
+        <Button colorScheme="blue" marginTop="16px" width="160px">
+          Browse Files
+        </Button>
+      </Flex>
+      <Heading marginTop="24px" size="sm">
+        Uploaded files
+      </Heading>
+      <Text>Drag & drop a file or browse files to upload a CV.</Text>
+    </Flex>
+  </Flex>
+);
+
+export default UserProfileForm;

--- a/frontend/src/components/userProfile/UserProfileForm.tsx
+++ b/frontend/src/components/userProfile/UserProfileForm.tsx
@@ -72,7 +72,7 @@ const UserProfileForm = ({ isSignup = true }: UserProfileFormProps) => (
         </>
       )}
     </Flex>
-    <Flex direction="column" flex={1} marginLeft="60px" marginTop="160px">
+    <Flex direction="column" flex={1} marginLeft="60px" marginTop="75px">
       <Heading size="sm">Upload your CV (optional)</Heading>
       <Flex
         align="center"


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add user's personal user page](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=c672742600084570b18b3b3ee32bc778)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- UserProfilePage displays differently depending on if the user viewing the page is an admin or a user
- only ui change for admin page: theres an extra empty box between the `AssignedStoryTranslationsTable` and its title
- there are multiple changes to the page for when the user is viewing themselves
  - viewing userid that isnt the users' own will redirect to a 404
  - the UserProfileForm has been extracted from the CompleteUserProfile page. It is now used in the UserProfilePage too
  - Approved Languages & Levels
    - the action column is now for leveling up (button does nothing) 
    - note: designs suggested moving the new language button here for users, but i think it's fine where it is. will follow up with them 
![image](https://user-images.githubusercontent.com/15113249/145911518-4bc256ac-7e0e-403a-8914-d9545fd5082a.png)

  - Assigned Story Translations 
    - action column is removed
    - "Assign New Story" button is removed

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. log in as carl sagan
2. go to http://localhost:3000/user/1
3. observe changes
4. go to http://localhost:3000/user/3 (or anything)
5. observe the 404 redirect
6. log in as angela merkel 
7. go to http://localhost:3000/user/1
8. observe changes

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- hows it look? 
- hows the code organization?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
