### PR TITLE
Redirect admins to / from /admins

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,10 @@ const App = () => {
   const [authenticatedUser, setAuthenticatedUser] =
     useState<AuthenticatedUser>(currentUser);
 
+  const isAdmin = authenticatedUser
+    ? authenticatedUser.role === "Admin"
+    : false;
+
   return (
     <ChakraProvider theme={customTheme}>
       <ForceLightMode>
@@ -62,13 +66,16 @@ const App = () => {
                   path="/complete-profile"
                   component={CompleteProfilePage}
                 />
-                <PrivateRoute exact path="/" component={HomePage} />
+                <PrivateRoute
+                  exact
+                  path="/"
+                  component={isAdmin ? AdminPage : HomePage}
+                />
                 <PrivateRoute
                   exact
                   path="/user/:userId"
                   component={UserProfilePage}
                 />
-                <PrivateRoute exact path="/admin" component={AdminPage} />
                 <PrivateRoute
                   exact
                   path="/translation/:storyIdParam/:storyTranslationIdParam"


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Redirect admins to / from /admins](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=f1209e12d6724adcb2b571af9d8f24a9)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- check if user is admin in App.tsx
- display Homepage at root if not admin. else display AdminPage

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. log in as angelamerkel
2. observe that youre directed to the admin page
3. login as carlsagan
4. observe that youre directed to the homepage
5. attempt going to /404, observe the 404

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
