### PR TITLE
Deny create_translation_test if there exists failed test within last …

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -131,10 +131,15 @@ class StoryService(IStoryService):
 
             for story_translation_test in story_translation_tests:
                 if story_translation_test.stage != "PUBLISH":
-                    self.logger.error(f"User has an ongoing story translation test for language {language}.")
-                    raise Exception(f"User has an ongoing story translation test for language {language}.")
+                    self.logger.error(
+                        f"User has an ongoing story translation test for language {language}."
+                    )
+                    raise Exception(
+                        f"User has an ongoing story translation test for language {language}."
+                    )
                 elif (
-                    story_translation_test.test_result == {} and story_translation_test.reviewer_last_activity
+                    story_translation_test.test_result == {}
+                    and story_translation_test.reviewer_last_activity
                     and last_30_days < story_translation_test.reviewer_last_activity
                 ):
                     self.logger.error("User has failed a test within the last 30 days.")


### PR DESCRIPTION
…30 days

## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Deny create_translation_test if there exists failed test within last 30 days](https://www.notion.so/uwblueprintexecs/Deny-create_translation_test-if-there-exists-failed-test-within-last-30-days-87a44734a2ff45fbbb055ada4e6834ad)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Raise exceptions in `create_translation_test` service if the user has test in the language that:
    - is not published,
    - or has current time - translator_last_activity < 30 days <=> current time - 30 days < translator_last_activity

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Setup Altair as an admin
2. View `story_translations` table using mysql
3. Create a story translation test using `createStoryTranslationTest` mutation in Altair:
```
mutation { createStoryTranslationTest(userId: 1, level: 2, language: "GERMAN") {
      story {
        id
      }
    }
  }
```
4. The story translation test should appear in the `story_translations` table
5. Create a story translation test with the same user and language (level can be different) using `createStoryTranslationTest` mutation:
```
mutation { createStoryTranslationTest(userId: 1, level: 2, language: "GERMAN") {
      story {
        id
      }
    }
  }
```
6. Should get "User has an ongoing story translation test for language {language}." error message, and the story translation test should NOT appear in the `story_translations` table
7. Give a failing test grade using `finishGradingStoryTranslation` mutation:
```
mutation {
  finishGradingStoryTranslation(storyTranslationTestId: 14, testFeedback: "blah", testResult: "{}"){
    ok
    storyTranslation{
      id
      stage
      
    }
  }
}
```
8. Create a story translation test with the same user and language using `createStoryTranslationTest` mutation:
```
mutation { createStoryTranslationTest(userId: 1, level: 2, language: "GERMAN") {
      story {
        id
      }
    }
  }
```
9. Should get "User has failed a test within the last 30 days." error message, and the story translation test should NOT appear in the `story_translations` table
10. Set the created translation test reviewer_last_activity to more than 30 days ago using mysql `UPDATE story_translations SET reviewer_last_activity = '2021-11-01 00:00:00' WHERE id = 14;`
11. Create a story translation test with the same user and language using `createStoryTranslationTest` mutation:
```
mutation { createStoryTranslationTest(userId: 1, level: 2, language: "GERMAN") {
      story {
        id
      }
    }
  }
```
12. The story translation test should appear in the `story_translations` table
13. Create a story translation test with the same user and language using `createStoryTranslationTest` mutation:
```
mutation { createStoryTranslationTest(userId: 1, level: 2, language: "GERMAN") {
      story {
        id
      }
    }
  }
```
14.  Should get "User has an ongoing story translation test for language {language}." error message, and the story translation test should NOT appear in the `story_translations` table
15. Give a passing test grade using `finishGradingStoryTranslation` mutation:
```
mutation {
  finishGradingStoryTranslation(storyTranslationTestId: 15, testFeedback: "good", testResult: "{\"translate\": \"FRENCH\", \"review\": \"FRENCH\", \"asdfasf\": \"ASDFASDF\"}"){
    ok
    storyTranslation{
      id
      stage
      
    }
  }
}
```
16. Create a story translation test with the same user and language using `createStoryTranslationTest` mutation:
```
mutation { createStoryTranslationTest(userId: 1, level: 2, language: "GERMAN") {
      story {
        id
      }
    }
  }
```
17. The story translation test should appear in the `story_translations` table

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does testing work
- Are exceptions correct
    - ~~To check if a test is ongoing, we look at `story_translation_test.stage != PUBLISHED` (should we instead look at something like `test_result == NULL`?)~~
    - ~~To check if there exists failed test within last 30 days, we look at current time - 30 days < translator_last_activity (is translator_last_activity the correct timestamp? should we also verify that `test_result == failed`?)~~

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
