### PR TITLE
Don’t return story translations if user already translating/reviewing for language

### DIFF
--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -13,8 +13,12 @@ def resolve_story_by_id(root, info, id):
     return services["story"].get_story(id)
 
 
-def resolve_stories_available_for_translation(root, info, language, level):
-    return services["story"].get_stories_available_for_translation(language, level)
+def resolve_stories_available_for_translation(root, info, language, level, user_id):
+    target_user_id = _select_user_id_for_available_translations_query(user_id)
+
+    return services["story"].get_stories_available_for_translation(
+        language, level, user_id=target_user_id
+    )
 
 
 def resolve_story_translations_by_user(
@@ -29,9 +33,13 @@ def resolve_story_translation_by_id(root, info, id):
     return services["story"].get_story_translation(id)
 
 
-def resolve_story_translations_available_for_review(root, info, language, level):
+def resolve_story_translations_available_for_review(
+    root, info, language, level, user_id=None
+):
+    target_user_id = _select_user_id_for_available_translations_query(user_id)
+
     return services["story"].get_story_translations_available_for_review(
-        language, level
+        language, level, user_id=target_user_id
     )
 
 
@@ -51,3 +59,10 @@ def resolve_story_translation_tests(root, info, language, level, stage, story_ti
     return services["story"].get_story_translation_tests(
         user, language, level, stage, story_title
     )
+
+
+def _select_user_id_for_available_translations_query(user_id):
+    # if caller is admin, use param use_id. Else, use caller id
+    calling_user_id = get_user_id_from_request()
+    isAdmin = services["user"].get_user_by_id(calling_user_id).role == "Admin"
+    return user_id if isAdmin else calling_user_id

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -137,11 +137,13 @@ class Query(graphene.ObjectType):
         graphene.List(StoryTranslationResponseDTO),
         language=graphene.String(required=True),
         level=graphene.Int(required=True),
+        user_id=graphene.ID(),
     )
     stories_available_for_translation = graphene.Field(
         graphene.List(StoryResponseDTO),
         language=graphene.String(required=True),
         level=graphene.Int(required=True),
+        user_id=graphene.ID(),
     )
 
     def resolve_comments_by_story_translation(
@@ -171,8 +173,12 @@ class Query(graphene.ObjectType):
     def resolve_user_by_email(root, info, email):
         return resolve_user_by_email(root, info, email)
 
-    def resolve_stories_available_for_translation(root, info, language, level):
-        return resolve_stories_available_for_translation(root, info, language, level)
+    def resolve_stories_available_for_translation(
+        root, info, language, level, user_id=None
+    ):
+        return resolve_stories_available_for_translation(
+            root, info, language, level, user_id
+        )
 
     def resolve_story_translations_by_user(
         root, info, user_id, is_translator=None, language=None, level=None
@@ -205,9 +211,11 @@ class Query(graphene.ObjectType):
     def resolve_story_translation_by_id(root, info, id):
         return resolve_story_translation_by_id(root, info, id)
 
-    def resolve_story_translations_available_for_review(root, info, language, level):
+    def resolve_story_translations_available_for_review(
+        root, info, language, level, user_id=None
+    ):
         return resolve_story_translations_available_for_review(
-            root, info, language, level
+            root, info, language, level, user_id
         )
 
 

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -160,11 +160,24 @@ class IStoryService(ABC):
         pass
 
     @abstractmethod
-    def get_story_translations_available_for_review(self, language, level):
+    def get_stories_available_for_translation(self, language, level, user_id):
         """
-        Return a list of stories available to be reviewed by user
+        Return a list of stories available to be translated by user
         :param level: level of user
         :param language: language being searched for
+        :param user_id: user_id looking for stories to translate
+        :return: list of StoryDTO's
+        :rtype: list of StoryDTO's
+        """
+        pass
+
+    @abstractmethod
+    def get_story_translations_available_for_review(self, language, level, user_id):
+        """
+        Return a list of story translations available to be reviewed by user
+        :param level: level of user
+        :param language: language being searched for
+        :param user_id: user_id looking for stories to translate
         :return: list of StoryTranslationResponseDTO's
         :rtype: list of StoryTranslationResponseDTO's
         """

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -180,8 +180,9 @@ export const buildHomePageStoriesQuery = (
 
 export const buildAssignStoryQuery = (
   isTranslator: boolean,
-  language: string | null,
-  level: number | null,
+  language: string,
+  level: number,
+  userId: number,
 ): QueryInformation => {
   const result = isTranslator
     ? {
@@ -190,7 +191,8 @@ export const buildAssignStoryQuery = (
           query StoriesAvailableForTranslation {
             storiesAvailableForTranslation(
               language: "${language}",
-              level: ${level}
+              level: ${level},
+              userId: ${userId}
             ) {
               storyId: id
               ${STORY_FIELDS}
@@ -204,7 +206,8 @@ export const buildAssignStoryQuery = (
           query StoriesAvailableForTranslation {
             storyTranslationsAvailableForReview(
               language: "${language}",
-              level: ${level}
+              level: ${level},
+              userId: ${userId}
             ) {
               storyId
               storyTranslationId: id

--- a/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
+++ b/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
@@ -366,6 +366,7 @@ const AssignedStoryTranslationsTable = ({
       </Table>
       {assignStory && (
         <AssignStoryModal
+          userId={userId}
           isOpen={assignStory}
           onClose={closeAssignStoryModal}
           onAssignStory={(story) => {

--- a/frontend/src/components/utils/AssignStoryModal.tsx
+++ b/frontend/src/components/utils/AssignStoryModal.tsx
@@ -36,6 +36,7 @@ export type StoryToAssign = {
 };
 
 export type AssignStoryModalProps = {
+  userId: number;
   isOpen: boolean;
   onClose: () => void;
   onAssignStory: (story: StoryToAssign) => void;
@@ -44,6 +45,7 @@ export type AssignStoryModalProps = {
 };
 
 const AssignStoryModal = ({
+  userId,
   isOpen,
   onClose,
   onAssignStory,
@@ -63,7 +65,12 @@ const AssignStoryModal = ({
     null,
   );
 
-  const query = buildAssignStoryQuery(role === "Translator", language, level);
+  const query = buildAssignStoryQuery(
+    role === "Translator",
+    language!,
+    level!,
+    userId,
+  );
 
   useQuery(query.string, {
     fetchPolicy: "cache-and-network",


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=fc6fd704b0674be19c756b4a1c30ef6c)
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- swapped out `_get_story_translations_user_translating` and `_get_story_translations_user_reviewing` for flexible query builder
- added checks to `get_stories_available_for_translation `and `get_story_translations_available_for_review`
  - if there exists ongoing story translations with same language+role for user, return []
  - this could be swapped with an error message that could be displayed, but the designs for that are TBD.
- passed in user_id for admin's UserProfile view to relative mutations

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

### Homepage View
#### Translate 
1. login as planetread+dwightdeisenhower@uwblueprint.org
2. observe ongoing no English US, but ongoing English UK and German translations.
3. go to browse stories. set TRANSLATOR role. 
4. Observe that no results show for English UK and German filters.
5. set language to English US. Notice results. complete flow and verify new (and correct) story translation in table. (note this tests the modified `create_translation`!)

#### Review
1. stay on same user
2. observe no ongoing review of English UK, but an ongoing English US
3. go to browse stories. set REVIEWER role. 
4. Observe that no results show for English US.
5. set language to English UK. Notice results. complete flow and verify it assigned the user correctly.  (note this tests the modified `assign_user_as_reviewer`!)

### Admin UserProfile View

**erase & reseed db**
```
docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data erase"
docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data"
```

#### Translate
1. go to http://localhost:3000/user/4 . observe ongoing no English US, but ongoing English UK and German translations.
2. attempt to assign English US. Notice results. complete flow and verify new (and correct) story translation in table. 
3. attempt to assign English UK and German.  Notice empty results for all levels

#### Review
1. Stay on the same page. observe no ongoing review of English UK, but an ongoing English US
2. attempt to assign English UK. Notice results for level 3. complete flow and verify it assigned the user correctly.
3. attempt to assign English US. Notice empty results for all levels


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
