### PR TITLE
Move authentication to GQL

### DIFF
--- a/backend/python/app/graphql/mutations/comment_mutation.py
+++ b/backend/python/app/graphql/mutations/comment_mutation.py
@@ -1,6 +1,9 @@
 import graphene
 
-from ...middlewares.auth import require_authorization_by_role_gql
+from ...middlewares.auth import (
+    get_user_id_from_request,
+    require_authorization_by_role_gql,
+)
 from ..service import services
 from ..types.comment_type import (
     CommentResponseDTO,
@@ -19,7 +22,10 @@ class CreateComment(graphene.Mutation):
 
     @require_authorization_by_role_gql({"User", "Admin"})
     def mutate(root, info, comment_data):
-        comment_response = services["comment"].create_comment(comment=comment_data)
+        user_id = get_user_id_from_request()
+        comment_response = services["comment"].create_comment(
+            comment=comment_data, user_id=user_id
+        )
         ok = True
         return CreateComment(ok=ok, comment=comment_response)
 

--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -213,7 +213,10 @@ class UpdateStoryTranslationStage(graphene.Mutation):
 
     def mutate(root, info, story_translation_data):
         try:
-            services["story"].update_story_translation_stage(story_translation_data)
+            user_id = get_user_id_from_request()
+            services["story"].update_story_translation_stage(
+                story_translation_data, user_id
+            )
             return UpdateStoryTranslationStage(ok=True)
         except Exception as e:
             error_message = getattr(e, "message", None)

--- a/backend/python/app/graphql/mutations/user_mutation.py
+++ b/backend/python/app/graphql/mutations/user_mutation.py
@@ -34,7 +34,7 @@ class UpdateMe(graphene.Mutation):
         Update the user that made the request
         """
         try:
-            user_id = int(get_user_id_from_request())
+            user_id = get_user_id_from_request()
             updated_user = services["user"].update_me(user_id, user)
             return UpdateMe(user=updated_user)
         except Exception as e:

--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -42,7 +42,7 @@ def resolve_story_translations(root, info, language, level, stage, story_title):
 
 @require_authorization_by_role_gql({"User", "Admin"})
 def resolve_story_translation_tests(root, info, language, level, stage, story_title):
-    user_id = int(get_user_id_from_request())
+    user_id = get_user_id_from_request()
     user = services["user"].get_user_by_id(user_id)
     return services["story"].get_story_translation_tests(
         user, language, level, stage, story_title

--- a/backend/python/app/middlewares/auth.py
+++ b/backend/python/app/middlewares/auth.py
@@ -27,7 +27,7 @@ def get_user_id_from_request():
         access_token, check_revoked=True
     )
     user_id = auth_service.user_service.get_user_id_by_auth_id(decoded_id_token["uid"])
-    return user_id
+    return int(user_id)
 
 
 """

--- a/backend/python/app/services/implementations/comment_service.py
+++ b/backend/python/app/services/implementations/comment_service.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from flask import current_app
 from sqlalchemy import func
 
-from ...middlewares.auth import get_user_id_from_request
 from ...models import db
 from ...models.comment import Comment
 from ...models.comment_all import CommentAll
@@ -17,10 +16,8 @@ class CommentService(ICommentService):
     def __init__(self, logger=current_app.logger):
         self.logger = logger
 
-    def create_comment(self, comment):
+    def create_comment(self, comment, user_id):
         try:
-            # TODO: remove cast to int once get_user_id_from_request is updated
-            user_id = int(get_user_id_from_request())
             new_comment = CommentAll(**comment)
             new_comment.user_id = user_id
 

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -6,7 +6,6 @@ from ...graphql.types.story_type import (
     StoryTranslationContentResponseDTO,
     StoryTranslationUpdateStatusResponseDTO,
 )
-from ...middlewares.auth import get_user_id_from_request
 from ...models import db
 from ...models.comment import Comment
 from ...models.story import Story
@@ -544,14 +543,12 @@ class StoryService(IStoryService):
         else:
             raise Exception("Story translation contents cannot be changed right now.")
 
-    def update_story_translation_stage(self, story_translation_data):
+    def update_story_translation_stage(self, story_translation_data, user_id):
         try:
             story_translation = StoryTranslation.query.filter_by(
                 id=story_translation_data["id"]
             ).first()
             new_stage = story_translation_data["stage"]
-            # TODO: remove cast to int once get_user_id_from_request is updated
-            user_id = int(get_user_id_from_request())
 
             if (
                 (new_stage == StageEnum.TRANSLATE or new_stage == StageEnum.PUBLISH)


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- services like create_comment are hard to unit test because the burden of authenticating the user is on the service rather than gql. moving the authentication to GQL adds clarity to responsibilities between moduals and also makes services easier to test

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. log in as carl sagan
2. go into a story translation
3. type text (tests story update service)
4. leave comments (tests comment service)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work 
- does it make sense

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
