### PR TITLE
Correct behaviour for right-to-left languages

### DIFF
--- a/backend/python/tools/insert_test_data.py
+++ b/backend/python/tools/insert_test_data.py
@@ -31,7 +31,7 @@ def insert_test_data():
             ('Dwight', 'D. Eisenhower', 'planetread+dwightdeisenhower@uwblueprint.org', '{os.getenv('AUTH_ID_4', '')}', 'User', '{{\"ENGLISH_UK\":4, \"ENGLISH_US\":4, \"GERMAN\":3}}', '{{\"ENGLISH_UK\":3, \"ENGLISH_US\":4}}'), \
             ('Alexander', 'Hamilton', 'planetread+alexanderhamilton@uwblueprint.org', '{os.getenv('AUTH_ID_5', '')}', 'User', '{{\"MANDARIN\":4, \"ENGLISH_UK\":3}}', '{{\"MANDARIN\":2}}'), \
             ('Angela', 'Merkel', 'planetread+angelamerkel@uwblueprint.org', '{os.getenv('AUTH_ID_6', '')}', 'Admin', '{{\"GERMAN\":4}}', '{{\"GERMAN\":4}}'), \
-            ('Richard', 'Feynman', 'planetread+richardfeynman@uwblueprint.org', '{os.getenv('AUTH_ID_7', '')}', 'User', '{{\"PORTUGUESE\":4, \"ENGLISH_UK\":4, \"GERMAN\":1}}', '{{\"PORTUGUESE\":1}}'); \
+            ('Richard', 'Feynman', 'planetread+richardfeynman@uwblueprint.org', '{os.getenv('AUTH_ID_7', '')}', 'User', '{{\"ARABIC\":4, \"ENGLISH_UK\":4, \"GERMAN\":1}}', '{{\"ARABIC\":1}}'); \
     "
     )
 
@@ -45,7 +45,7 @@ def insert_test_data():
                 (2, 'War and Peace', 'War and Peace is a literary work mixed with chapters on history and philosophy by the Russian author Leo Tolstoy.', 'https://www.youtube.com/watch?v=4dn7TEjnbPY', 1, '[\"GERMAN\", \"POLISH\"]', false), \
                 (3, 'A Tale of Two Cities', 'An 1859 historical novel by Charles Dickens, set in London and Paris before and during the French Revolution.', 'https://www.youtube.com/watch?v=5czA_L_eOp4', 3, '[\"MANDARIN\", \"ENGLISH_UK\"]', false), \
                 (4, 'Pride and Prejudice', 'Pride and Prejudice preaches the difference between superficial goodness and actual goodness.', 'https://www.youtube.com/watch?v=5xTh44G6RYs', 4, '[\"GERMAN\", \"ENGLISH_UK\"]', false), \
-                (5, 'To Kill a Mockingbird', 'To Kill a Mockingbird is a novel by the American author Harper Lee. A sentence cannot do this novel justice.', 'https://www.youtube.com/watch?v=3xM8hvEE2dI', 3, '[\"GERMAN\", \"ENGLISH_UK\", \"PORTUGUESE\", \"DUTCH\"]', false), \
+                (5, 'To Kill a Mockingbird', 'To Kill a Mockingbird is a novel by the American author Harper Lee. A sentence cannot do this novel justice.', 'https://www.youtube.com/watch?v=3xM8hvEE2dI', 3, '[\"GERMAN\", \"ENGLISH_UK\", \"ARABIC\", \"DUTCH\"]', false), \
                 (6, 'The Great Gatsby', 'Set in the Jazz Age on Long Island, near New York City, the novel depicts mysterious millionaire Jay Gatsby and Gatsby and Daisy Buchanan.', 'https://www.youtube.com/watch?v=e6Iu29TNfkM', 4, '[\"ENGLISH_US\"]', false), \
                 (7, 'Nineteen Eighty-Four', 'Nineteen Eighty-Four, often referred to as 1984, is a dystopian social science fiction novel by the English novelist George Orwell.', 'https://www.youtube.com/watch?v=h9JIKngJnCU', 2, '[]', false), \
                 (8, 'The Musical Donkey', 'There was a donkey who felt so happy that he sang through the night in the cucumber field. The problem was that the cucumbers couldn\"t bear it. What did they do?', 'https://www.youtube.com/watch?v=QfcttsaHTIY', 2, '[]', true), \
