### PR TITLE
Update local state when assigning new story translation

### DIFF
--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -74,7 +74,7 @@ class AssignUserAsReviewer(graphene.Mutation):
         user_id = graphene.ID(required=True)
         story_translation_id = graphene.ID(required=True)
 
-    ok = graphene.Boolean()
+    story = graphene.Field(lambda: CreateStoryTranslationResponseDTO)
 
     def mutate(root, info, user_id, story_translation_id):
         try:
@@ -83,8 +83,10 @@ class AssignUserAsReviewer(graphene.Mutation):
             story_translation = services["story"].get_story_translation(
                 story_translation_id
             )
-            services["story"].assign_user_as_reviewer(user, story_translation)
-            return AssignUserAsReviewer(ok=True)
+            new_story_translation = services["story"].assign_user_as_reviewer(
+                user, story_translation
+            )
+            return AssignUserAsReviewer(story=new_story_translation)
         except Exception as e:
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -38,9 +38,16 @@ class StoryRequestDTO(graphene.InputObjectType):
 class CreateStoryTranslationResponseDTO(graphene.ObjectType):
     id = graphene.Int(required=True)
     translator_id = graphene.Int(required=True)
+    reviewer_id = graphene.Int()
     story_id = graphene.String(required=True)
     language = graphene.String(required=True)
     stage = graphene.Field(StageEnum)
+    title = graphene.String(required=True)
+    description = graphene.String(required=True)
+    youtube_link = graphene.String(required=True)
+    level = graphene.Int(required=True)
+    translator_last_activity = graphene.DateTime()
+    reviewer_last_activity = graphene.DateTime()
 
 
 class CreateStoryTranslationRequestDTO(graphene.InputObjectType):

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -119,7 +119,7 @@ class StoryService(IStoryService):
             self.logger.error(str(error))
             raise error
 
-        return new_story_translation
+        return {**story.to_dict(), **new_story_translation.to_dict()}
 
     def create_translation_test(self, user_id, level, language):
         try:
@@ -442,7 +442,6 @@ class StoryService(IStoryService):
             and story_translation["language"] not in languages_currently_reviewing
             and user.approved_languages_review[story_translation["language"]]
             >= story_translation["level"]
-            and story_translation["stage"] == "TRANSLATE"
             and not story_translation["reviewer_id"]
             and user.id != story_translation["translator_id"]
         ):
@@ -453,6 +452,11 @@ class StoryService(IStoryService):
         else:
             self.logger.error("User can't be assigned as a reviewer")
             raise Exception("User can't be assigned as a reviewer")
+
+        return {
+            **self.get_story(story_translation.story_id),
+            **story_translation.to_dict(),
+        }
 
     def remove_reviewer_from_story_translation(self, story_translation):
         try:

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -121,6 +121,18 @@ class IStoryService(ABC):
         pass
 
     @abstractmethod
