### PR TITLE
Implement remove language flow

### DIFF
--- a/backend/python/app/services/implementations/user_service.py
+++ b/backend/python/app/services/implementations/user_service.py
@@ -538,7 +538,7 @@ class UserService(IUserService):
         try:
             if not language in LanguageEnum._member_names_:
                 raise Exception(f"Invalid language provided: {language}")
-            if level > 4 or level < 1:
+            if level > 4:
                 raise Exception(f"Invalid language level provided: {level}")
 
             user = User.query.filter_by(id=user_id).first()
@@ -551,7 +551,10 @@ class UserService(IUserService):
                 else user.approved_languages_review
             ) or {}
 
-            curr_languages[language] = level
+            if level < 1 and language in curr_languages:
+                curr_languages.pop(language)
+            else:
+                curr_languages[language] = level
 
             if is_translate:
                 user.approved_languages_translation = curr_languages

--- a/frontend/src/components/admin/ApprovedLanguagesTableComponent.tsx
+++ b/frontend/src/components/admin/ApprovedLanguagesTableComponent.tsx
@@ -14,7 +14,10 @@ import {
   SliderFilledTrack,
   SliderThumb,
   SliderMark,
+  Icon,
+  IconButton,
 } from "@chakra-ui/react";
+import { MdOutlineBlock } from "react-icons/md";
 import { ApprovedLanguagesMap, generateSortFn } from "../../utils/Utils";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 
@@ -36,6 +39,7 @@ type ApprovedLanguage = {
 export type ApprovedLanguagesTableComponentProps = {
   addNewLanguage: () => void;
   levelUpOnClick: (level: number, language: string) => void;
+  removeLanguageOnClick: (isTranslate: boolean, language: string) => void;
   onSliderValueChange: (
     isTranslate: boolean,
     language: string,
@@ -50,6 +54,7 @@ export type ApprovedLanguagesTableComponentProps = {
 const ApprovedLanguagesTableComponent = ({
   addNewLanguage,
   levelUpOnClick,
+  removeLanguageOnClick,
   onSliderValueChange,
   approvedLanguagesTranslation,
   approvedLanguagesReview,
@@ -147,7 +152,22 @@ const ApprovedLanguagesTableComponent = ({
             ))}
           </Slider>
         </Td>
-        {!isAdmin && (
+        {isAdmin ? (
+          <Td>
+            <IconButton
+              aria-label={`Remove approved language ${approvedLanguage.language}`}
+              background="transparent"
+              icon={<Icon as={MdOutlineBlock} />}
+              width="fit-content"
+              onClick={() =>
+                removeLanguageOnClick(
+                  approvedLanguage.role === "Translator",
+                  approvedLanguage.language,
+                )
+              }
+            />
+          </Td>
+        ) : (
           <Tooltip
             hasArrow
             label="Currently at maximum language level."
@@ -206,7 +226,7 @@ const ApprovedLanguagesTableComponent = ({
           {["LEVEL 1", "LEVEL 2", "LEVEL 3", "LEVEL 4"].map((level) => (
             <Th key={level}>{level}</Th>
           ))}
-          {!isAdmin && <Th width="7%">ACTION</Th>}
+          <Th width="7%">ACTION</Th>
         </Tr>
       </Thead>
       <Tbody>{tableBody}</Tbody>

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -84,3 +84,8 @@ export const NEW_BOOK_TEST_ADDED_MESSAGE =
   "The story translation test to add a new language has been added to the homepage. Please see the 'My Tests' tab.";
 
 export const NEW_BOOK_TEST_ADDED_BUTTON = "Take me to homepage";
+
+export const REMOVE_LANGUAGE_CONFIRMATION =
+  "By removing this language, the user will no longer be able to start translating or reviewing story translations in this language. However, the user will continue having access to any ongoing story translations in this language.";
+
+export const REMOVE_LANGUAGE_BUTTON = "I'm sure, remove";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Implement remove approved language flow](https://www.notion.so/uwblueprintexecs/Implement-remove-approved-language-flow-802140979e214faf9bae4bccbeba3f98)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- modified `updateApprovedLanguage` mutation to support language deletion
- implemented language deletion flow in `ApprovedLanguagesTable.tsx`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin
2. Go to any `/user/:id`
3. On any row in the "Approved Languages" table, click the action icon 
4. Verify that the delete language flow works and that the proper info alert displays after confirmation
5. Verify that the row is removed from the table
6. Login as any other user and go to profile page
7. observe that the action column doesn't have the same button as admin

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does the flow work and is it intuitive?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
