### PR TITLE
Implement fail test flow

### DIFF
--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -165,3 +165,29 @@ export type CreateTranslationTestResponse = {
     id: number;
   };
 };
+
+export const FINISH_GRADING_STORY_TRANSLATION = gql`
+  mutation FinishGradingStoryTranslation(
+    $storyTranslationTestId: Int!
+    $testFeedback: String
+    $testResult: JSONString!
+  ) {
+    finishGradingStoryTranslation(
+      storyTranslationTestId: $storyTranslationTestId
+      testFeedback: $testFeedback
+      testResult: $testResult
+    ) {
+      ok
+      storyTranslation {
+        id
+      }
+    }
+  }
+`;
+
+export type FinishGradingStoryTranslationResponse = {
+  ok: boolean;
+  storyTranslation: {
+    id: number;
+  };
+};

--- a/frontend/src/components/pages/StoryTestGradingPage.tsx
+++ b/frontend/src/components/pages/StoryTestGradingPage.tsx
@@ -21,6 +21,8 @@ import {
   GRADING_PAGE_FAIL_USER_BUTTON,
 } from "../../utils/Copy";
 import {
+  FINISH_GRADING_STORY_TRANSLATION,
+  FinishGradingStoryTranslationResponse,
   UPDATE_STORY_TRANSLATION_STAGE,
   UpdateStoryTranslationStageResponse,
 } from "../../APIClients/mutations/StoryMutations";
@@ -54,6 +56,7 @@ const StoryTestGradingPage = () => {
   const [title, setTitle] = useState<string>("");
   const [language, setLanguage] = useState<string>("");
   const [stage, setStage] = useState<string>("");
+  const [testFeedback] = useState<string>("");
 
   const [failUser, setFailUser] = useState(false);
 
@@ -91,6 +94,25 @@ const StoryTestGradingPage = () => {
   const [updateStoryTranslationStage] = useMutation<{
     updateStoryTranslationStage: UpdateStoryTranslationStageResponse;
   }>(UPDATE_STORY_TRANSLATION_STAGE);
+
+  const [finishGradingStoryTranslation] = useMutation<{
+    finishGradingStoryTranslation: FinishGradingStoryTranslationResponse;
+  }>(FINISH_GRADING_STORY_TRANSLATION);
+
+  const failGrade = async (testFeedback: string | null) => {
+    const result = await finishGradingStoryTranslation({
+      variables: {
+        storyTranslationTestId: storyTranslationId,
+        testFeedback,
+        testResult: "{}",
+      },
+    });
+    if (result.data?.finishGradingStoryTranslation.ok) {
+      history.push("/");
+    } else {
+      window.alert("Could not mark story translation as failed.");
+    }
+  };
 
   const createUpdateStoryTranslationStageMutation = (newStage: string) => {
     const updateStoryTranslationStageMutation = async () => {
@@ -245,7 +267,7 @@ const StoryTestGradingPage = () => {
         </Flex>
         <ConfirmationModal
           confirmation={failUser}
-          onConfirmationClick={() => {}} // TODO: implement fail user
+          onConfirmationClick={() => failGrade(testFeedback)}
           onClose={closeFailUserModal}
           confirmationMessage={GRADING_PAGE_FAIL_USER_CONFIRMATION}
           buttonMessage={GRADING_PAGE_FAIL_USER_BUTTON}


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Implement Fail Grade flow](https://www.notion.so/uwblueprintexecs/Implement-Fail-Grade-flow-078ae20bdcbd437c89c093df93a41068)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- added the finishGradingStoryTranslation mutation 
- added a function to fail the test 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. [Create a story translation test](http://localhost:5000/graphql?variables=null&operationName=CreateStoryTest&query=mutation%20CreateStoryTest%20%7B%0A%20%20createStoryTranslationTest(userId%3A%201%2C%20level%3A2%2C%20language%3A%22FRENCH%22)%7B%0A%20%20%20%20story%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20translatorId%0A%20%20%20%20%20%20storyId%0A%20%20%20%20%20%20language%0A%20%20%20%20%20%20stage%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D) 
2. login as angela merkel 
3. in console set the stage to `REVIEW` (`update story_translations set stage=2 where id = ... ;`)
4. go to the manage tests tab and navigate to the story test
5. fail the test
6. check that you are redirected, check that the test_result = {}, stage=PUBLISH 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- What behaviour do we expect after the test is failed? (currently just redirects to home)
- How will test feedback be added?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
