### PR TITLE
Implement admin approve new language flow

### DIFF
--- a/frontend/src/components/admin/TableFilter.tsx
+++ b/frontend/src/components/admin/TableFilter.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Select, { StylesConfig } from "react-select";
+import Select from "react-select";
 import { MdSearch } from "react-icons/md";
 import { Icon } from "@chakra-ui/icon";
 import {
@@ -19,6 +19,7 @@ import { stageOptions } from "../../constants/Stage";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 import { FILTER_TOOL_TIP_COPY } from "../../utils/Copy";
 import DropdownIndicator from "../utils/DropdownIndicator";
+import { colourStyles } from "../../theme/components/Select";
 
 export type TableFilterProps = {
   language: string | null;
@@ -49,26 +50,6 @@ const FilterBadges = ({ filterValue, setFilterValue }: FilterBadgesProps) => {
       </Button>
     </Badge>
   );
-};
-
-const colourStyles: StylesConfig = {
-  control: (styles) => ({
-    ...styles,
-    backgroundColor: "#F1F4F7", // #F1F4F7 is gray.100
-    border: "none",
-  }),
-  option: (styles, { isSelected }) => {
-    return {
-      ...styles,
-      color: "black",
-      backgroundColor: isSelected ? "#F1F4F7" : "white", // #F1F4F7 is gray.100
-      "&:hover": {
-        backgroundColor: "#F1F4F7", // #F1F4F7 is gray.100
-      },
-    };
-  },
-  indicatorSeparator: (styles) => ({ ...styles, display: "none" }),
-  placeholder: (styles) => ({ ...styles, color: "black" }),
 };
 
 const TableFilter = ({

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -163,6 +163,8 @@ const UserProfilePage = () => {
           <ApprovedLanguagesTable
             approvedLanguagesTranslation={approvedLanguagesTranslation}
             approvedLanguagesReview={approvedLanguagesReview}
+            setApprovedLanguagesTranslation={setApprovedLanguagesTranslation}
+            setApprovedLanguagesReview={setApprovedLanguagesReview}
             userId={parseInt(userId, 10)}
             setAlertText={setAlertText}
             setAlert={setAlert}
@@ -170,12 +172,13 @@ const UserProfilePage = () => {
             setAlertTimeout={setAlertTimeout}
             isAdmin={isAdmin}
           />
-          <Heading size="lg" marginTop="56px" marginBottom="20px">
+          <Heading size="lg" marginTop="56px" marginBottom="10px">
             Assigned Story Translations
           </Heading>
           {isAdmin &&
             (storyAssignStage !== StoryAssignStage.INITIAL ? (
               <InfoAlert
+                colour="orange.50"
                 message={
                   storyAssignStage === StoryAssignStage.SUCCESS
                     ? "A new story was assigned to the user."

--- a/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
+++ b/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
@@ -83,10 +83,22 @@ const AssignedStoryTranslationsTable = ({
     null,
   );
 
+  const [alertTimeout, setAlertTimeout] = useState(0);
+
+  const resetAlertTimeout = () => {
+    window.clearTimeout(alertTimeout);
+    const timeout: number = window.setTimeout(
+      () => setStoryAssignStage(StoryAssignStage.INITIAL),
+      5000,
+    );
+    setAlertTimeout(timeout);
+  };
+
   const closeAssignStoryModal = (cancelled = true) => {
     setAssignStory(false);
     if (cancelled) {
       setStoryAssignStage(StoryAssignStage.CANCELLED);
+      resetAlertTimeout();
     }
   };
   const openAssignStoryModal = () => {
@@ -244,6 +256,7 @@ const AssignedStoryTranslationsTable = ({
       setStoryAssignStage(StoryAssignStage.SUCCESS);
       // TODO: remove this line and add story translation locally
       window.location.reload();
+      resetAlertTimeout();
     }
   };
 
@@ -314,6 +327,7 @@ const AssignedStoryTranslationsTable = ({
         theme="gray"
         variant="striped"
         width="100%"
+        marginTop="20px"
       >
         <Thead>
           <Tr

--- a/frontend/src/theme/components/Select.ts
+++ b/frontend/src/theme/components/Select.ts
@@ -1,3 +1,5 @@
+import { StylesConfig } from "react-select";
+
 const Select = {
   baseStyle: {},
   variants: {
@@ -14,6 +16,26 @@ const Select = {
       },
     },
   },
+};
+
+export const colourStyles: StylesConfig = {
+  control: (styles) => ({
+    ...styles,
+    backgroundColor: "#F1F4F7", // #F1F4F7 is gray.100
+    border: "none",
+  }),
+  option: (styles, { isSelected }) => {
+    return {
+      ...styles,
+      color: "black",
+      backgroundColor: isSelected ? "#F1F4F7" : "white", // #F1F4F7 is gray.100
+      "&:hover": {
+        backgroundColor: "#F1F4F7", // #F1F4F7 is gray.100
+      },
+    };
+  },
+  indicatorSeparator: (styles) => ({ ...styles, display: "none" }),
+  placeholder: (styles) => ({ ...styles, color: "black" }),
 };
 
 export default Select;


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Implement approved language table "Add new level" flow](https://www.notion.so/uwblueprintexecs/Implement-approved-language-table-Add-new-level-flow-41bb51999eed4359976809f465787060)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- implemented approve new language flow, including new modal
- minor adjustments to keep both info alert behaviours on UserProfilePage consistent

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin
2. Go to any `/user/:id`
3. Click "Add New Language"
4. Select a role and verify that only new languages appear (not ones that the user is already approved for)
5. Select a level and click "Assign"
6. Verify that the new language appears in the table properly

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does the modal work?
- does the new row get inserted properly?
- verify that the info alert displays the correct information and behaves consistently with the "Assign New Story" flow

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
