### PR TITLE
Remove useless cancel/save buttons on Admin view of UserProfile

### DIFF
--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -1,13 +1,6 @@
 import React, { useContext, useState } from "react";
 import { useParams, useHistory, Redirect } from "react-router-dom";
-import {
-  Box,
-  Button,
-  Flex,
-  Heading,
-  Text,
-  useStyleConfig,
-} from "@chakra-ui/react";
+import { Button, Flex, Heading, Text, useStyleConfig } from "@chakra-ui/react";
 import { useQuery, useMutation } from "@apollo/client";
 
 import AuthContext from "../../contexts/AuthContext";
@@ -286,23 +279,6 @@ const UserProfilePage = () => {
             </>
           )}
         </Flex>
-      </Flex>
-      <Flex
-        alignItems="center"
-        boxShadow="0 0 12px -9px rgba(0, 0, 0, 0.7)"
-        direction="row"
-        height="90px"
-        justify="flex-end"
-        padding="20px 30px"
-      >
-        <Box>
-          <Button colorScheme="blue" variant="blueOutline">
-            Cancel
-          </Button>
-          <Button colorScheme="blue" marginLeft="24px" marginRight="48px">
-            Save Changes
-          </Button>
-        </Box>
       </Flex>
       {confirmDeleteUser && (
         <ConfirmationModal


### PR DESCRIPTION


## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Remove useless cancel/save buttons on Admin view of UserProfile](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=512100b41a2845e6973cb4e128095646)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Remove buttons in `UserProfilePage.tsx`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to user profile page and make sure there are no **Save** and **Cancel** buttons

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- morality

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