@@ -144,14 +144,14 @@ def insert_test_data():
             (8, 4, 'ENGLISH_UK', 'TRANSLATE', 4), \
             (9, 5, 'GERMAN', 'TRANSLATE', 4), \
             (10, 5, 'ENGLISH_UK', 'TRANSLATE', 1), \
-            (11, 5, 'PORTUGUESE', 'TRANSLATE', 7), \
+            (11, 5, 'ARABIC', 'TRANSLATE', 7), \
             (12, 5, 'DUTCH', 'TRANSLATE', 3), \
             (13, 6, 'ENGLISH_US', 'TRANSLATE', 1);"
     )
 
     # story translation contents
     db.engine.execute("ALTER TABLE story_translation_contents_all AUTO_INCREMENT = 1;")
-    full_translation = [2, 3, 5, 7, 11, 13]
+    full_translation = [2, 3, 5, 7, 13]
     story_count = 0
     for story_translation_id in full_translation:
         for i, content in enumerate(generic_content):
@@ -165,7 +165,7 @@ def insert_test_data():
             )
         story_count += 1
 
-    empty_translation = [1, 4, 6, 8, 9, 10, 12]
+    empty_translation = [1, 4, 6, 8, 9, 10, 11, 12]
     for story_translation_id in empty_translation:
         for line_index in range(10):
             id = story_count * 10 + line_index + 1

