### PR TITLE
Create get_story_translation_tests query

### DIFF
--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -1,4 +1,4 @@
-from ...middlewares.auth import require_authorization_by_role_gql
+from ...middlewares.auth import require_authorization_by_role_gql, get_user_id_from_request
 from ..service import services
 
 
@@ -35,3 +35,12 @@ def resolve_story_translations_available_for_review(root, info, language, level)
 @require_authorization_by_role_gql({"Admin"})
 def resolve_story_translations(root, info, language, level, stage, story_title):
     return services["story"].get_story_translations(language, level, stage, story_title)
+
+
+@require_authorization_by_role_gql({"User", "Admin"})
+def resolve_story_translation_tests(root, info, language, level, stage, story_title):
+    user_id = int(get_user_id_from_request())
+    user = services["user"].get_user_by_id(user_id)
+    return services["story"].get_story_translation_tests(user, language, level, stage, story_title)
+
+

--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -1,4 +1,7 @@
-from ...middlewares.auth import require_authorization_by_role_gql, get_user_id_from_request
+from ...middlewares.auth import (
+    get_user_id_from_request,
+    require_authorization_by_role_gql,
+)
 from ..service import services
 
 
@@ -41,6 +44,6 @@ def resolve_story_translations(root, info, language, level, stage, story_title):
 def resolve_story_translation_tests(root, info, language, level, stage, story_title):
     user_id = int(get_user_id_from_request())
     user = services["user"].get_user_by_id(user_id)
