### PR TITLE
Link to user instead of translation 

### DIFF
--- a/frontend/src/components/admin/StoryTestsTable.tsx
+++ b/frontend/src/components/admin/StoryTestsTable.tsx
@@ -128,7 +128,7 @@ const StoryTestsTable = ({
         key={`${storyTest.id}`}
       >
         <Td>
-          <Link isExternal href={`/user/${storyTest.id}`}>
+          <Link isExternal href={`/user/${storyTest.translatorId}`}>
             {storyTest.translatorName}
           </Link>
         </Td>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[MyTest table user link uses story_translation_id instead of user_id](https://www.notion.so/uwblueprintexecs/MyTest-table-user-link-uses-story_translation_id-instead-of-user_id-ad2fa10b2c4b46d4b3b0bc52d7ff0f2b)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Use translatorId instead of id

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin and go to http://localhost:3000/ 
2. Check that clicking on the name brings you to the correct profile

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