--- a/frontend/src/components/homepage/PreviewModal.tsx
+++ b/frontend/src/components/homepage/PreviewModal.tsx
@@ -17,7 +17,10 @@ import {
 import { Icon } from "@chakra-ui/icon";
 import { MdTrendingFlat } from "react-icons/md";
 
-import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
+import {
+  isRtlLanguage,
+  convertLanguageTitleCase,
+} from "../../utils/LanguageUtils";
 import { getLevelVariant } from "../../utils/StatusUtils";
 import convertStageTitleCase from "../../utils/StageUtils";
 import {
@@ -91,7 +94,12 @@ const PreviewModal = ({
         {c}
       </Text>
       {storyTranslationId && (
-        <Text variant="previewModalTranslationContent">
+        <Text
+          textAlign={
+            isRtlLanguage(convertLanguageTitleCase(language)) ? "right" : "left"
+          }
+          variant="previewModalTranslationContent"
+        >
           {translationContent[index]}
         </Text>
       )}

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -55,7 +55,7 @@ const TranslationPage = () => {
   const [stage, setStage] = useState<string>("");
 
   // TODO: remove eslint comment when setIsTest is used
-  const [isTest, setIsTest] = useState(false);  // eslint-disable-line
+  const [isTest, setIsTest] = useState(false); // eslint-disable-line
 
   // AutoSave
   const [changedStoryLines, setChangedStoryLines] = useState<

--- a/frontend/src/components/translation/EditableCell.tsx
+++ b/frontend/src/components/translation/EditableCell.tsx
@@ -9,6 +9,7 @@ export type EditableCellProps = {
   fontSize: string;
   maxChars: number;
   onChange: (newContent: string, lineIndex: number, maxChars: number) => void;
+  isRtl?: boolean;
 };
 
 const EditableCell = ({
@@ -17,6 +18,7 @@ const EditableCell = ({
   fontSize,
   maxChars,
   onChange,
+  isRtl = false,
 }: EditableCellProps) => {
   const textareaRef = useRef<any>(null);
   const [height, setHeight] = useState<string>("auto");
@@ -29,6 +31,7 @@ const EditableCell = ({
 
   return (
     <Textarea
+      dir={isRtl ? "rtl" : "ltr"}
       ref={textareaRef}
       variant={
         text?.length === maxChars ? "maxCharsReached" : "translationEditable"

--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -5,6 +5,7 @@ import { StoryLine } from "./Autosave";
 import StatusBadge from "../review/StatusBadge";
 import ApproveAll from "../review/ApproveAll";
 import { getStatusVariant } from "../../utils/StatusUtils";
+import { isRtlLanguage } from "../../utils/LanguageUtils";
 import {
   TRANSLATION_PAGE_TOOL_TIP_COPY,
   REVIEW_PAGE_TOOL_TIP_COPY,
@@ -88,6 +89,7 @@ const TranslationTable = ({
               maxChars={storyLine.originalContent.length * 2}
               onChange={onUserInput!!}
               fontSize={fontSize}
+              isRtl={isRtlLanguage(translatedLanguage)}
             />
           </Flex>
         ) : (
@@ -97,7 +99,12 @@ const TranslationTable = ({
             isDisabled={!translator}
           >
             <Flex flex={1} height="100%">
-              <Text variant="cell" flexGrow={1} fontSize={fontSize}>
+              <Text
+                textAlign={isRtlLanguage(translatedLanguage) ? "right" : "left"}
+                flexGrow={1}
+                fontSize={fontSize}
+                variant="cell"
+              >
                 {storyLine.translatedContent!!}
               </Text>
             </Flex>

--- a/frontend/src/utils/LanguageUtils.ts
+++ b/frontend/src/utils/LanguageUtils.ts
@@ -1,7 +1,7 @@
 import { convertStringTitleCase } from "./Utils";
 
 // Change language string to title case
-function convertLanguageTitleCase(language: string) {
+export function convertLanguageTitleCase(language: string) {
   // Handles 4 edge cases: ENGLISH_US, ENGLISH_UK, ENGLISH_INDIA, ASANTE_TWI
   switch (language) {
     case "ENGLISH_US":
@@ -21,7 +21,7 @@ function convertLanguageTitleCase(language: string) {
   }
 }
 
-function convertTitleCaseToLanguage(language: string) {
+export function convertTitleCaseToLanguage(language: string) {
   switch (language) {
     case "English (US)":
       return "ENGLISH_US";
@@ -40,4 +40,5 @@ function convertTitleCaseToLanguage(language: string) {
   }
 }
 
-export { convertLanguageTitleCase, convertTitleCaseToLanguage };
+export const isRtlLanguage = (titleCaseLanguage: string) =>
+  ["Arabic", "Hebrew", "Kurdish", "Urdu"].includes(titleCaseLanguage);


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Correct behaviour for right-to-left languages](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=65a0b13638174abeb19f7addc87c5893)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

if the translated language is a rtl language, 
-  set the dir attribute on the `EditableCell` to rtl
- right align the cell text for the translated language column
if the translated language is a ltr language, everything behaves as usual

The insert script has been modified to contain an Arabic translation to test this feature.

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. open http://localhost:3000/ and log in as planetread+**richardfeynman**@uwblueprint.org

Left to right languages
2. view english translation "East of Eden" and observe that EditableCells behave as expected. type some stuff
3. submit translation for review and observe that text remains left justified
4. return to homepage and open "PREVIEW BOOK". observe that cells are left justified. 

Right to left languages
2. view arabic translation "To Kill a Mockingbird" and observe that EditableCells are rtl. To test this, copy+paste these three words in this order
```
فطيرة
التوت
بالجبنة
```
the final text should read `فطيرة التوت بالجبنة` ([which means blueberry cheesecake!](https://translate.google.com/?sl=auto&tl=ar&text=blueberry%20cheesecake&op=translate)) and the cursor should always be on the left hand side
3. submit translation for review and observe that text is right justified
4. return to homepage and open "PREVIEW BOOK". observe that cells are right justified. 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work
- does the code make sense

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
