### PR TITLE
[Hotfix] Remove unused storyTranslations query fields on the frontend

### DIFF
--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -237,8 +237,6 @@ export const buildStoriesQuery = (
               level
               translatorName
               reviewerName
-              numTranslatedLines
-              numApprovedLines
             }
           }
           pageInfo {


### PR DESCRIPTION
Super quick PR for removing unneeded fields on the storyTranslations query as a result of [this change](https://github.com/uwblueprint/planet-read/pull/198/files#diff-d088b1642ca207d14aa58b53ccebff41b7d7f5111da99d8514131628fb4857b2L95)

Currently the story translations don't load on `/admin`, this fixes it

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
