### PR TITLE
Enable admin to download resume

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@types/react-table": "^7.0.29",
     "axios": "^0.21.2",
     "bootstrap": "^4.6.0",
+    "file-saver": "^2.0.5",
     "framer-motion": "^4",
     "graphql": "^15.5.0",
     "humps": "^2.0.1",
@@ -71,6 +72,7 @@
     ]
   },
   "devDependencies": {
+    "@types/file-saver": "^2.0.4",
     "@types/humps": "^2.0.0",
     "@types/jsonwebtoken": "^8.5.1",
     "@types/react-router-dom": "^5.1.7",

--- a/frontend/src/APIClients/queries/FileQueries.ts
+++ b/frontend/src/APIClients/queries/FileQueries.ts
@@ -1,0 +1,17 @@
+import { gql } from "@apollo/client";
+
+export type File = {
+  id: number;
+  file: string;
+  ext: string;
+};
+
+export const GET_FILE = gql`
+  query GetFile($id: Int!) {
+    fileById(id: $id) {
+      id
+      ext
+      file
+    }
+  }
+`;

--- a/frontend/src/APIClients/queries/UserQueries.ts
+++ b/frontend/src/APIClients/queries/UserQueries.ts
@@ -17,6 +17,7 @@ export type User = {
   firstName: string;
   lastName: string;
   email: string;
+  resume: number;
   approvedLanguagesTranslation: string;
   approvedLanguagesReview: string;
 } | null;

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -35,6 +35,7 @@ import ApprovedLanguagesTable from "../admin/ApprovedLanguagesTable";
 import AssignedStoryTranslationsTable from "../userProfile/AssignedStoryTranslationsTable";
 import { StoryAssignStage } from "../../constants/Enums";
 import InfoAlert from "../utils/InfoAlert";
+import { useFileDownload } from "../../utils/FileUtils";
 
 type UserProfilePageProps = {
   userId: string;
@@ -51,6 +52,7 @@ const UserProfilePage = () => {
   const [fullName, setFullName] = useState<string>("");
   const [email, setEmail] = useState<string>("");
   const [role, setRole] = useState<string>("");
+  const [resumeId, setResumeId] = useState<number | null>(null);
   const [confirmDeleteUser, setConfirmDeleteUser] = useState(false);
   const [alertText, setAlertText] = useState<string>("");
   const [alert, setAlert] = useState(false);
@@ -70,6 +72,8 @@ const UserProfilePage = () => {
 
   const history = useHistory();
 
+  const [downloadFile] = useFileDownload(resumeId, "resume");
+
   const { loading, error } = useQuery(GET_USER(parseInt(userId, 10)), {
     fetchPolicy: "cache-and-network",
     onCompleted: (data: { userById: User }) => {
@@ -82,6 +86,7 @@ const UserProfilePage = () => {
       );
       setFullName(`${user?.firstName} ${user?.lastName}`);
       setEmail(user?.email!);
+      setResumeId(user?.resume!);
       setApprovedLanguagesTranslation(translationLanguages);
       setApprovedLanguagesReview(reviewLanguages);
       setRole(
@@ -148,6 +153,17 @@ const UserProfilePage = () => {
             Last active on
           </Heading>
           <Text>TODO</Text>
+          {isAdmin && (
+            <>
+              <Heading size="sm" marginTop="36px">
+                User Files
+              </Heading>
+              {/* TODO: replace file name */}
+              <Button variant="link" onClick={() => downloadFile()}>
+                resume.pdf
+              </Button>
+            </>
+          )}
         </Flex>
         <Flex direction="column" margin="40px" flex={1}>
           {!isAdmin && <UserProfileForm isSignup={false} />}

--- a/frontend/src/theme/components/Button.ts
+++ b/frontend/src/theme/components/Button.ts
@@ -88,6 +88,13 @@ const Button = {
       textTransform: "capitalize",
       width: "40px",
     },
+    link: {
+      fontSize: "16px",
+      textTransform: "lowercase",
+      textDecoration: "underline",
+      width: "fit-content",
+      fontWeight: "normal",
+    },
   },
 };
 export default Button;

--- a/frontend/src/utils/FileUtils.ts
+++ b/frontend/src/utils/FileUtils.ts
@@ -1,0 +1,72 @@
+import { useLazyQuery } from "@apollo/client";
+import { saveAs } from "file-saver";
+import { File, GET_FILE } from "../APIClients/queries/FileQueries";
+
+// Retrieved from: https://stackoverflow.com/a/16245768
+const b64toBlob = (
+  b64Data: string,
+  contentType = "",
+  sliceSize = 512,
+): Blob => {
+  const byteCharacters = atob(b64Data);
+  const byteArrays = [];
+
+  for (let offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+    const slice = byteCharacters.slice(offset, offset + sliceSize);
+
+    const byteNumbers = new Array(slice.length);
+    for (let i = 0; i < slice.length; i += 1) {
+      byteNumbers[i] = slice.charCodeAt(i);
+    }
+
+    const byteArray = new Uint8Array(byteNumbers);
+    byteArrays.push(byteArray);
+  }
+
+  const blob = new Blob(byteArrays, { type: contentType });
+  return blob;
+};
+
+const getMIMETypeFromExtension = (ext: string) => {
+  switch (ext) {
+    case "txt":
+      return "text/plain;charset=utf-8";
+    case "png":
+      return "image/png";
+    case "jpg":
+      return "image/jpeg";
+    case "jpeg":
+      return "image/jpeg";
+    case "doc":
+      return "application/msword";
+    case "docx":
+      return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    case "pdf":
+      return "application/pdf";
+    default:
+      return "application/octet-stream";
+  }
+};
+
+/*
+ * A hook that retrieves a file through GraphQL and downloads the file.
+ *
+ * @param id - The file id
+ * @param filename - The filename to save as
+ *
+ * @returns downloadFile - A function used to download the file
+ */
+/* eslint-disable-next-line import/prefer-default-export */
+export const useFileDownload = (id: number | null, filename: string) => {
+  const [getFile] = useLazyQuery(GET_FILE, {
+    variables: { id },
+    onCompleted: (data: { fileById: File }) => {
+      const { ext, file } = data.fileById;
+      const blob = b64toBlob(file, getMIMETypeFromExtension(ext));
+      saveAs(blob, `${filename}.${ext}`);
+    },
+  });
+
+  const downloadFile = id ? getFile : () => {};
+  return [downloadFile];
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2600,6 +2600,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/file-saver@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.4.tgz#aaf9b96296150d737b2fefa535ced05ed8013d84"
+  integrity sha512-sPZYQEIF/SOnLAvaz9lTuydniP+afBMtElRTdYkeV1QtEgvtJ7qolCPjly6O32QI8CbEmP5O/fztMXEDWfEcrg==
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -6302,6 +6307,11 @@ file-loader@6.1.1:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
+
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
 file-uri-to-path@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Enable-admin-to-download-resume-f1ddd118506b466b8e33b1b376ee8467

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- add "User files" sidebar section to `UserProfilePage.tsx` for admins
- implement utility functions to download files
- created `useFileDownload` hook to encapsulate generic file download logic

for backend implementation, see https://github.com/uwblueprint/planet-read/pull/244

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. `docker-compose up --build`
2. Upload a few files (ideally pdf) using curl: `curl http://localhost:5000/graphql -F operations='{"query": "mutation ($file: Upload!) { createFile(file: $file) { ok }}", "variables": {"file": null }}' -F map='{ "0": ["variables.file"]}' -F 0=@file_name.pdf`
3. set resume of carl sagan to file id: `docker exec -it planet-read_db_1 mysql -u root -proot -e "UPDATE users SET resume=FILE_ID_HERE WHERE id=1;"`
4. Login as admin and go to `http://localhost:3000/#/user/1`
5. Click on "resume.pdf"
6. Verify that the file is downloaded and is the same as the file you uploaded
7. feel free to upload and test with different files (i tested with pdf, docx, txt)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?
- does the `useFileDownload` hook make sense?
- how should we display the filename under "User files"? right now it's hardcoded to resume.pdf` but another option is to fetch the complete filename from the backend instead of just the extension

![image](https://user-images.githubusercontent.com/45080644/147488715-b8ca6c7b-23c7-477e-9e34-ded8566f5cab.png)

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
