### PR TITLE
Add functionality to completeprofile page

### DIFF
--- a/backend/python/app/graphql/mutations/user_mutation.py
+++ b/backend/python/app/graphql/mutations/user_mutation.py
@@ -37,7 +37,9 @@ class UpdateMe(graphene.Mutation):
         """
         try:
             user_id = get_user_id_from_request()
-            res = services["file"].create_file(resume)
+            res = None
+            if resume:
+                res = services["file"].create_file(resume)
             updated_user = services["user"].update_me(user_id, user, res)
             return UpdateMe(user=updated_user)
         except Exception as e:

--- a/backend/python/app/services/implementations/user_service.py
+++ b/backend/python/app/services/implementations/user_service.py
@@ -234,7 +234,7 @@ class UserService(IUserService):
         new_user_dict["email"] = user.email
         return UserDTO(**new_user_dict)
 
-    def update_me(self, user_id, user, resume):
+    def update_me(self, user_id, user, resume=None):
         # TODO: start a new story test for given language when user wants to increase their level
         try:
             old_user = User.query.get(user_id)
@@ -242,16 +242,27 @@ class UserService(IUserService):
             if not old_user:
                 raise Exception("user_id {user_id} not found".format(user_id=user_id))
 
-            User.query.filter_by(id=user_id).update(
-                {
-                    User.first_name: user.first_name,
-                    User.last_name: user.last_name,
-                    User.email: user.email,
-                    User.resume: resume["id"],
-                    User.profile_pic: user.profile_pic,
-                    User.additional_experiences: user.additional_experiences,
-                }
-            )
+            if resume:
+                User.query.filter_by(id=user_id).update(
+                    {
+                        User.first_name: user.first_name,
+                        User.last_name: user.last_name,
+                        User.email: user.email,
+                        User.resume: resume["id"],
+                        User.profile_pic: user.profile_pic,
+                        User.additional_experiences: user.additional_experiences,
+                    }
+                )
+            else:
+                User.query.filter_by(id=user_id).update(
+                    {
+                        User.first_name: user.first_name,
+                        User.last_name: user.last_name,
+                        User.email: user.email,
+                        User.profile_pic: user.profile_pic,
+                        User.additional_experiences: user.additional_experiences,
+                    }
+                )
 
             db.session.commit()
 

--- a/frontend/src/APIClients/mutations/UserMutations.ts
+++ b/frontend/src/APIClients/mutations/UserMutations.ts
@@ -34,3 +34,19 @@ export type UpdateUserApprovedLanguagesResponse = {
     id: number;
   };
 };
+
+export const UPDATE_ME = gql`
+  mutation UpdateMe($userData: UpdateUserDTO!) {
+    updateMe(user: $userData) {
+      user {
+        id
+      }
+    }
+  }
+`;
+
+export type UpdateMeResponse = {
+  user: {
+    id: number;
+  };
+};

--- a/frontend/src/components/pages/CompleteProfilePage.tsx
+++ b/frontend/src/components/pages/CompleteProfilePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { useMutation } from "@apollo/client";
 import { Box, Button, Flex } from "@chakra-ui/react";
 import Header from "../navigation/Header";
@@ -7,13 +7,19 @@ import {
   UPDATE_ME,
   UpdateMeResponse,
 } from "../../APIClients/mutations/UserMutations";
+import AuthContext from "../../contexts/AuthContext";
 
 const CompleteProfilePage = () => {
-  const [name, setFullName] = useState("");
-  const [email, setEmail] = useState("");
+  const { authenticatedUser } = useContext(AuthContext);
+
+  const fullName = `${authenticatedUser!!.firstName} ${
+    authenticatedUser!!.lastName
+  }`;
+
+  const [name, setFullName] = useState(fullName);
+  const [email, setEmail] = useState(authenticatedUser!!.email);
   const [educationalQualification, setEducationalQualification] = useState("");
   const [languageExperience, setLanguageExperience] = useState("");
-
   const [updateMe] = useMutation<{
     response: UpdateMeResponse;
   }>(UPDATE_ME);
@@ -37,7 +43,7 @@ const CompleteProfilePage = () => {
       });
       window.location.href = `#/?welcome=true`;
     } catch (err) {
-      console.log(err);
+      window.alert(err);
     }
   };
 
@@ -46,6 +52,8 @@ const CompleteProfilePage = () => {
       <Header />
       <Flex direction="row" flex={1} margin="40px" marginLeft="90px">
         <UserProfileForm
+          fullName={name}
+          email={email}
           setFullName={setFullName}
           setEmail={setEmail}
           setEducationalQualification={setEducationalQualification}

--- a/frontend/src/components/pages/CompleteProfilePage.tsx
+++ b/frontend/src/components/pages/CompleteProfilePage.tsx
@@ -1,18 +1,56 @@
-import React from "react";
+import React, { useState } from "react";
+import { useMutation } from "@apollo/client";
 import { Box, Button, Flex } from "@chakra-ui/react";
 import Header from "../navigation/Header";
 import UserProfileForm from "../userProfile/UserProfileForm";
+import {
+  UPDATE_ME,
+  UpdateMeResponse,
+} from "../../APIClients/mutations/UserMutations";
 
 const CompleteProfilePage = () => {
-  const onSubmitClick = () => {
-    window.location.href = `#/?welcome=true`;
+  const [name, setFullName] = useState("");
+  const [email, setEmail] = useState("");
+  const [educationalQualification, setEducationalQualification] = useState("");
+  const [languageExperience, setLanguageExperience] = useState("");
+
+  const [updateMe] = useMutation<{
+    response: UpdateMeResponse;
+  }>(UPDATE_ME);
+
+  const onSubmitClick = async () => {
+    try {
+      const [firstName, lastName] = name.split(" ");
+      const tempAdditionalExperiences = {
+        educationalQualification,
+        languageExperience,
+      };
+      const additionalExperiences = JSON.stringify(tempAdditionalExperiences);
+      const userData = {
+        firstName,
+        lastName,
+        email,
+        additionalExperiences,
+      };
+      await updateMe({
+        variables: { userData },
+      });
+      window.location.href = `#/?welcome=true`;
+    } catch (err) {
+      console.log(err);
+    }
   };
 
   return (
     <Flex direction="column" height="100vh">
       <Header />
       <Flex direction="row" flex={1} margin="40px" marginLeft="90px">
-        <UserProfileForm />
+        <UserProfileForm
+          setFullName={setFullName}
+          setEmail={setEmail}
+          setEducationalQualification={setEducationalQualification}
+          setLanguageExperience={setLanguageExperience}
+        />
       </Flex>
       <Flex
         alignItems="center"

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -60,6 +60,9 @@ const UserProfilePage = () => {
   const [email, setEmail] = useState<string>("");
   const [role, setRole] = useState<string>("");
   const [resumeId, setResumeId] = useState<number | null>(null);
+  const [educationalQualification, setEducationalQualification] =
+    useState<string>("");
+  const [languageExperience, setLanguageExperience] = useState<string>("");
   const [confirmDeleteUser, setConfirmDeleteUser] = useState(false);
   const [alertText, setAlertText] = useState<string>("");
   const [alert, setAlert] = useState(false);
@@ -174,7 +177,15 @@ const UserProfilePage = () => {
           )}
         </Flex>
         <Flex direction="column" margin="40px" flex={1}>
-          {!isAdmin && <UserProfileForm isSignup={false} />}
+          {!isAdmin && (
+            <UserProfileForm
+              isSignup={false}
+              setFullName={setFullName}
+              setEmail={setEmail}
+              setEducationalQualification={setEducationalQualification}
+              setLanguageExperience={setLanguageExperience}
+            />
+          )}
           <Flex justifyContent="space-between" margin="40px 0 10px 0">
             <Heading size="lg"> Approved Languages & Levels </Heading>
           </Flex>

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -60,9 +60,11 @@ const UserProfilePage = () => {
   const [email, setEmail] = useState<string>("");
   const [role, setRole] = useState<string>("");
   const [resumeId, setResumeId] = useState<number | null>(null);
+  /* eslint-disable */
   const [educationalQualification, setEducationalQualification] =
     useState<string>("");
   const [languageExperience, setLanguageExperience] = useState<string>("");
+  /* eslint-enable */
   const [confirmDeleteUser, setConfirmDeleteUser] = useState(false);
   const [alertText, setAlertText] = useState<string>("");
   const [alert, setAlert] = useState(false);
@@ -177,9 +179,12 @@ const UserProfilePage = () => {
           )}
         </Flex>
         <Flex direction="column" margin="40px" flex={1}>
+          {/* TODO: use different state for email & fullname since currently the sidebar also gets modified */}
           {!isAdmin && (
             <UserProfileForm
               isSignup={false}
+              fullName={fullName}
+              email={email}
               setFullName={setFullName}
               setEmail={setEmail}
               setEducationalQualification={setEducationalQualification}

--- a/frontend/src/components/userProfile/UserProfileForm.tsx
+++ b/frontend/src/components/userProfile/UserProfileForm.tsx
@@ -19,9 +19,19 @@ import { languageOptions } from "../../constants/Languages";
 
 export type UserProfileFormProps = {
   isSignup?: boolean;
+  setFullName: (name: string) => void;
+  setEmail: (email: string) => void;
+  setEducationalQualification: (email: string) => void;
+  setLanguageExperience: (email: string) => void;
 };
 
-const UserProfileForm = ({ isSignup = true }: UserProfileFormProps) => (
+const UserProfileForm = ({
+  isSignup = true,
+  setFullName,
+  setEmail,
+  setEducationalQualification,
+  setLanguageExperience,
+}: UserProfileFormProps) => (
   <Flex direction="row" flex={1}>
     <Flex direction="column" flex={1} maxWidth="50%">
       <Heading size="lg">
@@ -36,19 +46,27 @@ const UserProfileForm = ({ isSignup = true }: UserProfileFormProps) => (
         <Heading marginTop="24px" size="sm">
           Full name*
         </Heading>
-        <Input type="name" />
+        <Input type="name" onChange={(e) => setFullName(e.target.value)} />
         <Heading marginTop="24px" size="sm">
           Email*
         </Heading>
-        <Input type="email" />
+        <Input type="email" onChange={(e) => setEmail(e.target.value)} />
         <Heading marginTop="24px" size="sm">
           Educational qualifications*
         </Heading>
-        <Textarea height="150px" type="qualifications" />
+        <Textarea
+          height="150px"
+          type="qualifications"
+          onChange={(e) => setEducationalQualification(e.target.value)}
+        />
         <Heading marginTop="24px" size="sm">
           Language experience*
         </Heading>
-        <Textarea height="150px" type="experience" />
+        <Textarea
+          height="150px"
+          type="experience"
+          onChange={(e) => setLanguageExperience(e.target.value)}
+        />
       </FormControl>
       {isSignup && (
         <>

--- a/frontend/src/components/userProfile/UserProfileForm.tsx
+++ b/frontend/src/components/userProfile/UserProfileForm.tsx
@@ -19,6 +19,8 @@ import { languageOptions } from "../../constants/Languages";
 
 export type UserProfileFormProps = {
   isSignup?: boolean;
+  fullName: string;
+  email: string;
   setFullName: (name: string) => void;
   setEmail: (email: string) => void;
   setEducationalQualification: (email: string) => void;
@@ -27,6 +29,8 @@ export type UserProfileFormProps = {
 
 const UserProfileForm = ({
   isSignup = true,
+  fullName,
+  email,
   setFullName,
   setEmail,
   setEducationalQualification,
@@ -46,11 +50,19 @@ const UserProfileForm = ({
         <Heading marginTop="24px" size="sm">
           Full name*
         </Heading>
-        <Input type="name" onChange={(e) => setFullName(e.target.value)} />
+        <Input
+          type="name"
+          value={fullName}
+          onChange={(e) => setFullName(e.target.value)}
+        />
         <Heading marginTop="24px" size="sm">
           Email*
         </Heading>
-        <Input type="email" onChange={(e) => setEmail(e.target.value)} />
+        <Input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
         <Heading marginTop="24px" size="sm">
           Educational qualifications*
         </Heading>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Use updateMe mutation in CompleteProfilePage](https://www.notion.so/uwblueprintexecs/Use-updateMe-mutation-in-CompleteProfilePage-eb38376e72d94f0a9b19d726e95f45a7)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Use the updateMe mutation to update user details based on form

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Signup with a new user on the login page
2. Fill in details on the form
3. Verify user details are updated by checking the users_all and users tables in the database

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Mutation is implemented correctly
- Additional details field is properly set
- Ignore the if statement in the UsersProfilePage (placeholder to avoid linter error until its properly implemented)

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
