### PR TITLE
Fix insert comments story_translation_content_ids

### DIFF
--- a/backend/python/tools/insert_test_data.py
+++ b/backend/python/tools/insert_test_data.py
@@ -208,13 +208,13 @@ def insert_test_data():
         "INSERT IGNORE INTO comments \
             (id, story_translation_content_id, user_id, comment_index, time, resolved, content) \
         VALUES \
-            (1, 51, 1, 0, '2021-07-31 01:48:42', True, 'Not sure if this grammar makes sense'), \
-            (2, 51, 4, 1, '2021-08-09 12:28:42', True, 'It''s fine, go back to grammar school man'), \
-            (3, 51, 1, 2, '2021-08-10 21:55:42', True, 'uwu dont need to be so mean man'), \
-            (4, 53, 1, 0, '2021-07-31 13:22:42', False, 'this comment is lonely uwu '), \
-            (5, 54, 4, 0, '2021-08-09 01:38:12', True, 'this comment is likes to be alone uwu '), \
-            (6, 59, 4, 0, '2021-08-09 18:23:32', False, 'this comment is disagreeable'), \
-            (7, 59, 1, 1, '2021-08-10 21:58:42', False, 'I agree!');"
+            (1, 41, 1, 0, '2021-07-31 01:48:42', True, 'Not sure if this grammar makes sense'), \
+            (2, 41, 4, 1, '2021-08-09 12:28:42', True, 'It''s fine, go back to grammar school man'), \
+            (3, 41, 1, 2, '2021-08-10 21:55:42', True, 'uwu dont need to be so mean man'), \
+            (4, 43, 1, 0, '2021-07-31 13:22:42', False, 'this comment is lonely uwu '), \
+            (5, 44, 4, 0, '2021-08-09 01:38:12', True, 'this comment is likes to be alone uwu '), \
+            (6, 49, 4, 0, '2021-08-09 18:23:32', False, 'this comment is disagreeable'), \
+            (7, 49, 1, 1, '2021-08-10 21:58:42', False, 'I agree!');"
     )
 
 


### PR DESCRIPTION
## Implementation description

- ids got offset by 10 due to changes inserted story translations + tests

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data erase"`
2. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data"`
3. log in as carl sagan and see that the Great Gatsby comments look lit

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
