### PR TITLE
Allow more action status flexibility in review page

### DIFF
--- a/backend/python/app/services/implementations/comment_service.py
+++ b/backend/python/app/services/implementations/comment_service.py
@@ -8,7 +8,6 @@ from ...models.comment import Comment
 from ...models.comment_all import CommentAll
 from ...models.story_translation import StoryTranslation
 from ...models.story_translation_content import StoryTranslationContent
-from ...models.story_translation_content_status import StoryTranslationContentStatus
 from ..interfaces.comment_service import ICommentService
 from .story_service import StoryService
 
@@ -73,12 +72,6 @@ class CommentService(ICommentService):
                 raise error
 
             db.session.add(new_comment)
-            db.session.commit()
-
-            story_translation_content = new_comment.story_translation_content
-            story_translation_content.status = (
-                StoryTranslationContentStatus.ACTION_REQUIRED
-            )
             db.session.commit()
 
             stc = StoryTranslationContent.query.filter_by(

--- a/frontend/src/components/review/StatusBadge.tsx
+++ b/frontend/src/components/review/StatusBadge.tsx
@@ -2,7 +2,12 @@ import React, { useState } from "react";
 import { Badge, Menu, MenuButton, MenuList, MenuItem } from "@chakra-ui/react";
 import { useMutation } from "@apollo/client";
 import { Icon } from "@chakra-ui/icon";
-import { MdCheck, MdTimer, MdArrowDropDown } from "react-icons/md";
+import {
+  MdCheck,
+  MdTimer,
+  MdArrowDropDown,
+  MdPriorityHigh,
+} from "react-icons/md";
 import {
   getStatusVariant,
   convertStatusTitleCase,
@@ -123,6 +128,14 @@ const StatusBadge = ({
           }}
         >
           Pending
+        </MenuItem>
+        <MenuItem
+          icon={<Icon as={MdPriorityHigh} height={6} width={6} />}
+          onClick={async () => {
+            handleStatusChange("ACTION_REQUIRED");
+          }}
+        >
+          Action Required
         </MenuItem>
       </MenuList>
       {sendAsApprovedLastLine && (


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Allow action status to be manually assigned, remove comment services involvement in statuses](https://www.notion.so/uwblueprintexecs/Allow-action-status-to-be-manually-assigned-remove-comment-services-involvement-in-statuses-c111880833024646870e0ddf31e2b41e)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- add "ACTION_REQUIRED" option to status badge dropdown
- remove `story_translation_contents.status changes` from comment_services

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data erase"`
2. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data"`
3. change story translation to review using `UPDATE story_translations SET stage='REVIEW' WHERE id=13;`
4. login as `planetread+dwightdeisenhower@uwblueprint.org`
5. click "View Translation" on "The Great Gatsby"
6. verify that the action status dropdown includes "Action Required"

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
