### PR TITLE
Fix: use StoryAll in get_story to get contents

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -38,7 +38,7 @@ class StoryService(IStoryService):
     def get_story(self, id):
         # get queries by the primary key, which is id for the Story table
         # note: include_relationships=True will only include StoryContents if StoryAll is called
-        # There are no security/permission issues by allowing users to view a deleted story, 
+        # There are no security/permission issues by allowing users to view a deleted story,
         # so StoryAll can be safely used here
         story = StoryAll.query.get(id)
         if story is None:

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -37,7 +37,10 @@ class StoryService(IStoryService):
 
     def get_story(self, id):
         # get queries by the primary key, which is id for the Story table
-        story = Story.query.get(id)
+        # note: include_relationships=True will only include StoryContents if StoryAll is called
+        # There are no security/permission issues by allowing users to view a deleted story, 
+        # so StoryAll can be safely used here
+        story = StoryAll.query.get(id)
         if story is None:
             self.logger.error("Invalid id")
             raise Exception("Invalid id")


### PR DESCRIPTION

## Implementation description

- use StoryAll instead of story to get contents (translate/review platform couldnt load because contents was coming back null)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. opn translation platform
2. observe that it works lol

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
