### PR TITLE
Allow users to upload resume

### DIFF
--- a/backend/python/app/graphql/mutations/file_mutation.py
+++ b/backend/python/app/graphql/mutations/file_mutation.py
@@ -2,7 +2,6 @@ import os
 
 import graphene
 from graphene_file_upload.scalars import Upload
-from werkzeug.utils import secure_filename
 
 from ..service import services
 from ..types.file_type import CreateFileDTO, FileDTO
@@ -18,17 +17,7 @@ class CreateFile(graphene.Mutation):
 
     def mutate(root, info, file=None):
         try:
-            upload_folder_path = os.getenv("UPLOAD_PATH")
-            upload_path = os.path.join(
-                upload_folder_path, secure_filename(file.filename)
-            )
-            if os.path.isfile(upload_path):
-                upload_path = services["file"].generate_file_name(
-                    secure_filename(file.filename)
-                )
-            file.save(upload_path)
-            file_dto = FileDTO(path=upload_path)
-            res = services["file"].create_file(file_dto)
+            res = services["file"].create_file(file)
             return CreateFile(file=res, ok=True)
         except Exception as e:
             error_message = getattr(e, "message", None)

--- a/backend/python/app/graphql/mutations/user_mutation.py
+++ b/backend/python/app/graphql/mutations/user_mutation.py
@@ -1,4 +1,5 @@
 import graphene
+from graphene_file_upload.scalars import Upload
 
 from ...middlewares.auth import (
     get_user_id_from_request,
@@ -26,16 +27,18 @@ class CreateUser(graphene.Mutation):
 class UpdateMe(graphene.Mutation):
     class Arguments:
         user = UpdateUserDTO(required=True)
+        resume = Upload(required=True)
 
     user = graphene.Field(lambda: UserDTO)
 
-    def mutate(root, info, user):
+    def mutate(root, info, user, resume=None):
         """
         Update the user that made the request
         """
         try:
             user_id = get_user_id_from_request()
-            updated_user = services["user"].update_me(user_id, user)
+            res = services["file"].create_file(resume)
+            updated_user = services["user"].update_me(user_id, user, res)
             return UpdateMe(user=updated_user)
         except Exception as e:
             error_message = getattr(e, "message", None)

--- a/backend/python/app/graphql/mutations/user_mutation.py
+++ b/backend/python/app/graphql/mutations/user_mutation.py
@@ -27,7 +27,7 @@ class CreateUser(graphene.Mutation):
 class UpdateMe(graphene.Mutation):
     class Arguments:
         user = UpdateUserDTO(required=True)
-        resume = Upload(required=True)
+        resume = Upload(required=False)
 
     user = graphene.Field(lambda: UserDTO)
 

--- a/backend/python/app/services/implementations/user_service.py
+++ b/backend/python/app/services/implementations/user_service.py
@@ -234,7 +234,7 @@ class UserService(IUserService):
         new_user_dict["email"] = user.email
         return UserDTO(**new_user_dict)
 
-    def update_me(self, user_id, user):
+    def update_me(self, user_id, user, resume):
         # TODO: start a new story test for given language when user wants to increase their level
         try:
             old_user = User.query.get(user_id)
@@ -247,7 +247,7 @@ class UserService(IUserService):
                     User.first_name: user.first_name,
                     User.last_name: user.last_name,
                     User.email: user.email,
-                    User.resume: user.resume,
+                    User.resume: resume["id"],
                     User.profile_pic: user.profile_pic,
                     User.additional_experiences: user.additional_experiences,
                 }


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Upload user’s resume](https://www.notion.so/uwblueprintexecs/Upload-user-s-resume-df9deacce79b41bda5907e9605a29150)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Moved the folder path logic to create_file 
- Allow users to upload a resume when in UpdateMe mutation

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as a user and copy the access token ([i.e. carl sagan](http://localhost:5000/graphql?variables=null&operationName=undefined&query=%0Amutation%20%7B%0A%20%20login%20(email%3A%22planetread%2Bcarlsagan%40uwblueprint.org%22%2C%20password%3A%22%22)%20%7B%0A%20%20%20%20accessToken%0A%20%20%20%20refreshToken%0A%20%20%20%20id%0A%20%20%7D%0A%7D))
2. Using your access token and a path to a file, try `curl http://localhost:5000/graphql -F operations='{"query": "mutation ($file: Upload!) { updateMe(resume: $file, user:{firstName: \"Carl\", lastName: \"Sagan\", email:\"planetread+carlsagan@uwblueprint.org\"}) { user {id} }}","variables": {"file": null}}' -F map='{ "0": ["variables.file"]}' -F 0=@resume.txt -H "Authorization: Bearer <AccessToken>"`
3. Check that the path in the files table is correct 
4. Check that the resume column in the users table updated with the correct file id 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work correctly?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
