### PR TITLE
Display correct user names on comments

### DIFF
--- a/frontend/src/APIClients/queries/CommentQueries.ts
+++ b/frontend/src/APIClients/queries/CommentQueries.ts
@@ -3,6 +3,7 @@ import { QueryInformation } from "./StoryQueries";
 
 const COMMENT_FIELDS = `
     id
+    userId
     commentIndex
     content
     storyTranslationContentId

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -88,7 +88,9 @@ export const GET_STORY_AND_TRANSLATION_CONTENTS = (
       numTranslatedLines
       numApprovedLines
       translatorId
+      translatorName
       reviewerId
+      reviewerName
     }
   }
 `;

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -48,6 +48,7 @@ const ReviewPage = () => {
   const [translatedStoryLines, setTranslatedStoryLines] = useState<StoryLine[]>(
     [],
   );
+  const [translatorId, setTranslatorId] = useState(-1);
   const [reviewerId, setReviewerId] = useState(-1);
   const [numTranslatedLines, setNumTranslatedLines] = useState(0);
   const [numApprovedLines, setNumApprovedLines] = useState(0);
@@ -56,6 +57,8 @@ const ReviewPage = () => {
   const [title, setTitle] = useState<string>("");
   const [language, setLanguage] = useState<string>("");
   const [stage, setStage] = useState<string>("");
+  const [translatorName, setTranslatorName] = useState<string>("");
+  const [reviewerName, setReviewerName] = useState<string>("");
 
   const [commentLine, setCommentLine] = useState(-1);
 
@@ -115,6 +118,7 @@ const ReviewPage = () => {
     {
       fetchPolicy: "cache-and-network",
       onCompleted: (data) => {
+        setTranslatorId(data.storyTranslationById.translatorId);
         setReviewerId(data.storyTranslationById.reviewerId);
         const storyContent = data.storyById.contents;
         const translatedContent = data.storyTranslationById.translationContents;
@@ -123,6 +127,8 @@ const ReviewPage = () => {
         setTitle(data.storyById.title);
         setNumTranslatedLines(data.storyTranslationById.numTranslatedLines);
         setNumApprovedLines(data.storyTranslationById.numApprovedLines);
+        setTranslatorName(data.storyTranslationById.translatorName);
+        setReviewerName(data.storyTranslationById.reviewerName);
 
         const contentArray: StoryLine[] = [];
         storyContent.forEach(({ content, lineIndex }: Content) => {
@@ -237,6 +243,9 @@ const ReviewPage = () => {
           storyTranslationContentId={storyTranslationContentId}
           commentLine={commentLine}
           storyTranslationId={storyTranslationId}
+          translatorId={translatorId}
+          translatorName={translatorName}
+          reviewerName={reviewerName}
           setCommentLine={setCommentLine}
           setTranslatedStoryLines={setTranslatedStoryLines}
           translatedStoryLines={translatedStoryLines}

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -53,6 +53,8 @@ const TranslationPage = () => {
   const [title, setTitle] = useState<string>("");
   const [language, setLanguage] = useState<string>("");
   const [stage, setStage] = useState<string>("");
+  const [translatorName, setTranslatorName] = useState<string>("");
+  const [reviewerName, setReviewerName] = useState<string>("");
 
   // TODO: remove eslint comment when setIsTest is used
   const [isTest, setIsTest] = useState(false); // eslint-disable-line
@@ -177,6 +179,8 @@ const TranslationPage = () => {
         setLanguage(data.storyTranslationById.language);
         setTitle(data.storyById.title);
         setNumTranslatedLines(data.storyTranslationById.numTranslatedLines);
+        setTranslatorName(data.storyTranslationById.translatorName);
+        setReviewerName(data.storyTranslationById.reviewerName);
 
         // TODO: uncomment when query is updated
         // setIsTest(data.storyById.isTest);
@@ -312,6 +316,9 @@ const TranslationPage = () => {
             storyTranslationContentId={storyTranslationContentId}
             commentLine={commentLine}
             storyTranslationId={storyTranslationId}
+            translatorId={translatorId}
+            translatorName={translatorName}
+            reviewerName={reviewerName}
             setCommentLine={setCommentLine}
             setTranslatedStoryLines={setTranslatedStoryLines}
             translatedStoryLines={translatedStoryLines}

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -15,6 +15,9 @@ import ExistingComment from "./ExistingComment";
 
 export type CommentPanelProps = {
   storyTranslationId: number;
+  translatorId: number;
+  translatorName: string;
+  reviewerName: string;
   commentLine: number;
   setCommentLine: (line: number) => void;
   storyTranslationContentId: number;
@@ -26,6 +29,9 @@ export type CommentPanelProps = {
 
 const CommentsPanel = ({
   storyTranslationId,
+  translatorId,
+  translatorName,
+  reviewerName,
   commentLine,
   storyTranslationContentId,
   setCommentLine,
@@ -72,6 +78,9 @@ const CommentsPanel = ({
           {comments.map((comment: CommentResponse) => (
             <ExistingComment
               key={comment.id}
+              userName={
+                translatorId === comment.userId ? translatorName : reviewerName
+              }
               comment={comment}
               WIPLineIndex={commentLine}
               updateCommentsAsResolved={updateCommentsAsResolved}

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useContext } from "react";
+import React, { useState } from "react";
 import { useMutation } from "@apollo/client";
 import { Text, Flex, Button } from "@chakra-ui/react";
-import AuthContext from "../../contexts/AuthContext";
 import WIPComment from "./WIPComment";
 import {
   UPDATE_COMMENT_BY_ID,
@@ -11,6 +10,7 @@ import { CommentResponse } from "../../APIClients/queries/CommentQueries";
 import { StoryLine } from "../translation/Autosave";
 
 export type ExistingCommentProps = {
+  userName: string;
   comment: CommentResponse;
   updateCommentsAsResolved: (index: number) => void;
   comments: CommentResponse[];
@@ -21,6 +21,7 @@ export type ExistingCommentProps = {
 };
 
 const ExistingComment = ({
+  userName,
   comment,
   updateCommentsAsResolved,
   setComments,
@@ -46,7 +47,6 @@ const ExistingComment = ({
   const [storyTranslationContentId, setStoryTranslationContentId] =
     useState(stcId);
 
-  const { authenticatedUser } = useContext(AuthContext);
   const [updateComment] = useMutation<{
     updateCommentById: UpdateCommentResponse;
   }>(UPDATE_COMMENT_BY_ID);
@@ -77,10 +77,6 @@ const ExistingComment = ({
     }
   };
 
-  const name = `
-    ${authenticatedUser!!.firstName}
-    ${authenticatedUser!!.lastName}`;
-
   const handleReply = () => {
     setStoryTranslationContentId(storyTranslationContentId);
     setReply(storyContentId);
@@ -107,7 +103,7 @@ const ExistingComment = ({
         </Text>
       )}
       <Flex justify="space-between" marginBottom="10px">
-        <p>{name}</p>
+        <p>{userName}</p>
         <p>
           {displayTime.toLocaleDateString("en-US", {
             month: "short",


### PR DESCRIPTION
## Notion ticket link

https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=b9f8e51d62604951a5a7831233697b91

## Implementation description

- retrieve translatorName and reviewerName from backend
- use the correct name in ExistingComments
- (note: did not change WIPComments because the name is always the authenticatedUser Name)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as carl sagan
2. see great gatsby 
3. wow look at all those names 
![image](https://user-images.githubusercontent.com/15113249/147263392-b14d9422-a28e-47ee-b053-353cc0a87b81.png)
4. log in as dwight and look at same translation
5. the names better match up!
![image](https://user-images.githubusercontent.com/15113249/147263442-84ea7801-051f-4706-aff9-05ae4e9d22cb.png)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
