### PR TITLE
Hide filters when displaying user's stories

### DIFF
--- a/frontend/src/components/homepage/Filter.tsx
+++ b/frontend/src/components/homepage/Filter.tsx
@@ -88,46 +88,50 @@ const Filter = ({
   const disabledStyle = useStyleConfig("Disabled");
   return (
     <Flex sx={filterStyle}>
-      <Heading size="lg">Filters</Heading>
-      {Object.keys(approvedLanguagesReview).length > 0 && (
+      {!isDisabled && (
         <>
+          <Heading size="lg">Filters</Heading>
+          {Object.keys(approvedLanguagesReview).length > 0 && (
+            <>
+              <Divider marginTop="24px" marginBottom="18px" />
+              <Box sx={isDisabled ? disabledStyle : undefined}>
+                <Heading size="sm">Role Required</Heading>
+                <ButtonRadioGroup
+                  name="Role"
+                  options={["Translator", "Reviewer"]}
+                  onChange={handleRoleChange}
+                  defaultValue={role ? "Translator" : "Reviewer"}
+                />
+              </Box>
+            </>
+          )}
           <Divider marginTop="24px" marginBottom="18px" />
           <Box sx={isDisabled ? disabledStyle : undefined}>
-            <Heading size="sm">Role Required</Heading>
+            <Heading size="sm">Translation Language</Heading>
+            <Select
+              size="sm"
+              variant="filled"
+              id="language"
+              value={isDisabled ? "undefined" : language}
+              onChange={handleSelectChange}
+            >
+              {languageOptions}
+            </Select>
+          </Box>
+          <Divider marginTop="24px" marginBottom="18px" />
+          <Box sx={isDisabled ? disabledStyle : undefined}>
+            <Heading size="sm">Access Level</Heading>
             <ButtonRadioGroup
-              name="Role"
-              options={["Translator", "Reviewer"]}
-              onChange={handleRoleChange}
-              defaultValue={role ? "Translator" : "Reviewer"}
+              name="Level"
+              options={levelOptions}
+              onChange={handleLevelChangeStr}
+              defaultValue={`Level ${level}`}
+              isDisabled={isDisabled}
+              dependentValue={language + role}
             />
           </Box>
         </>
       )}
-      <Divider marginTop="24px" marginBottom="18px" />
-      <Box sx={isDisabled ? disabledStyle : undefined}>
-        <Heading size="sm">Translation Language</Heading>
-        <Select
-          size="sm"
-          variant="filled"
-          id="language"
-          value={isDisabled ? "undefined" : language}
-          onChange={handleSelectChange}
-        >
-          {languageOptions}
-        </Select>
-      </Box>
-      <Divider marginTop="24px" marginBottom="18px" />
-      <Box sx={isDisabled ? disabledStyle : undefined}>
-        <Heading size="sm">Access Level</Heading>
-        <ButtonRadioGroup
-          name="Level"
-          options={levelOptions}
-          onChange={handleLevelChangeStr}
-          defaultValue={`Level ${level}`}
-          isDisabled={isDisabled}
-          dependentValue={language + role}
-        />
-      </Box>
     </Flex>
   );
 };

--- a/frontend/src/theme/components/Filter.ts
+++ b/frontend/src/theme/components/Filter.ts
@@ -5,6 +5,7 @@ const Filter = {
     justifyContent: "flex-start",
     marginRight: "10px",
     minWidth: "292px",
+    minHeight: "80vh",
     padding: "50px 50px 50px 50px",
   },
 };


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Do not display filters in “My stories” homepage](https://www.notion.so/uwblueprintexecs/Do-not-display-filters-in-My-stories-homepage-545d5c55b6634a4889bd26f35931f04d)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- hide filters on "My Work" tab
- adjust filter component styling to have a sufficient minimum height

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as any user
2. observe that the filters are hidden on the "My Work" section
3. verify that filters appear and are functional in the "Browse Stories" section

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
