### PR TITLE
Add mutation to finish grading test story translation

### DIFF
--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ...middlewares.auth import (
+    get_user_id_from_request,
     require_authorization_as_story_user_by_role,
     require_authorization_by_role_gql,
 )
@@ -12,7 +13,7 @@ from ..types.story_type import (
     StoryResponseDTO,
     StoryTranslationContentRequestDTO,
     StoryTranslationContentResponseDTO,
-    StoryTranslationResponseDTO,
+    StoryTranslationTestResponseDTO,
     StoryTranslationUpdateStatusResponseDTO,
     UpdateStoryTranslationStageRequestDTO,
 )
@@ -170,13 +171,14 @@ class FinishGradingStoryTranslation(graphene.Mutation):
         story_translation_test_id = graphene.Int(required=True)
 
     ok = graphene.Boolean()
-    story_translation = graphene.Field(lambda: StoryTranslationResponseDTO)
+    story_translation = graphene.Field(lambda: StoryTranslationTestResponseDTO)
 
     @require_authorization_by_role_gql({"Admin"})
     def mutate(root, info, test_result, test_feedback, story_translation_test_id):
         try:
+            reviewer_id = int(get_user_id_from_request())
             result = services["story"].finish_grading_story_translation(
-                test_result, test_feedback, story_translation_test_id
+                reviewer_id, test_result, test_feedback, story_translation_test_id
             )
             return FinishGradingStoryTranslation(ok=True, story_translation=result)
         except Exception as e:

--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -12,6 +12,7 @@ from ..types.story_type import (
     StoryResponseDTO,
     StoryTranslationContentRequestDTO,
     StoryTranslationContentResponseDTO,
+    StoryTranslationResponseDTO,
     StoryTranslationUpdateStatusResponseDTO,
     UpdateStoryTranslationStageRequestDTO,
 )
@@ -157,6 +158,27 @@ class ApproveAllStoryTranslationContent(graphene.Mutation):
             )
 
             return ApproveAllStoryTranslationContent(ok=True)
