### PR TITLE
Implement add new language flow for users

### DIFF
--- a/frontend/src/components/pages/NewLanguageModal.tsx
+++ b/frontend/src/components/pages/NewLanguageModal.tsx
@@ -55,13 +55,13 @@ const NewLanguageModal = ({
         </ModalHeader>
         <ModalBody margin="-10px 0 15px 0">
           <Text marginBottom="40px" fontSize="sm">
-            Before you can translate a new language, the book test for that
-            language must be completed first. This process may take more than
-            one week.
+            Before you can translate in a new language, you must pass a story
+            translation test in that language. Platform admins will mark your
+            test upon completion. This process may take more than one week.
           </Text>
           <Text marginBottom="20px">
-            Please select a new language that you would like to take the book
-            test in.
+            Please select a new language that you would like to take the story
+            translation test in.
           </Text>
           <Flex marginBottom="200px">
             <Select

--- a/frontend/src/components/pages/NewLanguageModal.tsx
+++ b/frontend/src/components/pages/NewLanguageModal.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+import Select from "react-select";
+import {
+  Button,
+  Flex,
+  Heading,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  Tooltip,
+} from "@chakra-ui/react";
+import { colourStyles } from "../../theme/components/Select";
+import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
+import DropdownIndicator from "../utils/DropdownIndicator";
+import { languageOptions } from "../../constants/Languages";
+
+export type NewLanguageModalProps = {
+  addNewTest: (newLanguage: string) => void;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const NewLanguageModal = ({
+  addNewTest,
+  isOpen,
+  onClose,
+}: NewLanguageModalProps) => {
+  const [newLanguage, setNewLanguage] = useState<string>("");
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="3xl">
+      <ModalOverlay />
+      <ModalContent padding="10px" marginTop="200px">
+        <ModalCloseButton position="static" marginLeft="auto" />
+        <ModalHeader paddingTop="-10px">
+          <Heading as="h3" size="lg">
+            Add New Language
+          </Heading>
+        </ModalHeader>
+        <ModalBody margin="-10px 0 15px 0">
+          <Text marginBottom="40px" fontSize="sm">
+            Before you can translate a new language, the book test for that
+            language must be completed first. This process may take more than
+            one week.
+          </Text>
+          <Text marginBottom="20px">
+            Please select a new language that you would like to take the book
+            test in.
+          </Text>
+          <Flex marginBottom="200px">
+            <Select
+              components={{ DropdownIndicator }}
+              getOptionLabel={(option: any) =>
+                convertLanguageTitleCase(option.value)
+              }
+              onChange={(option: any) => setNewLanguage(option?.value || "")}
+              options={languageOptions}
+              placeholder="Select language"
+              styles={colourStyles}
+            />
+          </Flex>
+          <Tooltip
+            hasArrow
+            isDisabled={newLanguage !== ""}
+            label="Please select a language to add first"
+            placement="top"
+          >
+            <Flex float="right" width="20%">
+              <Button
+                colorScheme="blue"
+                disabled={newLanguage === ""}
+                onClick={() => addNewTest(newLanguage)}
+              >
+                ADD TEST
+              </Button>
+            </Flex>
+          </Tooltip>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default NewLanguageModal;

--- a/frontend/src/components/pages/NewLanguageModal.tsx
+++ b/frontend/src/components/pages/NewLanguageModal.tsx
@@ -13,6 +13,7 @@ import {
   Text,
   Tooltip,
 } from "@chakra-ui/react";
+import { ApprovedLanguagesMap } from "../../utils/Utils";
 import { colourStyles } from "../../theme/components/Select";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 import DropdownIndicator from "../utils/DropdownIndicator";
@@ -20,16 +21,27 @@ import { languageOptions } from "../../constants/Languages";
 
 export type NewLanguageModalProps = {
   addNewTest: (newLanguage: string) => void;
+  approvedLanguagesTranslation: ApprovedLanguagesMap | undefined;
   isOpen: boolean;
   onClose: () => void;
 };
 
 const NewLanguageModal = ({
   addNewTest,
+  approvedLanguagesTranslation,
   isOpen,
   onClose,
 }: NewLanguageModalProps) => {
   const [newLanguage, setNewLanguage] = useState<string>("");
+  const unapprovedLanguageOptions = languageOptions.filter(function (obj) {
+    return (
+      !approvedLanguagesTranslation ||
+      !Object.prototype.hasOwnProperty.call(
+        approvedLanguagesTranslation,
+        obj.value,
+      )
+    );
+  });
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="3xl">
@@ -58,7 +70,7 @@ const NewLanguageModal = ({
                 convertLanguageTitleCase(option.value)
               }
               onChange={(option: any) => setNewLanguage(option?.value || "")}
-              options={languageOptions}
+              options={unapprovedLanguageOptions}
               placeholder="Select language"
               styles={colourStyles}
             />

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -298,6 +298,7 @@ const UserProfilePage = () => {
       {addNewLanguage && (
         <NewLanguageModal
           addNewTest={addNewTest}
+          approvedLanguagesTranslation={approvedLanguagesTranslation}
           isOpen={addNewLanguage}
           onClose={closeNewLanguageModal}
         />

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -21,6 +21,8 @@ import {
   MANAGE_USERS_TABLE_DELETE_USER_BUTTON,
   MANAGE_USERS_TABLE_DELETE_USER_CONFIRMATION,
   NEW_BOOK_TEST_ADDED_BUTTON,
+  NEW_BOOK_TEST_ADDED_HEADING,
+  NEW_BOOK_TEST_ADDED_MESSAGE,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
 import { GET_USER, User } from "../../APIClients/queries/UserQueries";
@@ -307,8 +309,8 @@ const UserProfilePage = () => {
         confirmation={alertNewTest}
         onClose={closeNewTestModal}
         onConfirmationClick={() => history.push("/")}
-        confirmationHeading="New Book Test Added"
-        confirmationMessage="The book test to add a new language has been added to the homepage. Please take one of the two tests available."
+        confirmationHeading={NEW_BOOK_TEST_ADDED_HEADING}
+        confirmationMessage={NEW_BOOK_TEST_ADDED_MESSAGE}
         buttonMessage={NEW_BOOK_TEST_ADDED_BUTTON}
       />
     </Flex>

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -20,6 +20,7 @@ import {
 import {
   MANAGE_USERS_TABLE_DELETE_USER_BUTTON,
   MANAGE_USERS_TABLE_DELETE_USER_CONFIRMATION,
+  NEW_BOOK_TEST_ADDED_BUTTON,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
 import { GET_USER, User } from "../../APIClients/queries/UserQueries";
@@ -33,8 +34,13 @@ import {
 } from "../../utils/Utils";
 import ApprovedLanguagesTable from "../admin/ApprovedLanguagesTable";
 import AssignedStoryTranslationsTable from "../userProfile/AssignedStoryTranslationsTable";
+import NewLanguageModal from "./NewLanguageModal";
 import { StoryAssignStage } from "../../constants/Enums";
 import InfoAlert from "../utils/InfoAlert";
+import {
+  CREATE_TRANSLATION_TEST,
+  CreateTranslationTestResponse,
+} from "../../APIClients/mutations/StoryMutations";
 
 type UserProfilePageProps = {
   userId: string;
@@ -67,6 +73,9 @@ const UserProfilePage = () => {
   const [storyAssignStage, setStoryAssignStage] = useState<StoryAssignStage>(
     StoryAssignStage.INITIAL,
   );
+
+  const [addNewLanguage, setAddNewLanguage] = useState(false);
+  const [alertNewTest, setAlertNewTest] = useState(false);
 
   const history = useHistory();
 
@@ -123,6 +132,40 @@ const UserProfilePage = () => {
 
   const filterStyle = useStyleConfig("Filter");
 
+  const [createTranslationTest] = useMutation<{
+    response: CreateTranslationTestResponse;
+  }>(CREATE_TRANSLATION_TEST);
+
+  const openNewLanguageModal = () => {
+    setAddNewLanguage(true);
+  };
+
+  const closeNewLanguageModal = () => {
+    setAddNewLanguage(false);
+  };
+
+  const closeNewTestModal = () => {
+    setAlertNewTest(false);
+  };
+
+  const addNewTest = async (newLanguage: string) => {
+    try {
+      await createTranslationTest({
+        variables: {
+          userId,
+          level: 2,
+          language: newLanguage,
+        },
+      });
+      closeNewLanguageModal();
+      setAlertNewTest(true);
+    } catch (err) {
+      window.alert(err);
+      closeNewLanguageModal();
+      closeNewTestModal();
+    }
+  };
+
   if (loading) return <div />;
   if (error) return <Redirect to="/404" />;
 
@@ -151,9 +194,17 @@ const UserProfilePage = () => {
         </Flex>
         <Flex direction="column" margin="40px" flex={1}>
           {!isAdmin && <UserProfileForm isSignup={false} />}
-          <Heading size="lg" marginTop="40px" marginBottom="10px">
-            Approved Languages & Levels
-          </Heading>
+          <Flex justifyContent="space-between" margin="40px 0 10px 0">
+            <Heading size="lg"> Approved Languages & Levels </Heading>
+            <Button
+              colorScheme="blue"
+              onClick={() => openNewLanguageModal()}
+              variant="blueOutline"
+              width="250px"
+            >
+              ADD NEW LANGUAGE +
+            </Button>
+          </Flex>
           {isAdmin &&
             (alert ? (
               <InfoAlert message={alertText} colour="orange.50" />
@@ -244,6 +295,21 @@ const UserProfilePage = () => {
           buttonMessage={MANAGE_USERS_TABLE_DELETE_USER_BUTTON}
         />
       )}
+      {addNewLanguage && (
+        <NewLanguageModal
+          addNewTest={addNewTest}
+          isOpen={addNewLanguage}
+          onClose={closeNewLanguageModal}
+        />
+      )}
+      <ConfirmationModal
+        confirmation={alertNewTest}
+        onClose={closeNewTestModal}
+        onConfirmationClick={() => history.push("/")}
+        confirmationHeading="New Book Test Added"
+        confirmationMessage="The book test to add a new language has been added to the homepage. Please take one of the two tests available."
+        buttonMessage={NEW_BOOK_TEST_ADDED_BUTTON}
+      />
     </Flex>
   );
 };


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Implement add new language flow for users](https://www.notion.so/uwblueprintexecs/Implement-add-new-language-flow-for-users-3ac4368314d74d239b896d70ca7b1cd2)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Created add new language modal for user to select a new language
- Adds a level 2 test for that language using create translation test mutation
- Existing confirmation modal is used to redirect user to homepage after test is added

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl (or another translator/reviewer)
2. Go to profile page
3. Click the add new language button
4. Hover over add test to see a tooltip
5. Select a language from the dropdown (verify that the drop down does not contain any already approved languages for translation)
6. Click add test
7. Click take me to homepage on the confirmation modal
8. Go to my tests tab and verify that the test has been added
9. Between steps 3-7, test closing both the add new language and new test added modals
10. Repeat steps for other languages if desired
11. Verify that adding the same new language twice results in an error (after clicking add test, an alert will show "Error: User has an ongoing story translation test for language {language}.", closing this alert closes the modal)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work as expected?
- Does the styling look good?
- Does the code look ok?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
