### PR TITLE
Fix: correct story table link and stories query

### DIFF
--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -6,7 +6,6 @@ export const STORY_FIELDS = `
     description
     youtubeLink
     level
-    dateUploaded
     `;
 
 export type Story = {
@@ -34,6 +33,7 @@ export const GET_STORIES = () =>
       query GetStories {
         stories {
           ${STORY_FIELDS}
+          dateUploaded
         }
       }
     `;

--- a/frontend/src/components/admin/StoriesTable.tsx
+++ b/frontend/src/components/admin/StoriesTable.tsx
@@ -96,7 +96,7 @@ const StoriesTable = ({ stories, setStories }: StoriesTableProps) => {
       key={`${story.id}`}
     >
       <Td>
-        <Link isExternal href={`/story/${story.id}`}>
+        <Link isExternal href={`#/story/${story.id}`}>
           {story.title}
         </Link>
       </Td>


### PR DESCRIPTION

## Implementation description

- story link on manage stories table works now
  - couldnt find any other hrefs that dont follow our new /#/ pattern
- homepage loads correctly. There is no dateUploaded field on the StoryTranslationDTO but I accidentally included it on #243 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as angela
2. manage stories
3. click links
4. profit
5. login as carl/any user
6. load homepage
7. profit

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- is it lit

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