+        except Exception as e:
+            error_message = getattr(e, "message", None)
+            raise Exception(error_message if error_message else str(e))
+
+
+class FinishGradingStoryTranslation(graphene.Mutation):
+    class Arguments:
+        test_result = graphene.JSONString(required=True)
+        test_feedback = graphene.String(required=False)
+        story_translation_test_id = graphene.Int(required=True)
+
+    ok = graphene.Boolean()
+    story_translation = graphene.Field(lambda: StoryTranslationResponseDTO)
+
+    @require_authorization_by_role_gql({"Admin"})
+    def mutate(root, info, test_result, test_feedback, story_translation_test_id):
+        try:
+            result = services["story"].finish_grading_story_translation(
+                test_result, test_feedback, story_translation_test_id
+            )
+            return FinishGradingStoryTranslation(ok=True, story_translation=result)
         except Exception as e:
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -16,6 +16,7 @@ from .mutations.story_mutation import (
     CreateStory,
     CreateStoryTranslation,
     CreateStoryTranslationTest,
+    FinishGradingStoryTranslation,
     RemoveReviewerFromStoryTranslation,
     RemoveUserFromStoryTranslation,
     SoftDeleteStoryTranslation,
@@ -85,6 +86,7 @@ class Mutation(graphene.ObjectType):
     update_user_approved_language = UpdateUserApprovedLanguages.Field()
     soft_delete_user = SoftDeleteUser.Field()
     remove_user_from_story_translation = RemoveUserFromStoryTranslation.Field()
+    finish_grading_story_translation = FinishGradingStoryTranslation.Field()
 
 
 class Query(graphene.ObjectType):

--- a/backend/python/app/models/story_translation_all.py
+++ b/backend/python/app/models/story_translation_all.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, inspect
+from sqlalchemy import Boolean, Float, inspect
 from sqlalchemy.dialects.mysql import TEXT
 from sqlalchemy.orm.properties import ColumnProperty
 
@@ -20,7 +20,7 @@ class StoryTranslationAll(db.Model):
     translation_contents = db.relationship(StoryTranslationContentAll)
     is_deleted = db.Column(Boolean, default=False, nullable=False)
     is_test = db.Column(Boolean, default=False, nullable=False)
-    test_grade = db.Column(db.Integer)
+    test_grade = db.Column(Float(3, 2))
     test_result = db.Column(db.JSON)
     test_feedback = db.Column(TEXT)
 

--- a/backend/python/migrations/versions/04653332ed3a_add_story_test_changes.py
+++ b/backend/python/migrations/versions/04653332ed3a_add_story_test_changes.py
@@ -30,7 +30,7 @@ def upgrade():
         sa.Column("test_feedback", mysql.TEXT(), nullable=True),
     )
     op.add_column(
-        "story_translations_all", sa.Column("test_grade", sa.Integer(), nullable=True)
+        "story_translations_all", sa.Column("test_grade", sa.Float(), nullable=True)
     )
     op.add_column(
         "story_translations_all", sa.Column("test_result", sa.JSON(), nullable=True)


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Finish grading a story translation](https://www.notion.so/uwblueprintexecs/Finish-grading-a-story-translation-3e1114e9235c49ad8aebd0847f14938a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added mutation that takes test_result, test_feedback, and story_translation_test_id params
- Check that translate and review are in the test_result param
- Calculate the test grade (correct = +1, partially correct = +0.5, others = none)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data erase"`
2. `docker exec -it planet-read_py-backend_1 /bin/bash -c "flask db downgrade"`  
3. `docker exec -it planet-read_py-backend_1 /bin/bash -c "flask db upgrade"`
4.  `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data"`
2. [Login as admin and set token](http://localhost:5000/graphql?variables=null&operationName=undefined&query=%0Amutation%20%7B%0A%20%20login%20(email%3A%22planetread%2Bangelamerkel%40uwblueprint.org%22%2C%20password%3A%22%22)%20%7B%0A%20%20%20%20accessToken%0A%20%20%20%20refreshToken%0A%20%20%20%20id%0A%20%20%7D%0A%7D)
3. [Make a new story test](http://localhost:5000/graphql?query=mutation%20%7B%0A%20%20createStoryTranslationTest(userId%3A%201%2C%20level%3A2%2C%20language%3A%22FRENCH%22)%7B%0A%20%20%20%20story%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20translatorId%0A%20%20%20%20%20%20storyId%0A%20%20%20%20%20%20language%0A%20%20%20%20%20%20stage%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=undefined)
2. [Check that you can't update the story translation if you're missing translate / review](http://localhost:5000/graphql?variables=null&operationName=undefined&query=mutation%20%7B%0A%20%20finishGradingStoryTranslation(storyTranslationTestId%3A%2014%2C%20testFeedback%3A%20%22good%22%2C%20testResult%3A%20%22%7B%5C%22review%5C%22%3A%20%5C%22falalala%5C%22%7D%22)%7B%0A%20%20%20%20ok%0A%20%20%20%20storyTranslation%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20stage%0A%20%20%20%20%20%20%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A)
3. add some story translation contents with the correct story translation id
3.[Check that you can update with all the correct params](http://localhost:5000/graphql?variables=null&operationName=undefined&query=mutation%20%7B%0A%20%20finishGradingStoryTranslation(storyTranslationTestId%3A%2014%2C%20testFeedback%3A%20%22good%22%2C%20testResult%3A%20%22%7B%5C%22translate%5C%22%3A%20%5C%22falalala%5C%22%2C%20%5C%22review%5C%22%3A%20%5C%22falalala%5C%22%7D%22)%7B%0A%20%20%20%20ok%0A%20%20%20%20storyTranslation%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20stage%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)
- check that the final grade adds up (try modifying the statuses and rerun the mutation) 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?
- Updated the test grade column to float type 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
