### PR TITLE
Do not display ‘resolve’ button if comment is resolved

### DIFF
--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -124,9 +124,11 @@ const ExistingComment = ({
             Reply
           </Button>
         )}
-        <Button onClick={resolveExistingComment} variant="commentLabel">
-          Resolve
-        </Button>
+        {!resolved && (
+          <Button onClick={resolveExistingComment} variant="commentLabel">
+            Resolve
+          </Button>
+        )}
       </Flex>
       {reply > -1 && (
         <WIPComment


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Do not display ‘resolve’ button if comment is resolved](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=f90370003fb141fdb6df223da412fe56)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Make the resolve button only display if comment is not resolved 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Create a comment 
2. Resolve comment, button should disappear

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Not much, small PR

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
