### PR TITLE
Add My Tests tab on homepage

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -180,6 +180,8 @@ class StoryService(IStoryService):
             if role_filter is not None:
                 filters.append(role_filter)
 
+            filters.append(StoryTranslation.is_test == False)
+
             stories = (
                 Story.query.join(
                     StoryTranslation,

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -82,6 +82,7 @@ const STORY_FIELDS = `
 
 export const buildHomePageStoriesQuery = (
   displayMyStories: boolean,
+  displayMyTests: boolean,
   language: string,
   isTranslator: boolean,
   level: number,
@@ -89,7 +90,23 @@ export const buildHomePageStoriesQuery = (
 ): QueryInformation => {
   let result = {};
 
-  if (isTranslator && !displayMyStories) {
+  if (displayMyTests) {
+    result = {
+      fieldName: "storyTranslationTests",
+      string: gql`
+            query StoryTranslationTests {
+              storyTranslationTests
+              {
+                storyTranslationId: id
+                storyId
+                translatorId
+                language
+                ${STORY_FIELDS}
+              }
+            }
+        `,
+    };
+  } else if (isTranslator && !displayMyStories) {
     result = {
       fieldName: "storiesAvailableForTranslation",
       string: gql`

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -116,12 +116,17 @@ const StoryCard = ({
     setPreview(!preview);
   };
 
+  const openTest = () => {
+    history.push(`/translation/${storyId}/${storyTranslationId}`);
+  };
+
   const openTranslation = () => {
     const storyTranslationUrlBase = isTranslator ? "translation" : "review";
     history.push(
       `/${storyTranslationUrlBase}/${storyId}/${storyTranslationId}`,
     );
   };
+
   const primaryBtnText = () => {
     if (isMyStory) {
       return storyTranslationId ? "view translation" : "edit translation";
@@ -133,6 +138,9 @@ const StoryCard = ({
   };
 
   const primaryBtnOnClick = () => {
+    if (isMyTest) {
+      return openTest;
+    }
     if (isMyStory) {
       return openTranslation;
     }

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -32,6 +32,7 @@ export type StoryCardProps = {
   level: number;
   language: string;
   isMyStory: boolean;
+  isMyTest: boolean;
   translatorId?: number;
   reviewerId?: number;
 };
@@ -45,6 +46,7 @@ const StoryCard = ({
   level,
   language,
   isMyStory,
+  isMyTest,
   translatorId,
 }: StoryCardProps) => {
   const { authenticatedUser } = useContext(AuthContext);
@@ -124,6 +126,9 @@ const StoryCard = ({
     if (isMyStory) {
       return storyTranslationId ? "view translation" : "edit translation";
     }
+    if (isMyTest) {
+      return "take test";
+    }
     return storyTranslationId ? "review" : "translate";
   };
 
@@ -173,6 +178,7 @@ const StoryCard = ({
                 {isTranslator ? "Translator" : "Reviewer"}
               </Badge>
             )}
+            {isMyTest && <Badge variant="role">Test Book</Badge>}
           </Flex>
         </Flex>
         <Text size="xs">{truncateText(description, 100)}</Text>
@@ -198,7 +204,7 @@ const StoryCard = ({
           marginTop="5px"
           onClick={previewBook}
         >
-          preview book
+          {isMyTest ? "preview" : "preview book"}
         </Button>
       </Flex>
       {preview && (

--- a/frontend/src/components/homepage/StoryList.tsx
+++ b/frontend/src/components/homepage/StoryList.tsx
@@ -5,6 +5,7 @@ import "./StoryList.css";
 export type StoryListProps = {
   stories: StoryCardProps[] | null;
   displayMyStories: boolean;
+  displayMyTests: boolean;
 };
 
 const LoadingCard = () => {
@@ -25,7 +26,11 @@ const NoStoriesFoundCard = () => {
   );
 };
 
-const StoryList = ({ stories, displayMyStories }: StoryListProps) => {
+const StoryList = ({
+  stories,
+  displayMyStories,
+  displayMyTests,
+}: StoryListProps) => {
   const createCardId = (storyId: number, storyTranslationId?: number) =>
     `story-${storyId}${
       storyTranslationId ? `-translation-${storyTranslationId}` : ``
@@ -61,6 +66,7 @@ const StoryList = ({ stories, displayMyStories }: StoryListProps) => {
         level={level}
         language={language}
         isMyStory={displayMyStories}
+        isMyTest={displayMyTests}
         translatorId={translatorId}
         reviewerId={reviewerId}
       />

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -25,6 +25,7 @@ const HomePage = () => {
   );
 
   const [displayMyStories, setDisplayMyStories] = useState<boolean>(true);
+  const [displayMyTests, setDisplayMyTests] = useState<boolean>(false);
   const [language, setLanguage] = useState<string>(
     Object.keys(approvedLanguagesTranslation)[0],
   );
@@ -54,11 +55,13 @@ const HomePage = () => {
 
   const handleDisplayMyStoriesChange = (nextOption: string) => {
     setStories(null);
+    setDisplayMyTests(nextOption === "My Tests");
     setDisplayMyStories(nextOption === "My Work");
   };
 
   const query = buildHomePageStoriesQuery(
     displayMyStories,
+    displayMyTests,
     language,
     isTranslator,
     level,
@@ -71,12 +74,13 @@ const HomePage = () => {
     onCompleted: (data) => {
       // Only the storyTranslationsByUser query returns the language in the gql
       // response; otherwise it must be added based on the user's language filter
-      const storyData = displayMyStories
-        ? data[query.fieldName]
-        : data[query.fieldName].map((storyObj: any) => ({
-            ...storyObj,
-            language,
-          }));
+      const storyData =
+        displayMyStories || displayMyTests
+          ? data[query.fieldName]
+          : data[query.fieldName].map((storyObj: any) => ({
+              ...storyObj,
+              language,
+            }));
       setStories(storyData);
     },
   });
@@ -94,7 +98,7 @@ const HomePage = () => {
           setLanguage={setLanguage}
           role={isTranslator}
           setIsTranslator={setIsTranslator}
-          isDisabled={displayMyStories}
+          isDisabled={displayMyStories || displayMyTests}
         />
         <Flex
           direction="column"
@@ -106,12 +110,16 @@ const HomePage = () => {
             size="tertiary"
             stacked={false}
             unselectedVariant="ghost"
-            options={["My Work", "Browse Stories"]}
-            name="My Work and Browse Stories toggle"
+            options={["My Work", "Browse Stories", "My Tests"]}
+            name="My Work, Browse Stories, and My Tests toggle"
             defaultValue="My Work"
             onChange={handleDisplayMyStoriesChange}
           />
-          <StoryList stories={stories} displayMyStories={displayMyStories} />
+          <StoryList
+            stories={stories}
+            displayMyStories={displayMyStories}
+            displayMyTests={displayMyTests}
+          />
         </Flex>
       </Flex>
       {showScrollToTop && (


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add My Tests tab on homepage](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=67ced17704474f09ba244adeff4eafab)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- add new GQL query to call the `StoryTranslationTests` mutation 
- create new tab on homepage to display tests 
- Slight modifications to story card to correctly display information for a story test 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to home page, sign in as Angela Merkel 
2. Create a new story translation test using [this link](http://localhost:5000/graphql?query=mutation%20%7B%0A%20%20createStoryTranslationTest(userId%3A%201%2C%20level%3A2%2C%20language%3A%22FRENCH%22)%7B%0A%20%20%20%20story%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20translatorId%0A%20%20%20%20%20%20storyId%0A%20%20%20%20%20%20language%0A%20%20%20%20%20%20stage%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=undefined)
3. Verify that there are tests displaying in my tests tab, all tests should display for admin 
4. Login as a user, verify that only tests for that user are displaying 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Correct tests are displaying for admin and user 
- Admins should be able to see all tests 
- Users can only see their own tests 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
