### PR TITLE
My test tab on homepage should not show INREVIEW/ PUBLISHED tests

### DIFF
--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -113,7 +113,7 @@ export const buildHomePageStoriesQuery = (
       fieldName: "storyTranslationTests",
       string: gql`
             query StoryTranslationTests {
-              storyTranslationTests
+              storyTranslationTests (stage: "TRANSLATE")
               {
                 storyTranslationId: id
                 storyId


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[My test tab on homepage should not show INREVIEW/ PUBLISHED tests](https://www.notion.so/uwblueprintexecs/My-test-tab-on-homepage-should-not-show-INREVIEW-PUBLISHED-tests-cec3ba26e46d4ed6b4856d6eb6796f81)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added `stage: TRANSLATE` argument to `storyTranslationTests` query in `buildHomePageStoriesQuery`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl (or anyone who can level up a language)
2. Go to profile and level up a language
3. Verify that a new test shows up under My Tests tab
4. Send the test for review
5. Verify that the test is no longer shown under My Tests tab
6. Publish the test by updating the row using mysql: `UPDATE story_translations set stage="PUBLISH" where id=14;`, or by using Altair as admin:
```
mutation {
  finishGradingStoryTranslation(storyTranslationTestId: 14, testFeedback: "blah", testResult: "{}"){
    ok
    storyTranslation{
      id
      stage
      
    }
  }
}
```
7. Verify that the test is still not shown under My Tests tab
8. Set the test back to translate state using mysql: `UPDATE story_translations set stage="TRANSLATE" where id=14;`
9. Verify that the test is shown under My Tests tab

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?
- Does the code make sense? I changed the `buildHomePageStoriesQuery`, because I wanted to leave the `storyTranslationTests` query and `get_story_translation_tests`service as general as possible

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
