### PR TITLE
Remove non PUBLISHED comment stage restrictions

### DIFF
--- a/backend/python/app/services/implementations/comment_service.py
+++ b/backend/python/app/services/implementations/comment_service.py
@@ -44,10 +44,11 @@ class CommentService(ICommentService):
         except Exception as error:
             self.logger.error(str(error))
             raise error
-
-        if (story_translation_stage == "TRANSLATE" and is_translator) or (
-            story_translation_stage == "REVIEW" and is_reviewer
-        ):
+        if story_translation_stage == "PUBLISH" and (is_translator or is_reviewer):
+            raise Exception(
+                "Comments cannot be left after the story has been published."
+            )
+        elif is_translator or is_reviewer:
             try:
                 new_comment.time = datetime.utcnow()
                 new_comment.resolved = False
@@ -85,18 +86,6 @@ class CommentService(ICommentService):
             )
 
             return new_comment
-        elif story_translation_stage == "TRANSLATE" and is_reviewer:
-            raise Exception(
-                "Comments cannot be left by reviewers while the story is being translated."
-            )
-        elif story_translation_stage == "REVIEW" and is_translator:
-            raise Exception(
-                "Comments cannot be left by translators while the story is being reviewed."
-            )
-        elif story_translation_stage == "PUBLISH" and (is_translator or is_reviewer):
-            raise Exception(
-                "Comments cannot be left after the story has been published."
-            )
         else:
             raise Exception("You are not authorized to leave comments on this story.")
 

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -233,14 +233,12 @@ const ReviewPage = () => {
           </Flex>
         </Flex>
         <CommentsPanel
-          disabled={stage === "TRANSLATE"}
           storyTranslationContentId={storyTranslationContentId}
           commentLine={commentLine}
           storyTranslationId={storyTranslationId}
           setCommentLine={setCommentLine}
           setTranslatedStoryLines={setTranslatedStoryLines}
           translatedStoryLines={translatedStoryLines}
-          reviewPage
         />
         {returnToTranslator && (
           <ConfirmationModal

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -308,7 +308,6 @@ const TranslationPage = () => {
         </Flex>
         {!isTest && (
           <CommentsPanel
-            disabled={!editable}
             storyTranslationContentId={storyTranslationContentId}
             commentLine={commentLine}
             storyTranslationId={storyTranslationId}

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -1,16 +1,12 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
-import { Box, Button, Flex, Select, Text, Tooltip } from "@chakra-ui/react";
+import { Box, Button, Flex, Select, Text } from "@chakra-ui/react";
 import {
   CommentResponse,
   buildCommentsQuery,
 } from "../../APIClients/queries/CommentQueries";
 import WIPComment from "./WIPComment";
 import { StoryLine } from "../translation/Autosave";
-import {
-  TRANSLATION_PAGE_TOOL_TIP_COPY,
-  REVIEW_PAGE_TOOL_TIP_COPY,
-} from "../../utils/Copy";
 import ExistingComment from "./ExistingComment";
 
 export type CommentPanelProps = {
@@ -18,10 +14,8 @@ export type CommentPanelProps = {
   commentLine: number;
   setCommentLine: (line: number) => void;
   storyTranslationContentId: number;
-  disabled: boolean;
   setTranslatedStoryLines: (storyLines: StoryLine[]) => void;
   translatedStoryLines: StoryLine[];
-  reviewPage?: boolean;
 };
 
 const CommentsPanel = ({
@@ -29,10 +23,8 @@ const CommentsPanel = ({
   commentLine,
   storyTranslationContentId,
   setCommentLine,
-  disabled,
   setTranslatedStoryLines,
   translatedStoryLines,
-  reviewPage = false,
 }: CommentPanelProps) => {
   const [comments, setComments] = useState<CommentResponse[]>([]);
   const [filterIndex, setFilterIndex] = useState(2);
@@ -103,10 +95,6 @@ const CommentsPanel = ({
     else setCommentLine(-1);
   };
 
-  const tooltipLabel = reviewPage
-    ? REVIEW_PAGE_TOOL_TIP_COPY
-    : TRANSLATION_PAGE_TOOL_TIP_COPY;
-
   return (
     <Box
       backgroundColor="gray.100"
@@ -116,19 +104,16 @@ const CommentsPanel = ({
       width="450px"
     >
       <Flex marginBottom="50px">
-        <Tooltip hasArrow label={tooltipLabel} isDisabled={!disabled}>
-          <Box>
-            <Button
-              colorScheme="blue"
-              size="secondary"
-              marginRight="10px"
-              onClick={handleCommentButton}
-              disabled={disabled}
-            >
-              Comment
-            </Button>
-          </Box>
-        </Tooltip>
+        <Box>
+          <Button
+            colorScheme="blue"
+            size="secondary"
+            marginRight="10px"
+            onClick={handleCommentButton}
+          >
+            Comment
+          </Button>
+        </Box>
         <Select
           name="comment filter"
           id="comment filter"
@@ -136,7 +121,6 @@ const CommentsPanel = ({
           variant="commentsFilter"
           onChange={handleCommentFilterSelectChange}
           width="160px"
-          disabled={disabled}
         >
           {filterOptionsComponent}
         </Select>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Remove non PUBLISHED comment stage restrictions](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=38538489e17b4470afb3369b39e423a7)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Remove the first two restrictions

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Reviewers and commenters should be able to leave comments on a story regardless of what stage it is in

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- idk, living a happy and meaningful life? 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
