### PR TITLE
Implement multi thread comment styling

### DIFF
--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -34,6 +34,7 @@ const CommentsPanel = ({
 }: CommentPanelProps) => {
   const [comments, setComments] = useState<CommentResponse[]>([]);
   const [filterIndex, setFilterIndex] = useState(2);
+  const [threadHeadMap, setThreadHeadMap] = useState<boolean[]>([]);
 
   const filterOptions = ["All", "Resolved", "Unresolved"];
   const filterToResolved = [null, true, false];
@@ -41,10 +42,35 @@ const CommentsPanel = ({
     storyTranslationId,
     filterToResolved[filterIndex],
   );
+
+  const updateThreadHeadMap = (cmts: CommentResponse[]) => {
+    /* A comment is a thread head if
+     * * It has the smallest lineIndex of all present comments for a story line
+     * * It's thread predecessor is resolved
+     */
+    const newThreadHeadMap = cmts.map((c: CommentResponse, i: number) => {
+      if (
+        i ===
+        cmts.findIndex(
+          (_c) => _c.storyTranslationContentId === c.storyTranslationContentId,
+        )
+      )
+        return true;
+      const lastC = cmts[i - 1];
+      return (
+        !c?.resolved &&
+        lastC?.resolved &&
+        lastC?.storyTranslationContentId === c?.storyTranslationContentId
+      );
+    });
+    setThreadHeadMap(newThreadHeadMap);
+  };
+
   useQuery(commentsQuery.string, {
     fetchPolicy: "cache-and-network",
     onCompleted: (data) => {
       setComments(data.commentsByStoryTranslation);
+      updateThreadHeadMap(data.commentsByStoryTranslation);
     },
   });
 
@@ -56,10 +82,23 @@ const CommentsPanel = ({
 
   const updateCommentsAsResolved = (index: number) => {
     const newComments = [...comments];
-    const updatedComment = { ...newComments[index - 1] };
-    updatedComment.resolved = true;
-    newComments[index - 1] = updatedComment;
-    setComments(newComments);
+    const commentsStateIdx = newComments.findIndex((c) => c.id === index);
+    const updatedComment = { ...newComments[commentsStateIdx] };
+    if (filterOptions[filterIndex] === "Unresolved") {
+      setComments(
+        // Resolving one comment resolves the entire thread
+        newComments.filter(
+          (c) =>
+            c.storyTranslationContentId !==
+            updatedComment.storyTranslationContentId,
+        ),
+      );
+    } else {
+      updatedComment.resolved = true;
+      newComments[commentsStateIdx] = updatedComment;
+      setComments(newComments);
+    }
+    updateThreadHeadMap(newComments);
   };
 
   const CommentsList = () => {
@@ -67,9 +106,10 @@ const CommentsPanel = ({
       return (
         <Box>
           {/* TODO: show correct placement of the WIPComment component once existing comment is displayed */}
-          {comments.map((comment: CommentResponse) => (
+          {comments.map((comment: CommentResponse, i: number) => (
             <ExistingComment
               key={comment.id}
+              commentsStateIdx={i}
               userName={
                 translatorId === comment.userId ? translatorName : reviewerName
               }
@@ -80,6 +120,8 @@ const CommentsPanel = ({
               setComments={setComments}
               setTranslatedStoryLines={setTranslatedStoryLines}
               translatedStoryLines={translatedStoryLines}
+              threadHeadMap={threadHeadMap}
+              updateThreadHeadMap={updateThreadHeadMap}
             />
           ))}
         </Box>
@@ -143,6 +185,7 @@ const CommentsPanel = ({
           setComments={setComments}
           setTranslatedStoryLines={setTranslatedStoryLines}
           translatedStoryLines={translatedStoryLines}
+          updateThreadHeadMap={updateThreadHeadMap}
         />
       )}
       <CommentsList />

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -84,9 +84,10 @@ const CommentsPanel = ({
     const newComments = [...comments];
     const commentsStateIdx = newComments.findIndex((c) => c.id === index);
     const updatedComment = { ...newComments[commentsStateIdx] };
+    // Resolving one comment resolves the entire thread
     if (filterOptions[filterIndex] === "Unresolved") {
+      // Remove all resolved comments
       setComments(
-        // Resolving one comment resolves the entire thread
         newComments.filter(
           (c) =>
             c.storyTranslationContentId !==
@@ -94,8 +95,22 @@ const CommentsPanel = ({
         ),
       );
     } else {
-      updatedComment.resolved = true;
-      newComments[commentsStateIdx] = updatedComment;
+      // Resolve entire thread
+      const updatedCommentIdxs: number[] = [];
+      newComments.forEach((c, i) => {
+        if (
+          c.storyTranslationContentId ===
+            updatedComment.storyTranslationContentId &&
+          !c.resolved
+        ) {
+          updatedCommentIdxs.push(i);
+        }
+      });
+      updatedCommentIdxs.forEach((i) => {
+        const updatedC = { ...newComments[i] };
+        updatedC.resolved = true;
+        newComments[i] = updatedC;
+      });
       setComments(newComments);
     }
     updateThreadHeadMap(newComments);

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -19,6 +19,7 @@ export type WIPCommentProps = {
   setComments: (comments: CommentResponse[]) => void;
   translatedStoryLines: StoryLine[];
   setTranslatedStoryLines: (storyLines: StoryLine[]) => void;
+  updateThreadHeadMap: (cmts: CommentResponse[]) => void;
 };
 
 const WIPComment = ({
@@ -29,6 +30,7 @@ const WIPComment = ({
   setTranslatedStoryLines,
   comments,
   translatedStoryLines,
+  updateThreadHeadMap,
 }: WIPCommentProps) => {
   const handleError = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
@@ -54,13 +56,16 @@ const WIPComment = ({
       if (result.data?.createComment.ok) {
         setText("");
         setCommentLine(-1);
-        setComments(
-          insertSortedComments(comments, result.data.createComment.comment),
+        const newComments = insertSortedComments(
+          comments,
+          result.data.createComment.comment,
         );
+        setComments(newComments);
         const updatedStoryLines = [...translatedStoryLines];
         updatedStoryLines[WIPLineIndex - 1].status =
           convertStatusTitleCase("ACTION_REQUIRED");
         setTranslatedStoryLines(updatedStoryLines);
+        updateThreadHeadMap(newComments);
       }
     } catch (err) {
       if (typeof err === "string") {


### PR DESCRIPTION
## Notion ticket link
https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=802f3a1377064bd79778c2a4ec31b616

## Implementation description

- defined and mapped comments to be thread heads or non thread heads
- styled comments accordingly 
- bonus: solved odd resolving behaviour 

A thread head is the beginning of a thread. it is not indented.
A live thread head is an unresolved thread head. it has a reply and resolve button. 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data erase"`
2. `docker exec -it planet-read_py-backend_1 /bin/bash -c "python -m tools.insert_test_data"`
3. login as carlsagan and go to http://localhost:3000/review/6/13
4. set comment filter to all
5. observe resolved thread on line 1
6. make new comment on line 1
7. observe that it appears as a live thread head
8. reply to the comment
9. observe that the replies appear as replies
10. resolve the thread. observe how it flattens into the resolved thread immediately
11. make new comment on line 1. observe that it appears as a live thread head. feel free to repeat steps 5-9 on filters unresolved & all. 
12. play with filters to see that comments still display correctly

Heres what I observe when testing:
![image](https://user-images.githubusercontent.com/15113249/147374386-6ddd7ed0-d577-4a5c-86cb-0e4e467bd743.png)

**bonus round: wackass resolving behaviour fixed**
1. set filter to All
2. resolve an existing comment. observe that the reply/resolve buttons disappear
3. create a new comment and resolve it. observe that the reply/resolve buttons disappear
4. set filter to unresolved
5. resolve an existing comment. observe that the comment disappears
6. create a new comment and resolve it. observe that the comment disappears

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work
- does the code make sense? the comment section code is quite busy

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
