### PR TITLE
Create admin "Manage Tests" page

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -799,7 +799,10 @@ class StoryService(IStoryService):
 
             # Remove language from story.translated_languages
             story = Story.query.filter_by(id=story_translation.story_id).first()
-            if story.translated_languages is not None:
+            if (
+                story.translated_languages is not None
+                and story_translation.language in story.translated_languages
+            ):
                 story.translated_languages.remove(story_translation.language)
                 Story.query.filter_by(id=story_translation.story_id).update(
                     story.to_dict()

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -288,3 +288,62 @@ export const GET_STORY_TRANSLATIONS_BY_USER = (userId: number) => gql`
     }
   }
 `;
+
+export type StoryTestResult = {
+  translate: number;
+  review?: number;
+};
+
+export type StoryTranslationTest = {
+  id: number;
+  language: string;
+  stage: string;
+  translatorId: number;
+  storyId: number;
+  title: string;
+  description: string;
+  youtubeLink: string;
+  level: number;
+  translatorName: string;
+  testGrade: number;
+  testResult: StoryTestResult | null;
+  testFeedback: string;
+  dateSubmitted: Date;
+};
+
+export const buildStoryTranslationTestsQuery = (
+  language?: string,
+  level?: number,
+  stage?: string,
+  storyTitle?: string,
+) => {
+  let queryParams = language ? `language: "${language}", ` : "";
+  queryParams += level ? `level: ${level}, ` : "";
+  queryParams += stage ? `stage: "${stage}", ` : "";
+  queryParams += storyTitle ? `storyTitle: "${storyTitle}", ` : "";
+  queryParams = queryParams ? `(${queryParams})` : "";
+
+  return {
+    fieldName: "storyTranslationTests",
+    string: gql`
+      query StoryTranslationsTests {
+        storyTranslationTests ${queryParams} {
+          id
+          language
+          stage
+          translatorId
+          storyId
+          title
+          description
+          youtubeLink
+          level
+          translatorName
+          testGrade
+          testResult
+          testFeedback
+          dateSubmitted
+        }
+      }
+    `,
+  };
+};

--- a/frontend/src/components/admin/ManageStoryTests.tsx
+++ b/frontend/src/components/admin/ManageStoryTests.tsx
@@ -10,7 +10,7 @@ import { convertTitleCaseToStage } from "../../utils/StageUtils";
 import StoryTestsTable from "./StoryTestsTable";
 
 const ManageStoryTests = () => {
-  // TODO: uncomment when filters are implemented
+  // TODO: uncomment if filters are implemented
   /* eslint-disable */
   const [language, setLanguage] = useState<string | null>(null);
   const [level, setLevel] = useState<string | null>(null);
@@ -30,7 +30,7 @@ const ManageStoryTests = () => {
     fetchPolicy: "cache-and-network",
     onCompleted: () => {
       const result = [...data[query.fieldName]];
-      setStoryTests(result);
+      setStoryTests(result.filter((test) => test.stage === "REVIEW"));
     },
   });
 

--- a/frontend/src/components/admin/ManageStoryTests.tsx
+++ b/frontend/src/components/admin/ManageStoryTests.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import { Box, Heading, Flex } from "@chakra-ui/react";
+import { useQuery } from "@apollo/client";
+import {
+  buildStoryTranslationTestsQuery,
+  StoryTranslationTest,
+} from "../../APIClients/queries/StoryQueries";
+import { convertTitleCaseToLanguage } from "../../utils/LanguageUtils";
+import { convertTitleCaseToStage } from "../../utils/StageUtils";
+import StoryTestsTable from "./StoryTestsTable";
+
+const ManageStoryTests = () => {
+  // TODO: uncomment when filters are implemented
+  /* eslint-disable */
+  const [language, setLanguage] = useState<string | null>(null);
+  const [level, setLevel] = useState<string | null>(null);
+  const [stage, setStage] = useState<string | null>(null);
+  const [searchText, setSearchText] = useState<string | null>(null);
+  const [storyTests, setStoryTests] = useState<StoryTranslationTest[]>([]);
+  /* eslint-enable */
+
+  const query = buildStoryTranslationTestsQuery(
+    convertTitleCaseToLanguage(language || ""),
+    parseInt(level || "", 10) || 0,
+    convertTitleCaseToStage(stage || ""),
+    searchText || "",
+  );
+
+  const { data } = useQuery(query.string, {
+    fetchPolicy: "cache-and-network",
+    onCompleted: () => {
+      const result = [...data[query.fieldName]];
+      setStoryTests(result);
+    },
+  });
+
+  return (
+    <Box textAlign="center">
+      <Flex>
+        <Heading float="left" margin="20px 30px" size="lg">
+          Tests
+        </Heading>
+      </Flex>
+      <StoryTestsTable storyTests={storyTests} setStoryTests={setStoryTests} />
+    </Box>
+  );
+};
+
+export default ManageStoryTests;

--- a/frontend/src/components/admin/StoryTestsTable.tsx
+++ b/frontend/src/components/admin/StoryTestsTable.tsx
@@ -16,7 +16,6 @@ import {
   Button,
 } from "@chakra-ui/react";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
-import convertStageTitleCase from "../../utils/StageUtils";
 import { getLevelVariant } from "../../utils/StatusUtils";
 import {
   MANAGE_TESTS_TABLE_DELETE_TEST_BUTTON,
@@ -48,7 +47,6 @@ const StoryTestsTable = ({
   setStoryTests,
 }: StoryTestsTableProps) => {
   const [isAscendingName, setIsAscendingName] = useState(true);
-  const [isAscendingStage, setIsAscendingStage] = useState(true);
   const [isAscendingDate, setIsAscendingDate] = useState(true);
 
   const [confirmDeleteTranslation, setConfirmDeleteTranslation] =
@@ -104,11 +102,6 @@ const StoryTestsTable = ({
       isAscending: isAscendingName,
       setIsAscending: setIsAscendingName,
     },
-    stage: {
-      sortFn: generateSortFn<StoryTranslationTest>("stage", isAscendingStage),
-      isAscending: isAscendingStage,
-      setIsAscending: setIsAscendingStage,
-    },
     date: {
       sortFn: dateSort,
       isAscending: isAscendingDate,
@@ -150,7 +143,6 @@ const StoryTestsTable = ({
             }`}
           </Badge>
         </Td>
-        <Td>{convertStageTitleCase(storyTest.stage)}</Td>
         <Td>{storyTest.dateSubmitted?.toLocaleDateString()}</Td>
         <Td>
           <Button
@@ -196,9 +188,6 @@ const StoryTestsTable = ({
             isAscendingName ? "↑" : "↓"
           }`}</Th>
           <Th>LANGUAGE & LEVEL</Th>
-          <Th cursor="pointer" onClick={() => sort("stage")}>{`PROGRESS ${
-            isAscendingStage ? "↑" : "↓"
-          }`}</Th>
           <Th cursor="pointer" onClick={() => sort("date")}>{`DATE SUBMITTED ${
             isAscendingDate ? "↑" : "↓"
           }`}</Th>

--- a/frontend/src/components/admin/StoryTestsTable.tsx
+++ b/frontend/src/components/admin/StoryTestsTable.tsx
@@ -1,0 +1,227 @@
+import React, { Dispatch, SetStateAction, useState } from "react";
+import { Icon } from "@chakra-ui/icon";
+import { MdDelete } from "react-icons/md";
+import { useMutation } from "@apollo/client";
+import { useHistory } from "react-router-dom";
+import {
+  Badge,
+  Link,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  IconButton,
+  Button,
+} from "@chakra-ui/react";
+import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
+import convertStageTitleCase from "../../utils/StageUtils";
+import { getLevelVariant } from "../../utils/StatusUtils";
+import {
+  MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_BUTTON,
+  MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_CONFIRMATION,
+} from "../../utils/Copy";
+import ConfirmationModal from "../utils/ConfirmationModal";
+import { generateSortFn } from "../../utils/Utils";
+import { StoryTranslationTest } from "../../APIClients/queries/StoryQueries";
+import {
+  SoftDeleteStoryTranslationResponse,
+  SOFT_DELETE_STORY_TRANSLATION,
+} from "../../APIClients/mutations/StoryMutations";
+
+interface StoryTranslationTestsFieldSortDict {
+  [field: string]: {
+    sortFn: (a: StoryTranslationTest, b: StoryTranslationTest) => number;
+    isAscending: boolean;
+    setIsAscending: Dispatch<SetStateAction<boolean>>;
+  };
+}
+
+export type StoryTestsTableProps = {
+  storyTests: StoryTranslationTest[];
+  setStoryTests: (newState: StoryTranslationTest[]) => void;
+};
+
+const StoryTestsTable = ({
+  storyTests,
+  setStoryTests,
+}: StoryTestsTableProps) => {
+  const [isAscendingName, setIsAscendingName] = useState(true);
+  const [isAscendingStage, setIsAscendingStage] = useState(true);
+  const [isAscendingDate, setIsAscendingDate] = useState(true);
+
+  const [confirmDeleteTranslation, setConfirmDeleteTranslation] =
+    useState(false);
+  const [idToDelete, setIdToDelete] = useState(0);
+
+  const [deleteStoryTranslation] = useMutation<{
+    response: SoftDeleteStoryTranslationResponse;
+  }>(SOFT_DELETE_STORY_TRANSLATION);
+
+  const history = useHistory();
+
+  const closeModal = () => {
+    setIdToDelete(0);
+    setConfirmDeleteTranslation(false);
+  };
+
+  const openModal = (id: number) => {
+    setIdToDelete(id);
+    setConfirmDeleteTranslation(true);
+  };
+
+  const callSoftDeleteStoryTranslationMutation = async () => {
+    await deleteStoryTranslation({
+      variables: {
+        id: idToDelete,
+      },
+    });
+    closeModal();
+    window.location.reload();
+  };
+
+  /*
+   * Compare the date submitted of two StoryTranslationTests based on
+   * ascending/descending order
+   */
+  const dateSort = (t1: StoryTranslationTest, t2: StoryTranslationTest) => {
+    const dateT1 = t1.dateSubmitted;
+    const dateT2 = t2.dateSubmitted;
+    const forwardCompare = +(dateT2 > dateT1); // 1 if dateT2 > dateT1
+    const reverseCompare = +(dateT1 > dateT2); // 1 if dateT1 > dateT2
+    return isAscendingDate
+      ? forwardCompare - reverseCompare
+      : reverseCompare - forwardCompare;
+  };
+
+  const sortDict: StoryTranslationTestsFieldSortDict = {
+    name: {
+      sortFn: generateSortFn<StoryTranslationTest>(
+        "translatorName",
+        isAscendingName,
+      ),
+      isAscending: isAscendingName,
+      setIsAscending: setIsAscendingName,
+    },
+    stage: {
+      sortFn: generateSortFn<StoryTranslationTest>("stage", isAscendingStage),
+      isAscending: isAscendingStage,
+      setIsAscending: setIsAscendingStage,
+    },
+    date: {
+      sortFn: dateSort,
+      isAscending: isAscendingDate,
+      setIsAscending: setIsAscendingDate,
+    },
+  };
+
+  const sort = (field: string) => {
+    const newStoryTests = [...storyTests];
+    const { sortFn, isAscending, setIsAscending } = sortDict[field];
+
+    setIsAscending(!isAscending);
+    newStoryTests.sort(sortFn);
+
+    setStoryTests(newStoryTests);
+  };
+
+  const tableBody = storyTests.map(
+    (storyTest: StoryTranslationTest, index: number) => (
+      <Tr
+        borderBottom={
+          index === storyTests.length - 1 ? "1em solid transparent" : ""
+        }
+        key={`${storyTest.id}`}
+      >
+        <Td>
+          <Link isExternal href={`/user/${storyTest.id}`}>
+            {storyTest.translatorName}
+          </Link>
+        </Td>
+        <Td>
+          <Badge
+            background={getLevelVariant(storyTest.level)}
+            marginBottom="3px"
+            marginTop="3px"
+          >
+            {`${convertLanguageTitleCase(storyTest.language)} | Level ${
+              storyTest.level
+            }`}
+          </Badge>
+        </Td>
+        <Td>{convertStageTitleCase(storyTest.stage)}</Td>
+        <Td>{storyTest.dateSubmitted?.toLocaleDateString()}</Td>
+        <Td>
+          <Button
+            borderRadius="8px"
+            colorScheme="blue"
+            size="secondary"
+            onClick={() =>
+              history.push(`/grade/${storyTest.storyId}/${storyTest.id}`)
+            }
+            width="110px"
+            marginRight="32px"
+          >
+            Grade
+          </Button>
+          <IconButton
+            aria-label={`Delete story test ${storyTest.id} for story ${storyTest.title}`}
+            background="transparent"
+            icon={<Icon as={MdDelete} />}
+            width="fit-content"
+            onClick={() => openModal(storyTest.id)}
+          />
+        </Td>
+      </Tr>
+    ),
+  );
+
+  return (
+    <Table
+      borderRadius="12px"
+      boxShadow="0px 0px 2px grey"
+      margin="auto"
+      size="sm"
+      theme="gray"
+      variant="striped"
+      width="95%"
+    >
+      <Thead>
+        <Tr
+          borderTop="1em solid transparent"
+          borderBottom="0.5em solid transparent"
+        >
+          <Th cursor="pointer" onClick={() => sort("name")}>{`NAME ${
+            isAscendingName ? "↑" : "↓"
+          }`}</Th>
+          <Th>LANGUAGE & LEVEL</Th>
+          <Th cursor="pointer" onClick={() => sort("stage")}>{`PROGRESS ${
+            isAscendingStage ? "↑" : "↓"
+          }`}</Th>
+          <Th cursor="pointer" onClick={() => sort("date")}>{`DATE SUBMITTED ${
+            isAscendingDate ? "↑" : "↓"
+          }`}</Th>
+          <Th width="18%">ACTION</Th>
+        </Tr>
+      </Thead>
+      <Tbody>{tableBody}</Tbody>
+      {confirmDeleteTranslation && (
+        <ConfirmationModal
+          confirmation={confirmDeleteTranslation}
+          onClose={closeModal}
+          onConfirmationClick={callSoftDeleteStoryTranslationMutation}
+          // TODO: change text
+          confirmationMessage={
+            MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_CONFIRMATION
+          }
+          buttonMessage={
+            MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_BUTTON
+          }
+        />
+      )}
+    </Table>
+  );
+};
+
+export default StoryTestsTable;

--- a/frontend/src/components/admin/StoryTestsTable.tsx
+++ b/frontend/src/components/admin/StoryTestsTable.tsx
@@ -19,8 +19,8 @@ import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 import convertStageTitleCase from "../../utils/StageUtils";
 import { getLevelVariant } from "../../utils/StatusUtils";
 import {
-  MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_BUTTON,
-  MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_CONFIRMATION,
+  MANAGE_TESTS_TABLE_DELETE_TEST_BUTTON,
+  MANAGE_TESTS_TABLE_DELETE_TEST_CONFIRMATION,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
 import { generateSortFn } from "../../utils/Utils";
@@ -211,13 +211,8 @@ const StoryTestsTable = ({
           confirmation={confirmDeleteTranslation}
           onClose={closeModal}
           onConfirmationClick={callSoftDeleteStoryTranslationMutation}
-          // TODO: change text
-          confirmationMessage={
-            MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_CONFIRMATION
-          }
-          buttonMessage={
-            MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_BUTTON
-          }
+          confirmationMessage={MANAGE_TESTS_TABLE_DELETE_TEST_CONFIRMATION}
+          buttonMessage={MANAGE_TESTS_TABLE_DELETE_TEST_BUTTON}
         />
       )}
     </Table>

--- a/frontend/src/components/navigation/Header.tsx
+++ b/frontend/src/components/navigation/Header.tsx
@@ -10,6 +10,7 @@ export enum AdminPageOption {
   StoryTranslations = 1,
   Translators,
   Reviewers,
+  Tests,
 }
 
 export type HeaderProps = {
@@ -91,6 +92,16 @@ const Header = ({
             }
           >
             Manage Reviewers
+          </Button>
+          <Button
+            onClick={() => setAdminPageOption(AdminPageOption.Tests)}
+            variant={
+              adminPageOption === AdminPageOption.Tests
+                ? "headerSelect"
+                : "header"
+            }
+          >
+            Manage Tests
           </Button>
         </Flex>
       )}

--- a/frontend/src/components/pages/AdminPage.tsx
+++ b/frontend/src/components/pages/AdminPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Header, { AdminPageOption } from "../navigation/Header";
 import ManageStoryTranslations from "../admin/ManageStoryTranslations";
 import ManageUsers from "../admin/ManageUsers";
+import ManageStoryTests from "../admin/ManageStoryTests";
 
 const AdminPage = () => {
   const [adminPageOption, setAdminPageOption] = useState(
@@ -15,6 +16,8 @@ const AdminPage = () => {
         return <ManageUsers isTranslators />;
       case AdminPageOption.Reviewers:
         return <ManageUsers isTranslators={false} />;
+      case AdminPageOption.Tests:
+        return <ManageStoryTests />;
       default:
         return <ManageStoryTranslations />;
     }

--- a/frontend/src/components/pages/StoryTestGradingPage.tsx
+++ b/frontend/src/components/pages/StoryTestGradingPage.tsx
@@ -46,7 +46,6 @@ const StoryTestGradingPage = () => {
   const [translatedStoryLines, setTranslatedStoryLines] = useState<StoryLine[]>(
     [],
   );
-  const [reviewerId, setReviewerId] = useState(-1);
   const [numApprovedLines, setNumApprovedLines] = useState(0);
 
   const [fontSize, setFontSize] = useState<string>("12px");
@@ -98,7 +97,6 @@ const StoryTestGradingPage = () => {
     {
       fetchPolicy: "cache-and-network",
       onCompleted: (data) => {
-        setReviewerId(data.storyTranslationById.reviewerId);
         const storyContent = data.storyById.contents;
         const translatedContent = data.storyTranslationById.translationContents;
         setLanguage(data.storyTranslationById.language);
@@ -128,8 +126,8 @@ const StoryTestGradingPage = () => {
     },
   );
 
-  if (loading || reviewerId === -1) return <div />;
-  if (+authenticatedUser!!.id !== reviewerId) return <Redirect to="/404" />;
+  if (loading) return <div />;
+  if (authenticatedUser!!.role !== "Admin") return <Redirect to="/404" />;
   return (
     <Flex
       height="100vh"

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -68,3 +68,8 @@ export const DELETE_STORY_CONFIRMATION =
   "By removing this story and all story translations associated with it, all data will be removed from the database. This action cannot be undone.";
 
 export const DELETE_STORY_BUTTON = "I'm sure, remove";
+
+export const MANAGE_TESTS_TABLE_DELETE_TEST_CONFIRMATION =
+  "By deleting this test, the user has to wait for 30 days before they can take this test again.";
+
+export const MANAGE_TESTS_TABLE_DELETE_TEST_BUTTON = "I'm sure, delete test";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Create Manage Tests admin page](https://www.notion.so/uwblueprintexecs/Create-Manage-Tests-admin-page-32dbf205f61e4e94822aef4b22dce5fc)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- created table to display story translation tests that have been submitted (in REVIEW)
- fix grading page to allow admin access
- fix soft_delete_story_translation mutation to handle deletion of story tests

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data erase"`
2. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data"`
3. create a few story translation tests using the mutation below
4. on Altair, login as Carl Sagan and update story test stage using the mutation below
5. login as Angela Merkel and go to `/admin`
6. click on "Manage Tests" and verify that only the story test in review appears in the table
7. click on "grade", should lead to grading page
8. try deleting story test, verify that the flow works

#### Create story translation test
```
mutation CreateStoryTest {
  createStoryTranslationTest(userId: 1, level:2, language:"FRENCH"){
    story{
      id
      translatorId
      storyId
      language
      stage
    }
  }
}
```

#### Update story test stage
```
mutation UpdateStage {
  updateStoryTranslationStage(storyTranslationData: {id: 14, stage: REVIEW}) {
    ok
  }
}
```


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does the table look good?
- does the code look okay?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
