### PR TITLE
Change default comment filter to "Unresolved"

### DIFF
--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -35,7 +35,7 @@ const CommentsPanel = ({
   reviewPage = false,
 }: CommentPanelProps) => {
   const [comments, setComments] = useState<CommentResponse[]>([]);
-  const [filterIndex, setFilterIndex] = useState(0);
+  const [filterIndex, setFilterIndex] = useState(2);
 
   const filterOptions = ["All", "Resolved", "Unresolved"];
   const filterToResolved = [null, true, false];


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Make the default comment filter unresolved](https://www.notion.so/uwblueprintexecs/Make-the-default-comment-filter-unresolved-63bdde5306204af9820b1aa9975f9450)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- change default filter index to "Unresolved"

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as any user
2. Go to any story translation
3. Verify that the default filter is "Unresolved"

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
