### PR TITLE
Resolve entire thread when comment resolved

### DIFF
--- a/backend/python/app/services/implementations/comment_service.py
+++ b/backend/python/app/services/implementations/comment_service.py
@@ -144,6 +144,13 @@ class CommentService(ICommentService):
                 )
             for key, value in updated_comment.__dict__.items():
                 setattr(comment, key, value)
+
+            if updated_comment["resolved"] == True:
+                thread_comments = Comment.query.filter_by(
+                    story_translation_content_id=comment.story_translation_content_id
+                ).all()
+                for com in thread_comments:
+                    com.resolved = True
             db.session.commit()
 
             story_translation = (

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -118,12 +118,12 @@ const ExistingComment = ({
         {content}
       </Text>
       <Flex>
-        {!commentIndex && (
+        {!resolved && !commentIndex && (
           <Button onClick={() => handleReply()} variant="commentLabel">
             Reply
           </Button>
         )}
-        {!resolved && (
+        {!resolved && !commentIndex && (
           <Button onClick={resolveExistingComment} variant="commentLabel">
             Resolve
           </Button>


### PR DESCRIPTION
## Notion ticket link

https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=88d025db50c24db5a3544e520060539d


## Implementation description

- in service, resolve all comments for a translation content id
- only display resolve button at head of thread  
  - resolving any part of the thread works but the ui is a little confusing if you can resolve in thread
  - do not display reply button if resolved 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. log in as carl sagan and look at the great gatsby
2. resolve a comment. observe the entire thread disappears
3. set the comment filter to resolved. note the lack of reply and resolve buttons

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work and make sense

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