-    return services["story"].get_story_translation_tests(user, language, level, stage, story_title)
-
-
+    return services["story"].get_story_translation_tests(
+        user, language, level, stage, story_title
+    )

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -190,7 +190,7 @@ class Query(graphene.ObjectType):
     ):
         return resolve_story_translation_tests(
             root, info, language, level, stage, story_title
-        ) 
+        )
 
     def resolve_story_translation_by_id(root, info, id):
         return resolve_story_translation_by_id(root, info, id)

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -38,6 +38,7 @@ from .queries.story_query import (
     resolve_stories_available_for_translation,
     resolve_story_by_id,
     resolve_story_translation_by_id,
+    resolve_story_translation_tests,
     resolve_story_translations,
     resolve_story_translations_available_for_review,
     resolve_story_translations_by_user,
@@ -49,6 +50,7 @@ from .types.story_type import (
     StoryResponseDTO,
     StoryTranslationConnection,
     StoryTranslationResponseDTO,
+    StoryTranslationTestResponseDTO,
 )
 from .types.user_type import UserDTO
 
@@ -96,6 +98,13 @@ class Query(graphene.ObjectType):
     story_by_id = graphene.Field(StoryResponseDTO, id=graphene.Int(required=True))
     story_translations = graphene.relay.ConnectionField(
         StoryTranslationConnection,
+        language=graphene.String(),
+        level=graphene.Int(),
+        stage=graphene.String(),
+        story_title=graphene.String(),
+    )
+    story_translation_tests = graphene.Field(
+        graphene.List(StoryTranslationTestResponseDTO),
         language=graphene.String(),
         level=graphene.Int(),
         stage=graphene.String(),
@@ -175,6 +184,13 @@ class Query(graphene.ObjectType):
         return resolve_story_translations(
             root, info, language, level, stage, story_title
         )
+
+    def resolve_story_translation_tests(
+        root, info, language=None, level=None, stage=None, story_title=None, **kwargs
+    ):
+        return resolve_story_translation_tests(
+            root, info, language, level, stage, story_title
+        ) 
 
     def resolve_story_translation_by_id(root, info, id):
         return resolve_story_translation_by_id(root, info, id)

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -79,6 +79,7 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
     translator_name = graphene.String()
     reviewer_name = graphene.String()
 
+
 class StoryTranslationTestResponseDTO(graphene.ObjectType):
     id = graphene.Int(required=True)
     language = graphene.String(required=True)

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -79,12 +79,27 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
     translator_name = graphene.String()
     reviewer_name = graphene.String()
 
+class StoryTranslationTestResponseDTO(graphene.ObjectType):
+    id = graphene.Int(required=True)
+    language = graphene.String(required=True)
+    stage = graphene.Field(StageEnum, required=True)
+    translator_id = graphene.Int()
+    story_id = graphene.Int(required=True)
+    title = graphene.String(required=True)
+    description = graphene.String(required=True)
+    youtube_link = graphene.String(required=True)
+    level = graphene.Int(required=True)
+    translator_name = graphene.String()
+    test_grade = graphene.Int()
+    test_result = graphene.JSONString(required=False)
+    test_feedback = graphene.String()
+    date_submitted = graphene.DateTime()
+
 
 class StoryTranslationNode(graphene.ObjectType):
     story_translation_id = graphene.Int(required=True)
     language = graphene.String(required=True)
     stage = graphene.Field(StageEnum, required=True)
-    translation_contents = graphene.List(StoryTranslationContentResponseDTO)
     translator_id = graphene.Int()
     reviewer_id = graphene.Int()
     story_id = graphene.Int(required=True)
@@ -92,8 +107,6 @@ class StoryTranslationNode(graphene.ObjectType):
     description = graphene.String(required=True)
     youtube_link = graphene.String(required=True)
     level = graphene.Int(required=True)
-    num_translated_lines = graphene.Int()
-    num_approved_lines = graphene.Int()
     translator_name = graphene.String()
     reviewer_name = graphene.String()
 

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -228,7 +228,7 @@ class StoryService(IStoryService):
         except Exception as error:
             self.logger.error(str(error))
             raise error
-    
+
     def get_story_translation_tests(
         self,
         user,

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -94,6 +94,21 @@ class IStoryService(ABC):
         pass
 
     @abstractmethod
+    def get_story_translation_tests(self, user, language, level, stage, story_title):
+        """Return a list of story translation tests based on filters
+
+        :param user: UserDTO 
+        :param language: language of story translation tests to filter by
+        :param level: level of story translation tests to filter by
+        :param stage: stage of story translation tests to filter by
+        :param story_title: story_title of story translation tests to filter by
+        :return: list of StoryTranslationTestResponseDTO's
+        :rtype: list of StoryTranslationTestResponseDTO's
+'s
+        """
+        pass
+
+    @abstractmethod
     def get_story_translation(self, id):
         """Return a story currently being translated/reviewed
         :param id: id of the story translation

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -97,14 +97,13 @@ class IStoryService(ABC):
     def get_story_translation_tests(self, user, language, level, stage, story_title):
         """Return a list of story translation tests based on filters
 
-        :param user: UserDTO 
+        :param user: UserDTO
         :param language: language of story translation tests to filter by
         :param level: level of story translation tests to filter by
         :param stage: stage of story translation tests to filter by
         :param story_title: story_title of story translation tests to filter by
         :return: list of StoryTranslationTestResponseDTO's
         :rtype: list of StoryTranslationTestResponseDTO's
-'s
         """
         pass
 

--- a/backend/python/app/tests/helpers/story_translation_helpers.py
+++ b/backend/python/app/tests/helpers/story_translation_helpers.py
@@ -25,15 +25,15 @@ def assert_story_translation_equals_model(
     story_translation_response,
     story_model,
     story_translation_model,
-    translation_contents,
-    num_translated_lines,
-    num_approved_lines,
+    translation_contents=[],
+    num_translated_lines=0,
+    num_approved_lines=0,
 ):
     assert story_translation_response["id"] == story_translation_model.id
     assert story_translation_response["language"] == story_translation_model.language
     assert story_translation_response["stage"] == story_translation_model.stage
     for translation_content_response, translation_content in zip(
-        story_translation_response["translation_contents"], translation_contents
+        story_translation_response.get("translation_contents", []), translation_contents
     ):
         assert translation_content_response["id"] == translation_content["id"]
         assert (
@@ -57,27 +57,14 @@ def assert_story_translation_equals_model(
     assert story_translation_response["description"] == story_model.description
     assert story_translation_response["youtube_link"] == story_model.youtube_link
     assert story_translation_response["level"] == story_model.level
-    assert story_translation_response["num_translated_lines"] == num_translated_lines
-    assert story_translation_response["num_approved_lines"] == num_approved_lines
-    assert story_translation_response["num_content_lines"] == len(translation_contents)
-
-def assert_story_translation_test_equals_model(
-    story_translation_test_response,
-    story_model,
-    story_translation_test_model,
-):
-    assert story_translation_test_response["id"] == story_translation_test_model.id
-    assert story_translation_test_response["language"] == story_translation_test_model.language
-    assert story_translation_test_response["stage"] == story_translation_test_model.stage
     assert (
-        story_translation_test_response["translator_id"]
-        == story_translation_test_model.translator_id
+        story_translation_response.get("num_translated_lines", 0)
+        == num_translated_lines
     )
-    assert story_translation_test_response["story_id"] == story_translation_test_model.story_id
-    assert story_translation_test_response["title"] == story_model.title
-    assert story_translation_test_response["description"] == story_model.description
-    assert story_translation_test_response["youtube_link"] == story_model.youtube_link
-    assert story_translation_test_response["level"] == story_model.level
+    assert story_translation_response.get("num_approved_lines", 0) == num_approved_lines
+    assert story_translation_response.get("num_content_lines", 0) == len(
+        translation_contents
+    )
 
 
 def create_story(db):
@@ -120,6 +107,7 @@ def create_reviewer(db):
             approved_languages_review={"ENGLISH_US": 4, "ENGLISH_UK": 4},
         ),
     )
+
 
 def create_admin(db):
     return db_session_add_commit_obj(

--- a/backend/python/app/tests/helpers/story_translation_helpers.py
+++ b/backend/python/app/tests/helpers/story_translation_helpers.py
@@ -61,6 +61,24 @@ def assert_story_translation_equals_model(
     assert story_translation_response["num_approved_lines"] == num_approved_lines
     assert story_translation_response["num_content_lines"] == len(translation_contents)
 
+def assert_story_translation_test_equals_model(
+    story_translation_test_response,
+    story_model,
+    story_translation_test_model,
+):
+    assert story_translation_test_response["id"] == story_translation_test_model.id
+    assert story_translation_test_response["language"] == story_translation_test_model.language
+    assert story_translation_test_response["stage"] == story_translation_test_model.stage
+    assert (
+        story_translation_test_response["translator_id"]
+        == story_translation_test_model.translator_id
+    )
+    assert story_translation_test_response["story_id"] == story_translation_test_model.story_id
+    assert story_translation_test_response["title"] == story_model.title
+    assert story_translation_test_response["description"] == story_model.description
+    assert story_translation_test_response["youtube_link"] == story_model.youtube_link
+    assert story_translation_test_response["level"] == story_model.level
+
 
 def create_story(db):
     return db_session_add_commit_obj(
@@ -100,6 +118,20 @@ def create_reviewer(db):
             role="User",
             approved_languages_translation={"ENGLISH_US": 4, "ENGLISH_UK": 4},
             approved_languages_review={"ENGLISH_US": 4, "ENGLISH_UK": 4},
+        ),
+    )
+
+def create_admin(db):
+    return db_session_add_commit_obj(
+        db,
+        UserAll(
+            first_name="Angela",
+            last_name="Merkel",
+            email="planetread+angelamerkel@uwblueprint.org",
+            auth_id="thirdsecret",
+            role="Admin",
+            approved_languages_translation={"GERMAN": 4},
+            approved_languages_review={"GERMAN": 4},
         ),
     )
 

--- a/backend/python/app/tests/services/test_story_service.py
+++ b/backend/python/app/tests/services/test_story_service.py
@@ -10,7 +10,6 @@ from ..helpers.story_helpers import StoryRequestDTO, assert_story_equals_model
 from ..helpers.story_translation_helpers import (
     StoryTranslationRequestDTO,
     assert_story_translation_equals_model,
-    assert_story_translation_test_equals_model,
     create_admin,
     create_reviewer,
     create_story_translation,
@@ -185,8 +184,8 @@ def test_get_story_translations():
     # includes all fields
     pass
 
-def test_get_story_translation_tests(app, db, services):
 
+def test_get_story_translation_tests(app, db, services):
     first_translator_obj = create_translator(db)
     second_translator_obj = create_reviewer(db)
     admin_obj = create_admin(db)
@@ -215,18 +214,24 @@ def test_get_story_translation_tests(app, db, services):
 
     # Test for admin
     tests = [first_story_translation_resp, second_story_translation_resp]
-    admin_get_story_translation_tests_resp = services["story"].get_story_translation_tests(admin_obj)
+    admin_get_story_translation_tests_resp = services[
+        "story"
+    ].get_story_translation_tests(admin_obj)
     assert len(admin_get_story_translation_tests_resp) == 2
     for test_resp, test in zip(admin_get_story_translation_tests_resp, tests):
-        assert_story_translation_test_equals_model(test_resp, story, test)
-    
+        assert_story_translation_equals_model(test_resp, story, test)
+
     # Test for user
-    user_get_story_translation_tests_resp = services["story"].get_story_translation_tests(first_translator_obj)
+    user_get_story_translation_tests_resp = services[
+        "story"
+    ].get_story_translation_tests(first_translator_obj)
     assert len(user_get_story_translation_tests_resp) == 1
 
     user_story_translation_test = user_get_story_translation_tests_resp[0]
     assert user_story_translation_test["translator_id"] == first_translator_obj.id
-    assert_story_translation_test_equals_model(user_story_translation_test, story, first_story_translation_resp)
+    assert_story_translation_equals_model(
+        user_story_translation_test, story, first_story_translation_resp
+    )
 
 
 def test_assign_user_as_reviewer():

--- a/backend/python/app/tests/services/test_story_service.py
+++ b/backend/python/app/tests/services/test_story_service.py
@@ -10,6 +10,8 @@ from ..helpers.story_helpers import StoryRequestDTO, assert_story_equals_model
 from ..helpers.story_translation_helpers import (
     StoryTranslationRequestDTO,
     assert_story_translation_equals_model,
+    assert_story_translation_test_equals_model,
+    create_admin,
     create_reviewer,
     create_story_translation,
     create_story_translation_contents,
@@ -180,8 +182,51 @@ def test_get_story_translation_raises_error_for_invalid_id():
 
 
 def test_get_story_translations():
-    # includes all fields, including num_translated_lines
+    # includes all fields
     pass
+
+def test_get_story_translation_tests(app, db, services):
+
+    first_translator_obj = create_translator(db)
+    second_translator_obj = create_reviewer(db)
+    admin_obj = create_admin(db)
+
+    # Create test story
+    story = StoryRequestDTO(
+        title="Title",
+        description="Description",
+        youtube_link="",
+        level=2,
+        translated_languages=[],
+    )
+    content = ["Story content 1.", "Story content 2.", "Story content 3."]
+    story_resp = services["story"].create_story(story, content)
+    story_obj = Story.query.get(story_resp.id)
+    story_obj.is_test = True
+    db.session.commit()
+
+    # Create story translation tests
+    first_story_translation_resp = services["story"].create_translation_test(
+        first_translator_obj.id, 2, "ENGLISH"
+    )
+    second_story_translation_resp = services["story"].create_translation_test(
+        second_translator_obj.id, 2, "ENGLISH"
+    )
+
+    # Test for admin
+    tests = [first_story_translation_resp, second_story_translation_resp]
+    admin_get_story_translation_tests_resp = services["story"].get_story_translation_tests(admin_obj)
+    assert len(admin_get_story_translation_tests_resp) == 2
+    for test_resp, test in zip(admin_get_story_translation_tests_resp, tests):
+        assert_story_translation_test_equals_model(test_resp, story, test)
+    
+    # Test for user
+    user_get_story_translation_tests_resp = services["story"].get_story_translation_tests(first_translator_obj)
+    assert len(user_get_story_translation_tests_resp) == 1
+
+    user_story_translation_test = user_get_story_translation_tests_resp[0]
+    assert user_story_translation_test["translator_id"] == first_translator_obj.id
+    assert_story_translation_test_equals_model(user_story_translation_test, story, first_story_translation_resp)
 
 
 def test_assign_user_as_reviewer():


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Retrieve storyTranslationsTests](https://www.notion.so/uwblueprintexecs/Retrieve-storyTranslationsTests-03c53ae24da54cf6888f71b72d648472)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- implemented get_story_translation_tests query
- removed unused fields from StoryTranslationNodeDTO

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

Reset data:
1. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data erase"`
2. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data"`

Make new story translation tests:
1. [make test for user 1](http://localhost:5000/graphql?query=mutation%20CreateStoryTranslationTest%20%7B%0A%20%20createStoryTranslationTest(userId%3A%201%2C%20level%3A2%2C%20language%3A%22FRENCH%22)%7B%0A%20%20%20%20story%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20translatorId%0A%20%20%20%20%20%20storyId%0A%20%20%20%20%20%20language%0A%20%20%20%20%20%20stage%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A%0A&operationName=CreateStoryTranslationTest)
2. [make test for user 2](http://localhost:5000/graphql?query=mutation%20CreateStoryTranslationTest%20%7B%0A%20%20createStoryTranslationTest(userId%3A%202%2C%20level%3A2%2C%20language%3A%22FRENCH%22)%7B%0A%20%20%20%20story%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20translatorId%0A%20%20%20%20%20%20storyId%0A%20%20%20%20%20%20language%0A%20%20%20%20%20%20stage%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A%0A&operationName=CreateStoryTranslationTest)

Test query on Altair client
- [login](http://localhost:5000/graphql?query=%0Amutation%20LoginAdmin%20%7B%0A%20%20login%20(email%3A%22planetread%2Bangelamerkel%40uwblueprint.org%22%2C%20password%3A%22.%22)%20%7B%0A%20%20%20%20accessToken%0A%20%20%20%20refreshToken%0A%20%20%20%20id%0A%20%20%7D%0A%7D&operationName=LoginAdmin) + make query as admin, verify that both story translations are fetched
- [login](http://localhost:5000/graphql?query=%0Amutation%20LoginUser%20%7B%0A%20%20login%20(email%3A%22planetread%2Bcarlsagan%40uwblueprint.org%22%2C%20password%3A%22.%22)%20%7B%0A%20%20%20%20accessToken%0A%20%20%20%20refreshToken%0A%20%20%20%20id%0A%20%20%7D%0A%7D&operationName=LoginUser) + make query as user 1, verify that only the corresponding test for the user is fetched

Query:
```
query StoryTranslationTests {
  storyTranslationTests {
    id
    storyId
    title
    language
    stage
    youtubeLink
    description
    testGrade
    testResult
    testFeedback
    translatorName
  }
}
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does the query work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
