### PR TITLE
Fix: use delete icon for deleting languages

### DIFF
--- a/frontend/src/components/admin/ApprovedLanguagesTableComponent.tsx
+++ b/frontend/src/components/admin/ApprovedLanguagesTableComponent.tsx
@@ -17,7 +17,7 @@ import {
   Icon,
   IconButton,
 } from "@chakra-ui/react";
-import { MdOutlineBlock } from "react-icons/md";
+import { MdDelete } from "react-icons/md";
 import { ApprovedLanguagesMap, generateSortFn } from "../../utils/Utils";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 
@@ -157,7 +157,7 @@ const ApprovedLanguagesTableComponent = ({
             <IconButton
               aria-label={`Remove approved language ${approvedLanguage.language}`}
               background="transparent"
-              icon={<Icon as={MdOutlineBlock} />}
+              icon={<Icon as={MdDelete} />}
               width="fit-content"
               onClick={() =>
                 removeLanguageOnClick(


### PR DESCRIPTION
## Implementation description

- oops, shouldve caught this in the last pr. we're sticking to the trash icon through out the web app, but some of the designs are old and use the wrong icon

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. 
![image](https://user-images.githubusercontent.com/15113249/147255504-486b43ab-6f82-4f57-a51e-149bc1a9c77c.png)
garbage 🗑️ 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it look lit

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
