### PR TITLE
Implement demoting language level flow

### DIFF
--- a/frontend/src/components/admin/ApprovedLanguagesTableComponent.tsx
+++ b/frontend/src/components/admin/ApprovedLanguagesTableComponent.tsx
@@ -119,7 +119,7 @@ const ApprovedLanguagesTableComponent = ({
         <Td colSpan={4} align="center">
           <Slider
             isDisabled={!isAdmin}
-            defaultValue={approvedLanguage.level}
+            value={approvedLanguage.level}
             min={1}
             max={4}
             step={1}

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -94,3 +94,8 @@ export const GRADING_PAGE_FAIL_USER_CONFIRMATION =
   "By failing this user, they have to wait for 30 days before they can take this test again.";
 
 export const GRADING_PAGE_FAIL_USER_BUTTON = "I'm sure, fail user";
+
+export const DEMOTE_LEVEL_CONFIRMATION =
+  "By lowering the level at this language, the user will no longer be able to start translating or reviewing story translations at this level, in this language. The user will continue having access to any ongoing story translations at this level, in this langauge.";
+
+export const DEMOTE_LEVEL_BUTTON = "I'm sure, lower level";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Implement demoting language level flow](https://www.notion.so/uwblueprintexecs/Implement-demoting-language-level-flow-4f23433446704bda876f4c1f3bc9846a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- show modal when admin attempts to demote user's approved level

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin
2. Click on any user page (http://localhost:3000/#/user/:id)
3. Move the slider to a lower approved level for a translation language
4. Confirm that confirmation modal shows up
5. Close the modal and confirm the approved level is unchanged and no gql calls were made
6. Move slider to a lower approved level for a translation language again
7. Confirm that confirmation modal shows up, and click `I'm sure, lower level`
8. Verify that approved language is lowered
9. Repeats steps 3-8 for a review language

___Sanity Checks:___
10. Confirm that you can still delete an approved language
11. Confirm that you can still add an approved language
12. Login as a regular user and confirm the profile user page still works as expected

![demote level](https://user-images.githubusercontent.com/32009013/147416928-53928656-1b45-4d08-bbf3-95a37f1e11f5.gif)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- is there a better way to temporarily save the mutation arguments while the confirmation modal is shown?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
