### PR TITLE
Implement level up language flow

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -125,6 +125,7 @@ class StoryService(IStoryService):
             story_translation_tests = (
                 StoryTranslation.query.filter(StoryTranslation.translator_id == user_id)
                 .filter(StoryTranslation.language == language)
+                .filter(StoryTranslation.is_test == True)
                 .all()
             )
 

--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -129,3 +129,22 @@ export const UPDATE_STORY = gql`
   }
 `;
 export type UpdateStoryResponse = { ok: boolean };
+
+export const CREATE_TRANSLATION_TEST = gql`
+  mutation UpdateStory($userId: ID!, $level: Int!, $language: String!) {
+    createStoryTranslationTest(
+      userId: $userId
+      level: $level
+      language: $language
+    ) {
+      story {
+        id
+      }
+    }
+  }
+`;
+export type CreateTranslationTestResponse = {
+  story: {
+    id: number;
+  };
+};

--- a/frontend/src/components/admin/ApprovedLanguagesTable.tsx
+++ b/frontend/src/components/admin/ApprovedLanguagesTable.tsx
@@ -1,22 +1,7 @@
-import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useMutation } from "@apollo/client";
-import {
-  Table,
-  Thead,
-  Tbody,
-  Tooltip,
-  Tr,
-  Th,
-  Td,
-  Tfoot,
-  Button,
-  Slider,
-  SliderTrack,
-  SliderFilledTrack,
-  SliderThumb,
-  SliderMark,
-} from "@chakra-ui/react";
-import { ApprovedLanguagesMap, generateSortFn } from "../../utils/Utils";
+import { useHistory } from "react-router-dom";
+import { ApprovedLanguagesMap } from "../../utils/Utils";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 import {
   UPDATE_USER_APPROVED_LANGUAGES,
@@ -25,21 +10,20 @@ import {
 import ApproveLanguageModal, {
   NewApprovedLanguage,
 } from "../utils/ApproveLanguageModal";
+import {
+  CREATE_TRANSLATION_TEST,
+  CreateTranslationTestResponse,
+} from "../../APIClients/mutations/StoryMutations";
+import ApprovedLanguagesTableComponent from "./ApprovedLanguagesTableComponent";
+import ConfirmationModal from "../utils/ConfirmationModal";
 
-interface ApprovedLanguageFieldSortDict {
-  [field: string]: {
-    sortFn: (a: ApprovedLanguage, b: ApprovedLanguage) => number;
-    isAscending: boolean;
-    setIsAscending: Dispatch<SetStateAction<boolean>>;
-  };
-}
-
-type ApprovedLanguage = {
-  language: string;
-  level: number;
-  role: string;
-  sliderValue: number;
-};
+import {
+  LEVEL_UP_LANGUAGE_CONFIRMATION,
+  LEVEL_UP_LANGUAGE_BUTTON,
+  NEW_BOOK_TEST_ADDED_HEADING,
+  NEW_BOOK_TEST_ADDED_MESSAGE,
+  NEW_BOOK_TEST_ADDED_BUTTON,
+} from "../../utils/Copy";
 
 export type ApprovedLanguagesTableProps = {
   approvedLanguagesTranslation: ApprovedLanguagesMap | undefined;
@@ -68,12 +52,12 @@ const ApprovedLanguagesTable = ({
   setAlertTimeout,
   isAdmin = false,
 }: ApprovedLanguagesTableProps) => {
-  const [approvedLanguages, setApprovedLanguages] = useState<
-    ApprovedLanguage[]
-  >([]);
+  const history = useHistory();
 
-  const [isAscendingLanguage, setIsAscendingLanguage] = useState(true);
-  const [isAscendingRole, setIsAscendingRole] = useState(true);
+  const [confirmLevelUp, setConfirmLevelUp] = useState(false);
+  const [alertNewTest, setAlertNewTest] = useState(false);
+  const [testLevel, setTestLevel] = useState(0);
+  const [testLanguage, setTestLanguage] = useState("");
 
   const [approveNewLanguage, setApproveNewLanguage] = useState(false);
 
@@ -99,6 +83,9 @@ const ApprovedLanguagesTable = ({
   const [updateUserApprovedLanguages] = useMutation<{
     response: UpdateUserApprovedLanguagesResponse;
   }>(UPDATE_USER_APPROVED_LANGUAGES);
+  const [createTranslationTest] = useMutation<{
+    response: CreateTranslationTestResponse;
+  }>(CREATE_TRANSLATION_TEST);
 
   const getAlertText = (
     isTranslate: boolean,
@@ -157,45 +144,6 @@ const ApprovedLanguagesTable = ({
     }
   };
 
-  const fieldSortDict: ApprovedLanguageFieldSortDict = {
-    language: {
-      sortFn: generateSortFn<ApprovedLanguage>("language", isAscendingLanguage),
-      isAscending: isAscendingLanguage,
-      setIsAscending: setIsAscendingLanguage,
-    },
-    role: {
-      sortFn: generateSortFn<ApprovedLanguage>("role", isAscendingRole),
-      isAscending: isAscendingRole,
-      setIsAscending: setIsAscendingRole,
-    },
-  };
-
-  const sortApprovedLanguages = (field: string) => {
-    const newApprovedLanguages = [...approvedLanguages];
-    const { sortFn, isAscending, setIsAscending } = fieldSortDict[field];
-    setIsAscending(!isAscending);
-    newApprovedLanguages.sort(sortFn);
-    setApprovedLanguages(newApprovedLanguages);
-  };
-
-  useEffect(() => {
-    if (approvedLanguagesTranslation && approvedLanguagesReview) {
-      const translationLanguages = Object.entries(
-        approvedLanguagesTranslation,
-      ).map(([language, level]) => {
-        return { language, level, role: "Translator", sliderValue: level };
-      });
-      const reviewLanguages = Object.entries(approvedLanguagesReview).map(
-        ([language, level]) => {
-          return { language, level, role: "Reviewer", sliderValue: level };
-        },
-      );
-      const combined = translationLanguages.concat(reviewLanguages);
-      sortApprovedLanguages("language");
-      setApprovedLanguages(combined);
-    }
-  }, [approvedLanguagesTranslation, approvedLanguagesReview]);
-
   const onSliderValueChange = (
     isTranslate: boolean,
     language: string,
@@ -221,122 +169,50 @@ const ApprovedLanguagesTable = ({
     closeApproveLanguageModal(false);
   };
 
-  const tableBody = approvedLanguages.map(
-    (approvedLanguage: ApprovedLanguage, index: number) => (
-      <Tr
-        borderBottom={
-          index === approvedLanguages.length - 1 ? "1px solid gray" : ""
-        }
-        key={`${approvedLanguage.language}/${approvedLanguage.role}`}
-      >
-        <Td>{convertLanguageTitleCase(approvedLanguage.language)}</Td>
-        <Td>{approvedLanguage.role}</Td>
-        <Td colSpan={4} align="center">
-          <Slider
-            isDisabled={!isAdmin}
-            defaultValue={approvedLanguage.level}
-            min={1}
-            max={4}
-            step={1}
-            marginLeft="20px"
-            size="lg"
-            width="79%"
-            onChange={(val: number) =>
-              onSliderValueChange(
-                approvedLanguage.role === "Translator",
-                approvedLanguage.language,
-                val,
-                approvedLanguage.level,
-              )
-            }
-          >
-            <SliderTrack height="6px">
-              <SliderFilledTrack bg="blue.500" />
-            </SliderTrack>
-            <SliderThumb boxShadow="0px 0px 3px black" />
-            {[1, 2, 3, 4].map((val) => (
-              <SliderMark
-                key={val}
-                value={val}
-                height="6px"
-                width="4px"
-                marginTop="-3px"
-                // #64A1CD is light blue, #ECF1F4 is light gray
-                bg={approvedLanguage.sliderValue > val ? "#64A1CD" : "#ECF1F4"}
-              />
-            ))}
-          </Slider>
-        </Td>
-        {!isAdmin && (
-          <Tooltip
-            hasArrow
-            label="Currently at maximum language level."
-            isDisabled={approvedLanguage.level !== 4}
-          >
-            <Td>
-              <Button
-                aria-label="Level up approval language and level"
-                background="white"
-                size="sm"
-                width="103px"
-                variant="blueOutline"
-                isDisabled={approvedLanguage.level === 4}
-              >
-                Level Up
-              </Button>
-            </Td>
-          </Tooltip>
-        )}
-      </Tr>
-    ),
-  );
+  const closeNewTestModal = () => {
+    setAlertNewTest(false);
+  };
+
+  const closeLevelUpModal = () => {
+    setTestLevel(0);
+    setTestLanguage("");
+    setConfirmLevelUp(false);
+  };
+
+  const openLevelUpModal = (level: number, language: string) => {
+    setTestLevel(level);
+    setTestLanguage(language);
+    setConfirmLevelUp(true);
+  };
+
+  const callCreateTranslationTestMutation = async () => {
+    try {
+      await createTranslationTest({
+        variables: {
+          userId,
+          level: testLevel,
+          language: testLanguage,
+        },
+      });
+      closeLevelUpModal();
+      setAlertNewTest(true);
+    } catch (err) {
+      window.alert(err);
+      closeLevelUpModal();
+      closeNewTestModal();
+    }
+  };
 
   return (
     <>
-      <Table
-        borderRadius="12px"
-        boxShadow="0px 0px 2px grey"
-        theme="gray"
-        variant="striped"
-        width="100%"
-        marginTop="20px"
-      >
-        <Thead>
-          <Tr
-            borderTop="1em solid transparent"
-            borderBottom="0.5em solid transparent"
-          >
-            <Th
-              cursor="pointer"
-              onClick={() => sortApprovedLanguages("language")}
-              width="12%"
-            >
-              {`LANGUAGE ${isAscendingLanguage ? "↑" : "↓"}`}
-            </Th>
-            <Th
-              cursor="pointer"
-              onClick={() => sortApprovedLanguages("role")}
-              width="12%"
-            >{`ROLE ${isAscendingRole ? "↑" : "↓"}`}</Th>
-            {["LEVEL 1", "LEVEL 2", "LEVEL 3", "LEVEL 4"].map((level) => (
-              <Th key={level}>{level}</Th>
-            ))}
-            {!isAdmin && <Th width="7%">ACTION</Th>}
-          </Tr>
-        </Thead>
-        <Tbody>{tableBody}</Tbody>
-        <Tfoot padding="12px">
-          <Button
-            margin="16px 0px 16px 12px"
-            size="secondary"
-            variant="blueOutline"
-            width="254px"
-            onClick={openApproveLanguageModal}
-          >
-            Add New Language
-          </Button>
-        </Tfoot>
-      </Table>
+      <ApprovedLanguagesTableComponent
+        addNewLanguage={isAdmin ? openApproveLanguageModal : () => undefined}
+        levelUpOnClick={openLevelUpModal}
+        onSliderValueChange={onSliderValueChange}
+        approvedLanguagesTranslation={approvedLanguagesTranslation}
+        approvedLanguagesReview={approvedLanguagesReview}
+        isAdmin={isAdmin}
+      />
       {approveNewLanguage && (
         <ApproveLanguageModal
           isOpen={approveNewLanguage}
@@ -346,6 +222,21 @@ const ApprovedLanguagesTable = ({
           approvedLanguagesReview={approvedLanguagesReview!}
         />
       )}
+      <ConfirmationModal
+        confirmation={confirmLevelUp}
+        onClose={closeLevelUpModal}
+        onConfirmationClick={callCreateTranslationTestMutation}
+        confirmationMessage={LEVEL_UP_LANGUAGE_CONFIRMATION}
+        buttonMessage={LEVEL_UP_LANGUAGE_BUTTON}
+      />
+      <ConfirmationModal
+        confirmation={alertNewTest}
+        onClose={closeNewTestModal}
+        onConfirmationClick={() => history.push("/")}
+        confirmationHeading={NEW_BOOK_TEST_ADDED_HEADING}
+        confirmationMessage={NEW_BOOK_TEST_ADDED_MESSAGE}
+        buttonMessage={NEW_BOOK_TEST_ADDED_BUTTON}
+      />
     </>
   );
 };

--- a/frontend/src/components/admin/ApprovedLanguagesTableComponent.tsx
+++ b/frontend/src/components/admin/ApprovedLanguagesTableComponent.tsx
@@ -1,0 +1,228 @@
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+import {
+  Table,
+  Thead,
+  Tbody,
+  Tooltip,
+  Tr,
+  Th,
+  Td,
+  Tfoot,
+  Button,
+  Slider,
+  SliderTrack,
+  SliderFilledTrack,
+  SliderThumb,
+  SliderMark,
+} from "@chakra-ui/react";
+import { ApprovedLanguagesMap, generateSortFn } from "../../utils/Utils";
+import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
+
+interface ApprovedLanguageFieldSortDict {
+  [field: string]: {
+    sortFn: (a: ApprovedLanguage, b: ApprovedLanguage) => number;
+    isAscending: boolean;
+    setIsAscending: Dispatch<SetStateAction<boolean>>;
+  };
+}
+
+type ApprovedLanguage = {
+  language: string;
+  level: number;
+  role: string;
+  sliderValue: number;
+};
+
+export type ApprovedLanguagesTableComponentProps = {
+  addNewLanguage: () => void;
+  levelUpOnClick: (level: number, language: string) => void;
+  onSliderValueChange: (
+    isTranslate: boolean,
+    language: string,
+    newLevel: number,
+    oldLevel: number,
+  ) => void;
+  approvedLanguagesTranslation: ApprovedLanguagesMap | undefined;
+  approvedLanguagesReview: ApprovedLanguagesMap | undefined;
+  isAdmin?: boolean;
+};
+
+const ApprovedLanguagesTableComponent = ({
+  addNewLanguage,
+  levelUpOnClick,
+  onSliderValueChange,
+  approvedLanguagesTranslation,
+  approvedLanguagesReview,
+  isAdmin = false,
+}: ApprovedLanguagesTableComponentProps) => {
+  const [approvedLanguages, setApprovedLanguages] = useState<
+    ApprovedLanguage[]
+  >([]);
+
+  const [isAscendingLanguage, setIsAscendingLanguage] = useState(true);
+  const [isAscendingRole, setIsAscendingRole] = useState(true);
+
+  const fieldSortDict: ApprovedLanguageFieldSortDict = {
+    language: {
+      sortFn: generateSortFn<ApprovedLanguage>("language", isAscendingLanguage),
+      isAscending: isAscendingLanguage,
+      setIsAscending: setIsAscendingLanguage,
+    },
+    role: {
+      sortFn: generateSortFn<ApprovedLanguage>("role", isAscendingRole),
+      isAscending: isAscendingRole,
+      setIsAscending: setIsAscendingRole,
+    },
+  };
+
+  const sortApprovedLanguages = (field: string) => {
+    const newApprovedLanguages = [...approvedLanguages];
+    const { sortFn, isAscending, setIsAscending } = fieldSortDict[field];
+    setIsAscending(!isAscending);
+    newApprovedLanguages.sort(sortFn);
+    setApprovedLanguages(newApprovedLanguages);
+  };
+
+  useEffect(() => {
+    if (approvedLanguagesTranslation && approvedLanguagesReview) {
+      const translationLanguages = Object.entries(
+        approvedLanguagesTranslation,
+      ).map(([language, level]) => {
+        return { language, level, role: "Translator", sliderValue: level };
+      });
+      const reviewLanguages = Object.entries(approvedLanguagesReview).map(
+        ([language, level]) => {
+          return { language, level, role: "Reviewer", sliderValue: level };
+        },
+      );
+      const combined = translationLanguages.concat(reviewLanguages);
+      sortApprovedLanguages("language");
+      setApprovedLanguages(combined);
+    }
+  }, [approvedLanguagesTranslation, approvedLanguagesReview]);
+
+  const tableBody = approvedLanguages.map(
+    (approvedLanguage: ApprovedLanguage, index: number) => (
+      <Tr
+        borderBottom={
+          index === approvedLanguages.length - 1 ? "1px solid gray" : ""
+        }
+        key={`${approvedLanguage.language}/${approvedLanguage.role}`}
+      >
+        <Td>{convertLanguageTitleCase(approvedLanguage.language)}</Td>
+        <Td>{approvedLanguage.role}</Td>
+        <Td colSpan={4} align="center">
+          <Slider
+            isDisabled={!isAdmin}
+            defaultValue={approvedLanguage.level}
+            min={1}
+            max={4}
+            step={1}
+            marginLeft="20px"
+            size="lg"
+            width="79%"
+            onChange={(val: number) =>
+              onSliderValueChange(
+                approvedLanguage.role === "Translator",
+                approvedLanguage.language,
+                val,
+                approvedLanguage.level,
+              )
+            }
+          >
+            <SliderTrack height="6px">
+              <SliderFilledTrack bg="blue.500" />
+            </SliderTrack>
+            <SliderThumb boxShadow="0px 0px 3px black" />
+            {[1, 2, 3, 4].map((val) => (
+              <SliderMark
+                key={val}
+                value={val}
+                height="6px"
+                width="4px"
+                marginTop="-3px"
+                // #64A1CD is light blue, #ECF1F4 is light gray
+                bg={approvedLanguage.sliderValue > val ? "#64A1CD" : "#ECF1F4"}
+              />
+            ))}
+          </Slider>
+        </Td>
+        {!isAdmin && (
+          <Tooltip
+            hasArrow
+            label="Currently at maximum language level."
+            isDisabled={approvedLanguage.level !== 4}
+          >
+            <Td>
+              <Button
+                aria-label="Level up approval language and level"
+                background="white"
+                size="sm"
+                width="103px"
+                variant="blueOutline"
+                isDisabled={approvedLanguage.level === 4}
+                onClick={() =>
+                  levelUpOnClick(
+                    approvedLanguage.level + 1,
+                    approvedLanguage.language,
+                  )
+                }
+              >
+                Level Up
+              </Button>
+            </Td>
+          </Tooltip>
+        )}
+      </Tr>
+    ),
+  );
+
+  return (
+    <Table
+      borderRadius="12px"
+      boxShadow="0px 0px 2px grey"
+      theme="gray"
+      variant="striped"
+      width="100%"
+      marginTop="20px"
+    >
+      <Thead>
+        <Tr
+          borderTop="1em solid transparent"
+          borderBottom="0.5em solid transparent"
+        >
+          <Th
+            cursor="pointer"
+            onClick={() => sortApprovedLanguages("language")}
+            width="12%"
+          >
+            {`LANGUAGE ${isAscendingLanguage ? "↑" : "↓"}`}
+          </Th>
+          <Th
+            cursor="pointer"
+            onClick={() => sortApprovedLanguages("role")}
+            width="12%"
+          >{`ROLE ${isAscendingRole ? "↑" : "↓"}`}</Th>
+          {["LEVEL 1", "LEVEL 2", "LEVEL 3", "LEVEL 4"].map((level) => (
+            <Th key={level}>{level}</Th>
+          ))}
+          {!isAdmin && <Th width="7%">ACTION</Th>}
+        </Tr>
+      </Thead>
+      <Tbody>{tableBody}</Tbody>
+      <Tfoot padding="12px">
+        <Button
+          margin="16px 0px 16px 12px"
+          size="secondary"
+          variant="blueOutline"
+          width="254px"
+          onClick={addNewLanguage}
+        >
+          Add New Language
+        </Button>
+      </Tfoot>
+    </Table>
+  );
+};
+
+export default ApprovedLanguagesTableComponent;

--- a/frontend/src/components/utils/ConfirmationModal.tsx
+++ b/frontend/src/components/utils/ConfirmationModal.tsx
@@ -13,10 +13,11 @@ import {
   Text,
 } from "@chakra-ui/react";
 
-type ConfirmationModalProps = {
+export type ConfirmationModalProps = {
   confirmation: boolean;
   onClose: () => void;
   onConfirmationClick: () => void;
+  confirmationHeading?: string;
   confirmationMessage: string;
   buttonMessage: string;
 };
@@ -25,6 +26,7 @@ const ConfirmationModal = ({
   confirmation,
   onClose,
   onConfirmationClick,
+  confirmationHeading = "Are you sure?",
   confirmationMessage,
   buttonMessage,
 }: ConfirmationModalProps) => {
@@ -45,7 +47,7 @@ const ConfirmationModal = ({
         >
           <Flex>
             <Heading as="h3" size="md">
-              Are you sure?
+              {confirmationHeading}
             </Heading>
             <ModalCloseButton
               position="static"

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -73,3 +73,14 @@ export const MANAGE_TESTS_TABLE_DELETE_TEST_CONFIRMATION =
   "By deleting this test, the user has to wait for 30 days before they can take this test again.";
 
 export const MANAGE_TESTS_TABLE_DELETE_TEST_BUTTON = "I'm sure, delete test";
+export const LEVEL_UP_LANGUAGE_CONFIRMATION =
+  "By levelling up this language, you will be able to access the book test on the homepage. Successfully passing the test will confirm your level up.";
+
+export const LEVEL_UP_LANGUAGE_BUTTON = "I'm sure, level up";
+
+export const NEW_BOOK_TEST_ADDED_HEADING = "New Story Translation Test Added";
+
+export const NEW_BOOK_TEST_ADDED_MESSAGE =
+  "The story translation test to add a new language has been added to the homepage. Please see the 'My Tests' tab.";
+
+export const NEW_BOOK_TEST_ADDED_BUTTON = "Take me to homepage";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Implement level up language flow](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=2ca8903a499a4d5bb6b0cb978762d26c)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- moved the table jsx and specific logic to ApprovedLanguagesTableComponent
- added confirmation modals for leveling up language, and notifying users to move to homepage

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as carl sagan
2. go to user profile 
3. hit level up button 
4. observe that flow exists
5. hit level up button again 
6. observe error `Error: User has an ongoing story translation test for language [abcd].`
7. fail the story translation test to observe the other error.  You'll need to do this in altair as an admin:
```
mutation {
  finishGradingStoryTranslation(storyTranslationTestId: 14, testFeedback: "blah", testResult: "{}"){
    ok
    storyTranslation{
      id
      stage
      
    }
  }
}
```
8. hit level up button again 
9. observe error `Error: User has failed a test within the last 30 days.`
10. hardcode the fail time to be father into the past than 30 days. `UPDATE story_translations SET reviewer_last_activity = '2021-11-01 00:00:00' WHERE id = 14;`
11. hit level up button again. the flow should work and you should be able to make another story test!

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work
- does the modularlization of ApprovedLanguagesTableComponent make sense? ApprovedLanguagesTable was getting too cluttered

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
