### PR TITLE
Hide comment panel for tests

### DIFF
--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -74,6 +74,7 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
     description = graphene.String(required=True)
     youtube_link = graphene.String(required=True)
     level = graphene.Int(required=True)
+    is_test = graphene.Boolean()
     num_translated_lines = graphene.Int()
     num_approved_lines = graphene.Int()
     num_content_lines = graphene.Int()

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -359,6 +359,7 @@ class StoryService(IStoryService):
                     Story.description.label("description"),
                     Story.youtube_link.label("youtube_link"),
                     Story.level.label("level"),
+                    Story.is_test.label("is_test"),
                     StoryTranslation.id.label("id"),
                     StoryTranslation.language.label("language"),
                     StoryTranslation.stage.label("stage"),

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -87,6 +87,7 @@ export const GET_STORY_AND_TRANSLATION_CONTENTS = (
       }
       numTranslatedLines
       numApprovedLines
+      isTest
       translatorId
       translatorName
       reviewerId

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -53,11 +53,9 @@ const TranslationPage = () => {
   const [title, setTitle] = useState<string>("");
   const [language, setLanguage] = useState<string>("");
   const [stage, setStage] = useState<string>("");
+  const [isTest, setIsTest] = useState(false);
   const [translatorName, setTranslatorName] = useState<string>("");
   const [reviewerName, setReviewerName] = useState<string>("");
-
-  // TODO: remove eslint comment when setIsTest is used
-  const [isTest, setIsTest] = useState(false); // eslint-disable-line
 
   const history = useHistory();
 
@@ -181,9 +179,7 @@ const TranslationPage = () => {
         setNumTranslatedLines(data.storyTranslationById.numTranslatedLines);
         setTranslatorName(data.storyTranslationById.translatorName);
         setReviewerName(data.storyTranslationById.reviewerName);
-
-        // TODO: uncomment when query is updated
-        // setIsTest(data.storyById.isTest);
+        setIsTest(data.storyTranslationById.isTest);
 
         const contentArray: StoryLine[] = [];
         storyContent.forEach(({ content, lineIndex }: Content) => {


### PR DESCRIPTION
## Implementation description

- get is_test from the backend for the story translation on the TranslationPage
- hid panel (actually already implemented, yay!) 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as carlsagan
2. observe that non-test story translations still have their comments
3. make a test 
```
mutation { createStoryTranslationTest(userId: 1, level: 2, language: "GERMAN") {
      story {
        id
      }
    }
  }
```
4. observe the missing comment panel
5. send for review and observe the still missing comment panel

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- anyother edge cases?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
