### PR TITLE
Download files via fileById

### DIFF
--- a/backend/python/app/graphql/queries/file_query.py
+++ b/backend/python/app/graphql/queries/file_query.py
@@ -1,6 +1,7 @@
+from ...middlewares.auth import require_authorization_by_role_gql
 from ..service import services
 
 
-# TODO: require User or Admin role
+@require_authorization_by_role_gql({"User", "Admin"})
 def resolve_file_by_id(root, info, id):
     return services["file"].get_file(id)

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -47,7 +47,7 @@ from .queries.story_query import (
 )
 from .queries.user_query import resolve_user_by_email, resolve_user_by_id, resolve_users
 from .types.comment_type import CommentResponseDTO
-from .types.file_type import FileDTO
+from .types.file_type import DownloadFileDTO, FileDTO
 from .types.story_type import (
     StoryResponseDTO,
     StoryTranslationConnection,
@@ -97,7 +97,7 @@ class Query(graphene.ObjectType):
         story_translation_id=graphene.Int(required=True),
         resolved=graphene.Boolean(),
     )
-    file_by_id = graphene.Field(FileDTO, id=graphene.Int(required=True))
+    file_by_id = graphene.Field(DownloadFileDTO, id=graphene.Int(required=True))
     stories = graphene.Field(graphene.List(StoryResponseDTO))
     story_by_id = graphene.Field(StoryResponseDTO, id=graphene.Int(required=True))
     story_translations = graphene.relay.ConnectionField(

--- a/backend/python/app/graphql/types/file_type.py
+++ b/backend/python/app/graphql/types/file_type.py
@@ -13,3 +13,4 @@ class CreateFileDTO(graphene.InputObjectType):
 class DownloadFileDTO(graphene.ObjectType):
     id = graphene.Int()
     file = graphene.String(required=True)
+    ext = graphene.String(required=True)

--- a/backend/python/app/graphql/types/file_type.py
+++ b/backend/python/app/graphql/types/file_type.py
@@ -8,3 +8,8 @@ class FileDTO(graphene.ObjectType):
 
 class CreateFileDTO(graphene.InputObjectType):
     path = graphene.String(required=True)
+
+
+class DownloadFileDTO(graphene.ObjectType):
+    id = graphene.Int()
+    file = graphene.String(required=True)

--- a/backend/python/app/services/implementations/file_service.py
+++ b/backend/python/app/services/implementations/file_service.py
@@ -22,7 +22,10 @@ class FileService(IFileService):
             # encode file data as base64 string
             file_bytes = open(file.path, "rb").read()
             encoded = b64encode(file_bytes).decode("utf-8")
-            return DownloadFileDTO(id=id, file=encoded)
+
+            # extract extension and path
+            _, file_extension = os.path.splitext(file.path)
+            return DownloadFileDTO(id=id, file=encoded, ext=file_extension[1:])
         except Exception as e:
             reason = getattr(e, "message", None)
             self.logger.error(

--- a/backend/python/app/services/implementations/file_service.py
+++ b/backend/python/app/services/implementations/file_service.py
@@ -1,5 +1,7 @@
 import os
+from base64 import b64encode
 
+from ...graphql.types.file_type import DownloadFileDTO
 from ...models import db
 from ...models.file import File
 from ..interfaces.file_service import IFileService
@@ -10,11 +12,25 @@ class FileService(IFileService):
         self.logger = logger
 
     def get_file(self, id):
-        file = File.query.get(id)
-        if file is None:
-            self.logger.error(f"Invalid id {id}")
-            raise Exception(f"Invalid id {id}")
-        return file.to_dict()
+        try:
+            file = File.query.get(id)
+
+            if not file:
+                self.logger.error(f"Invalid file id: {id}")
+                raise Exception(f"Invalid file id: {id}")
+
+            # encode file data as base64 string
+            file_bytes = open(file.path, "rb").read()
+            encoded = b64encode(file_bytes).decode("utf-8")
+            return DownloadFileDTO(id=id, file=encoded)
+        except Exception as e:
+            reason = getattr(e, "message", None)
+            self.logger.error(
+                "Failed to get file. Reason = {reason}".format(
+                    reason=(reason if reason else str(e))
+                )
+            )
+            raise e
 
     def generate_file_name(self, filename):
         # append number to the filename if duplicate filename found

--- a/backend/python/app/services/interfaces/file_service.py
+++ b/backend/python/app/services/interfaces/file_service.py
@@ -3,17 +3,17 @@ from abc import ABC, abstractmethod
 
 class IFileService(ABC):
     """
-    A class to handle CRUD functionality for entities
+    A class to handle CRUD functionality for file entities
     """
 
     @abstractmethod
     def get_file(self, id):
-        """Return a dictionary from the File object based on id
+        """Return a File and its contents based on id
 
         :param id: File id
-        :return: dictionary of File object
-        :rtype: dictionary
-        :raises Exception: id retrieval fails
+        :return: DownloadFileDTO containing file data
+        :rtype: DownloadFileDTO
+        :raises Exception: id retrieval fails or base64 encoding fails
         """
         pass
 


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Download-files-via-fileById-cce5b4acf4b0455981e6452e294eec77

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- implement `fileById` query by converting file data to a base64 string and returning it in a `DownloadFileDTO`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. start docker containers
2. in any directory, run `curl http://localhost:5000/graphql -F operations='{"query": "mutation ($file: Upload!) { createFile(file: $file) { ok }}", "variables": {"file": null }}' -F map='{ "0": ["variables.file"]}' -F 0=@file_name.txt`, replacing `file_name.txt` with any file in the directory to upload the file
3. in Altair, login as any user and run the query below
4. verify that the query succeeds and the file string is returned
5. if you want to verify that the string encoded properly, copy and run the following code in `codesandbox.io`

```
// Retrieved from https://developer.mozilla.org/en-US/docs/Glossary/Base64
function b64_to_utf8(str) {
  return decodeURIComponent(escape(atob(str)));
}
const b64String = "FILE_STRING_HERE";
const decoded = b64_to_utf8(b64String);
console.log(decoded);
```
**Note**: I'm not sure if the above ^ works for decoding non-`.txt` files

#### fileById query
```
query Download {
  fileById(id: 1) {
    id
    file
  }
}
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work for files that aren't `.txt` files? e.g. `.pdf`, `.docx`

Also, should we include a `fileName` field in the `DownloadFileDTO`? I'm thinking it'll be useful to at least return the file extension

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