+    def assign_user_as_reviewer(self, user, story_translation):
+        """Assign a user as a reviewer of a story translation
+
+        :param user: user object
+        :param story_translation: dictionary of story translation fields
+        :return: dictionary of StoryTranslation object
+        :rtype: dictionary
+        :raises Exception: if user can't be assigned as a reviewer
+        """
+        pass
+
+    @abstractmethod
     def update_story(self, story_id, title, description, youtube_link):
         """Update a single story
         :param story_id: id of story to be updated

--- a/backend/python/app/tests/services/test_story_service.py
+++ b/backend/python/app/tests/services/test_story_service.py
@@ -102,8 +102,10 @@ def test_create_translation(app, db, services):
         reviewer_id=reviewer_obj.id,
     )
     story_translation_resp = services["story"].create_translation(story_translation)
-    story_translation_obj = StoryTranslation.query.get(story_translation_resp.id)
-    assert story_translation_resp == story_translation_obj
+    story_translation_obj = StoryTranslation.query.get(story_translation_resp["id"])
+    assert_story_translation_equals_model(
+        story_translation_resp, story_obj, story_translation_obj
+    )
 
     get_story_translation_resp = services["story"].get_story_translation(
         story_translation_obj.id

--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -1,4 +1,5 @@
 import { gql } from "@apollo/client";
+import { StoryTranslation, STORY_FIELDS } from "../queries/StoryQueries";
 
 export const UPDATE_STORY_TRANSLATION_CONTENTS = gql`
   mutation UpdateStoryTranslationContents(
@@ -52,17 +53,22 @@ export const CREATE_TRANSLATION = gql`
   ) {
     createStoryTranslation(storyTranslationData: $storyTranslationData) {
       story {
-        id
+        storyTranslationId: id
+        storyId
+        translatorId
+        reviewerId
+        language
+        stage
+        translatorLastActivity
+        reviewerLastActivity
+        ${STORY_FIELDS}
       }
     }
   }
 `;
 
-// TODO: update mutation to retrieve story translation fields
 export type CreateTranslationResponse = {
-  story: {
-    id: number;
-  };
+  story: StoryTranslation;
 };
 
 export const ASSIGN_REVIEWER = gql`
@@ -71,13 +77,24 @@ export const ASSIGN_REVIEWER = gql`
       storyTranslationId: $storyTranslationId
       userId: $userId
     ) {
-      ok
+      story {
+        storyTranslationId: id
+        storyId
+        translatorId
+        reviewerId
+        language
+        stage
+        translatorLastActivity
+        reviewerLastActivity
+        ${STORY_FIELDS}
+      }
     }
   }
 `;
 
-// TODO: update mutation to retrieve story translation fields
-export type AssignReviewerResponse = { ok: boolean };
+export type AssignReviewerResponse = {
+  story: StoryTranslation;
+};
 
 export const UNASSIGN_REVIEWER = gql`
   mutation UnassignReviewer($storyTranslationId: ID!) {

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -1,6 +1,6 @@
 import { DocumentNode, gql } from "@apollo/client";
 
-const STORY_FIELDS = `
+export const STORY_FIELDS = `
     title
     description
     youtubeLink

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -66,7 +66,7 @@ const StoryCard = ({
       const result = await assignUserAsReviewer({
         variables: { storyTranslationId, userId: +authenticatedUser!!.id },
       });
-      if (result.data?.assignUserAsReviewer.ok) {
+      if (result.data?.assignUserAsReviewer.story.storyId) {
         history.push(`/review/${storyId}/${storyTranslationId}`);
       } else {
         handleError("Unable to assign reviewer.");
@@ -94,9 +94,9 @@ const StoryCard = ({
       const result = await createTranslation({
         variables: { storyTranslationData },
       });
-      if (result.data?.createStoryTranslation.story.id) {
+      if (result.data?.createStoryTranslation.story.storyTranslationId) {
         history.push(
-          `/translation/${storyId}/${result.data?.createStoryTranslation.story.id}`,
+          `/translation/${storyId}/${result.data?.createStoryTranslation.story.storyTranslationId}`,
         );
       } else {
         handleError("Unable to assign translator.");

--- a/frontend/src/components/utils/ApproveLanguageModal.tsx
+++ b/frontend/src/components/utils/ApproveLanguageModal.tsx
@@ -26,15 +26,6 @@ import { ApprovedLanguagesMap } from "../../utils/Utils";
 import DropdownIndicator from "./DropdownIndicator";
 import { colourStyles } from "../../theme/components/Select";
 
-export type StoryToAssign = {
-  storyId: number;
-  storyTranslationId?: number;
-  title: string;
-  description: string;
-  level: number;
-  language: string;
-};
-
 export type NewApprovedLanguage = {
   language: string;
   level: number;


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Update-Assigned-Story-Translations-state-dd7f387197524954966b4a64cb903529

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- modfiied return types for createStoryTranslation and assignUserAsReviewer mutations to return story translation object
- update local state when new story translation is assigned
- modified condition in `assign_user_as_reviewer` to accept case where translation isn't in TRANSLATE stage

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as admin, go to /user/4
2. click "assign new story"
3. select Translator, English (US), Level 2, Nineteen Eighty-Four
4. verify that new story translation is assigned and the row appears (observe no refresh)
5. click "assign new story" again
6. select Reviewer, English (UK), Level 3, A Tale of Two Cities
7. verify that row appears
8. delete both rows, verify that it works

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
