### PR TITLE
Backend/activity time mutation

### DIFF
--- a/backend/python/app/graphql/mutations/comment_mutation.py
+++ b/backend/python/app/graphql/mutations/comment_mutation.py
@@ -40,8 +40,9 @@ class UpdateCommentById(graphene.Mutation):
     @require_authorization_by_role_gql({"User", "Admin"})
     def mutate(root, info, comment_data):
         try:
+            user_id = get_user_id_from_request()
             comment_response = services["comment"].update_comment(
-                updated_comment=comment_data
+                updated_comment=comment_data, user_id=user_id
             )
             ok = True
             return UpdateCommentById(ok=ok, comment=comment_response)

--- a/backend/python/app/services/implementations/comment_service.py
+++ b/backend/python/app/services/implementations/comment_service.py
@@ -10,6 +10,9 @@ from ...models.story_translation import StoryTranslation
 from ...models.story_translation_content import StoryTranslationContent
 from ...models.story_translation_content_status import StoryTranslationContentStatus
 from ..interfaces.comment_service import ICommentService
+from .story_service import StoryService
+
+story_service = StoryService(current_app.logger)
 
 
 class CommentService(ICommentService):
@@ -84,7 +87,7 @@ class CommentService(ICommentService):
 
             new_comment.line_index = stc.line_index
 
-            self._update_story_translation_last_activity(
+            story_service._update_story_translation_last_activity(
                 story_translation, is_translator
             )
 
@@ -161,7 +164,7 @@ class CommentService(ICommentService):
                 .first()
             )
             is_translator = user_id == story_translation.translator_id
-            self._update_story_translation_last_activity(
+            story_service._update_story_translation_last_activity(
                 story_translation, is_translator
             )
         except Exception as error:
@@ -191,17 +194,3 @@ class CommentService(ICommentService):
 
         # TODO: return updated comments as list of CommentResponseDTO's
         return updated_comments
-
-    def _update_story_translation_last_activity(self, story_translation, is_translator):
-        try:
-            if not story_translation:
-                raise Exception("Error. Story translation does not exist.")
-            if is_translator:
-                story_translation.translator_last_activity = datetime.utcnow()
-                db.session.commit()
-            else:
-                story_translation.reviewer_last_activity = datetime.utcnow()
-                db.session.commit()
-        except Exception as error:
-            self.logger.error(error)
-            raise error

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from flask import current_app
 from sqlalchemy.orm import aliased
 
@@ -523,6 +525,9 @@ class StoryService(IStoryService):
                     StoryTranslationContent, story_translation_contents
                 )
                 db.session.commit()
+
+                self._update_story_translation_last_activity(story_translation, True)
+
                 return story_translation_contents
             except Exception as error:
                 reason = getattr(error, "message", None)
@@ -550,15 +555,19 @@ class StoryService(IStoryService):
             ).first()
             new_stage = story_translation_data["stage"]
 
+            is_translator = user_id == story_translation.translator_id
+            is_reviewer = user_id == story_translation.reviewer_id
+
             if (
                 (new_stage == StageEnum.TRANSLATE or new_stage == StageEnum.PUBLISH)
-                and user_id == story_translation.reviewer_id
-            ) or (
-                new_stage == StageEnum.REVIEW
-                and user_id == story_translation.translator_id
-            ):
+                and is_reviewer
+            ) or (new_stage == StageEnum.REVIEW and is_translator):
                 story_translation.stage = new_stage
                 db.session.commit()
+
+                self._update_story_translation_last_activity(
+                    story_translation, is_translator
+                )
             else:
                 error = "User is not authorized to update translation stage to: {stage}".format(
                     stage=new_stage
@@ -630,6 +639,8 @@ class StoryService(IStoryService):
 
                 story_translation_content.status = status
                 db.session.commit()
+
+                self._update_story_translation_last_activity(story_translation, False)
             else:
                 raise Exception(
                     "Error. Story Translation is not in REVIEW stage and its statuses cannot be updated."
@@ -663,6 +674,8 @@ class StoryService(IStoryService):
                     translation_content[1].status = "APPROVED"
 
                 db.session.commit()
+
+                self._update_story_translation_last_activity(story_translation, False)
             else:
                 raise Exception(
                     "Error. Story Translation is not in REVIEW stage and its statuses cannot be updated."
@@ -845,3 +858,17 @@ class StoryService(IStoryService):
                 final_grade += 0.5
 
         return final_grade
+
+    def _update_story_translation_last_activity(self, story_translation, is_translator):
+        try:
+            if not story_translation:
+                raise Exception("Error. Story translation does not exist.")
+            if is_translator:
+                story_translation.translator_last_activity = datetime.utcnow()
+                db.session.commit()
+            else:
+                story_translation.reviewer_last_activity = datetime.utcnow()
+                db.session.commit()
+        except Exception as error:
+            self.logger.error(error)
+            raise error

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -675,6 +675,9 @@ class StoryService(IStoryService):
 
                 db.session.commit()
 
+                story_translation = StoryTranslation.query.filter_by(
+                    id=story_translation_id
+                ).first()
                 self._update_story_translation_last_activity(story_translation, False)
             else:
                 raise Exception(


### PR DESCRIPTION
…t mutations/queries

## Notion ticket link

<!-- Please replace with your ticket's URL -->

[update translator_last_activity and reviewer_last_activity in relevant mutations/queries](https://www.notion.so/uwblueprintexecs/update-translator_last_activity-and-reviewer_last_activity-in-relevant-mutations-queries-35720c1545224b138eaf3d0c6cf35ade)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added `_update_story_translation_last_activity` function in `story_service.py`
- Call this function in applicable services in order to update the last activity time (services are: `update_story_translation_contents`, `update_story_translation_stage`, `update_story_translation_content_status`, `approve_all_story_translation_content`, `create_comment`, `update_comment`)
- Added `user_id` parameter to `update_comment` service for `_update_story_translation_last_activity` function call

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. View the `reviewer_last_activity` and `translator_last_activity` columns in the `story_translations` table using mysql
1. Sign in as `planetread+carlsagan@uwblueprint.org`
2. Edit Great Gatsby translation
3. View the `story_translations` table again, the appropriate timestamp (row: id 10, column: translator_last_activity) should be updated
4. Make a comment on Great Gatsby translation
5. View the `story_translations` table again, the appropriate timestamp (row: id 10, column: translator_last_activity) should be updated
6. Resolve a comment on Great Gatsby translation
7. View the `story_translations` table again, the appropriate timestamp (row: id 10, column: translator_last_activity) should be updated
8. Send Great Gatsby translation for review
9. View the `story_translations` table again, the appropriate timestamp (row: id 10, column: translator_last_activity) should be updated
10. Sign out
11. Sign in as `planetread+dwightdeisenhower@uwblueprint.org`
12. Update status on Great Gatsby translation
13. View the `story_translations` table again, the appropriate timestamp (row: id 10, column: reviewer_last_activity) should be updated
14. Make a comment on Great Gatsby translation
15. View the `story_translations` table again, the appropriate timestamp (row: id 10, column: reviewer_last_activity) should be updated
16. Resolve a comment on Great Gatsby translation
17. View the `story_translations` table again, the appropriate timestamp (row: id 10, column: reviewer_last_activity) should be updated
18. Mark all as approved  Great Gatsby translation
19. View the `story_translations` table again, the appropriate timestamp (row: id 10, column: reviewer_last_activity) should be updated

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does testing work
- Does implementation make sense
    - Made instance of `story_service` in `comment_service.py` to use `update_story_translation_last_activity` function in `create_comment` and `update_comment` services (please see Kristy's comment below)

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
