### PR TITLE
Redirect to homepage after story translation stage change

### DIFF
--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 import { Box, Divider, Flex, Button, Tooltip } from "@chakra-ui/react";
-import { useParams, Redirect } from "react-router-dom";
+import { useParams, Redirect, useHistory } from "react-router-dom";
 
 import AuthContext from "../../contexts/AuthContext";
 import ProgressBar from "../utils/ProgressBar";
@@ -62,6 +62,8 @@ const ReviewPage = () => {
   const [returnToTranslator, setReturnToTranslator] = useState(false);
   const [submitTranslation, setSubmitTranslation] = useState(false);
 
+  const history = useHistory();
+
   const closeReturnToTranslatorModal = () => {
     setReturnToTranslator(false);
   };
@@ -97,7 +99,7 @@ const ReviewPage = () => {
           variables: { storyTranslationData },
         });
         if (result.data?.updateStoryTranslationStage.ok) {
-          window.location.reload();
+          history.push("/");
         } else {
           window.alert(`Unable to update story stage to ${stage}.`);
         }

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 import { Box, Button, Divider, Flex, Text, Tooltip } from "@chakra-ui/react";
-import { useParams, Redirect } from "react-router-dom";
+import { useParams, Redirect, useHistory } from "react-router-dom";
 
 import AuthContext from "../../contexts/AuthContext";
 import ProgressBar from "../utils/ProgressBar";
@@ -56,6 +56,8 @@ const TranslationPage = () => {
 
   // TODO: remove eslint comment when setIsTest is used
   const [isTest, setIsTest] = useState(false); // eslint-disable-line
+
+  const history = useHistory();
 
   // AutoSave
   const [changedStoryLines, setChangedStoryLines] = useState<
@@ -154,7 +156,7 @@ const TranslationPage = () => {
         variables: { storyTranslationData },
       });
       if (result.data?.updateStoryTranslationStage.ok) {
-        window.location.reload();
+        history.push("/");
       } else {
         window.alert("Unable to send for review.");
       }


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Redirect user to homepage after story translation stage change](https://www.notion.so/uwblueprintexecs/Redirect-user-to-homepage-after-story-translation-stage-change-c1828eca207b483caf6baad2ac50fd82)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- replace `window.location.reload()` with `history.push("/")`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login to any user
2. Go to any story translation and click the bottom right button to update story translation stage
3. Observe redirect to homepage

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
