### PR TITLE
(Bugfix) Truncate progress value to 2 decimal places

### DIFF
--- a/frontend/src/components/utils/ProgressBar.tsx
+++ b/frontend/src/components/utils/ProgressBar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Progress } from "@chakra-ui/react";
 import "./ProgressBar.css";
+import { truncate } from "../../utils/Utils";
 
 type ProgressBarProps = {
   percentageComplete: number;
@@ -11,7 +12,7 @@ const ProgressBar = ({ percentageComplete, type }: ProgressBarProps) => {
   return (
     <div className="progress-bar-container">
       <p className="progress-label">
-        {type} Progress: {percentageComplete}%
+        {type} Progress: {truncate(percentageComplete, 2)}%
       </p>
       <div>
         <Progress

--- a/frontend/src/utils/Utils.ts
+++ b/frontend/src/utils/Utils.ts
@@ -59,3 +59,9 @@ export const generateSortFn =
 export const isObjEmpty = (o: object): boolean => {
   return Object.keys(o).length === 0;
 };
+
+// Retrieved from: https://stackoverflow.com/a/11818658
+export const truncate = (num: number, decimals: number): string => {
+  const re = new RegExp(`^-?\\d+(?:.\\d{0,${decimals || -1}})?`);
+  return num.toString().match(re)![0];
+};


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Truncate-progress-number-54e778e01a2742fd9ed32c9d2b326529

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- added util function to truncate decimal number

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login to any user
2. Go to profile page and click any "Level up" button
3. Go to story test and edit translation, verify that the decimal numbers are truncated

![image](https://user-images.githubusercontent.com/45080644/147287925-2f9841b8-779d-4af2-84fa-38bb4e66a628.png)
![image](https://user-images.githubusercontent.com/45080644/147287947-03dc192e-5640-4f4b-b951-706b9163483c.png)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- verify that the whole numbers don't display 2 decimals

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
