### PR TITLE
Add last edited column to story translations table

### DIFF
--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -110,6 +110,8 @@ class StoryTranslationNode(graphene.ObjectType):
     level = graphene.Int(required=True)
     translator_name = graphene.String()
     reviewer_name = graphene.String()
+    translator_last_activity = graphene.DateTime()
+    reviewer_last_activity = graphene.DateTime()
 
     class Meta:
         interfaces = (graphene.relay.Node,)

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -214,6 +214,8 @@ export type StoryTranslation = {
   reviewerName: string | null;
   numTranslatedLines: number;
   numApprovedLines: number;
+  translatorLastActivity: string | null;
+  reviewerLastActivity: string | null;
 };
 
 export const buildStoryTranslationsQuery = (
@@ -257,6 +259,8 @@ export const buildStoryTranslationsQuery = (
               level
               translatorName
               reviewerName
+              translatorLastActivity
+              reviewerLastActivity
             }
           }
           pageInfo {

--- a/frontend/src/components/admin/StoryTranslationsTable.tsx
+++ b/frontend/src/components/admin/StoryTranslationsTable.tsx
@@ -74,6 +74,29 @@ const StoryTranslationsTable = ({
     window.location.reload();
   };
 
+  const lastEditedDate = (storyTranslation: StoryTranslation): Date | null => {
+    const translatorLastActivity = storyTranslation?.translatorLastActivity
+      ? new Date(storyTranslation.translatorLastActivity)
+      : null;
+    const reviewerLastActivity = storyTranslation?.reviewerLastActivity
+      ? new Date(storyTranslation.reviewerLastActivity)
+      : null;
+
+    if (!translatorLastActivity) {
+      return reviewerLastActivity;
+    }
+    if (!reviewerLastActivity) {
+      return translatorLastActivity;
+    }
+
+    return new Date(
+      Math.max(
+        translatorLastActivity.getTime(),
+        reviewerLastActivity.getTime(),
+      ),
+    );
+  };
+
   const tableBody = storyTranslationSlice.map(
     (storyTranslationObj: StoryTranslation, index: number) => (
       <Tr
@@ -114,6 +137,7 @@ const StoryTranslationsTable = ({
             {storyTranslationObj?.reviewerName}
           </Link>
         </Td>
+        <Td>{lastEditedDate(storyTranslationObj)?.toLocaleDateString?.()}</Td>
         <Td>
           <IconButton
             aria-label={`Delete story translation ${storyTranslationObj?.storyTranslationId} for story ${storyTranslationObj?.title}`}
@@ -148,6 +172,7 @@ const StoryTranslationsTable = ({
           <Th>PROGRESS</Th>
           <Th>TRANSLATOR</Th>
           <Th>REVIEWER</Th>
+          <Th>LAST EDITED</Th>
           <Th>ACTION</Th>
         </Tr>
       </Thead>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add last edited column to StoryTranslationsTable](https://www.notion.so/uwblueprintexecs/Add-last-edited-column-to-StoryTranslationsTable-e03de6729fd94c339b3c00f12cc98e35)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- modified storyTranslations query and DTO to fetch last activity for translator and reviewer
- added column in StoryTranslationsTable to show last edited time

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as planetread+carlsagan@uwblueprint.org
2. go to translation for "To Kill A Mockingbird"
3. make some edits
4. login as planetread+angelamerkel@uwblueprint.org
5. verify that the "To Kill a Mockingbird" row for Carl Sagan shows the last edited timestamp
6. click on the "To Kill a Mockingbird" link in the row
7. verify that the last edited column appears in the story page also

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- is there a more optimal way to check for the most recent date?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
