### PR TITLE
Export story translation .docx

### DIFF
--- a/backend/python/app/graphql/queries/file_query.py
+++ b/backend/python/app/graphql/queries/file_query.py
@@ -4,4 +4,5 @@ from ..service import services
 
 @require_authorization_by_role_gql({"User", "Admin"})
 def resolve_file_by_id(root, info, id):
-    return services["file"].get_file(id)
+    file = services["file"].get_file_path(id)
+    return services["file"].download_file(file.path)

--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -47,6 +47,13 @@ def resolve_story_translation_statistics(root, info):
     return services["story"].get_story_translation_statistics()
 
 
+def resolve_export_story_translation(root, info, id):
+    res = services["story"].export_story_translation(id)
+    file = services["file"].get_file(res["id"])
+    services["file"].delete_file(res["path"])
+    return file
+
+
 @require_authorization_by_role_gql({"Admin"})
 def resolve_story_translations(
     root, info, language, level, stage, story_title, story_id

--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -49,7 +49,7 @@ def resolve_story_translation_statistics(root, info):
 
 def resolve_export_story_translation(root, info, id):
     res = services["story"].export_story_translation(id)
-    file = services["file"].get_file(res["id"])
+    file = services["file"].download_file(res["path"])
     services["file"].delete_file(res["path"])
     return file
 

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -37,6 +37,7 @@ from .mutations.user_mutation import (
 from .queries.comment_query import resolve_comments_by_story_translation
 from .queries.file_query import resolve_file_by_id
 from .queries.story_query import (
+    resolve_export_story_translation,
     resolve_stories,
     resolve_stories_available_for_translation,
     resolve_story_by_id,
@@ -154,6 +155,9 @@ class Query(graphene.ObjectType):
     story_translation_statistics = graphene.Field(
         StoryTranslationStatisticsResponseDTO,
     )
+    export_story_translation = graphene.Field(
+        DownloadFileDTO, id=graphene.Int(required=True)
+    )
 
     def resolve_comments_by_story_translation(
         root, info, story_translation_id, resolved=None
@@ -229,6 +233,9 @@ class Query(graphene.ObjectType):
 
     def resolve_story_translation_statistics(root, info):
         return resolve_story_translation_statistics(root, info)
+
+    def resolve_export_story_translation(root, info, id):
+        return resolve_export_story_translation(root, info, id)
 
 
 schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/backend/python/app/graphql/types/file_type.py
+++ b/backend/python/app/graphql/types/file_type.py
@@ -11,6 +11,5 @@ class CreateFileDTO(graphene.InputObjectType):
 
 
 class DownloadFileDTO(graphene.ObjectType):
-    id = graphene.Int()
     file = graphene.String(required=True)
     ext = graphene.String(required=True)

--- a/backend/python/app/services/implementations/file_service.py
+++ b/backend/python/app/services/implementations/file_service.py
@@ -13,7 +13,7 @@ class FileService(IFileService):
     def __init__(self, logger):
         self.logger = logger
 
-    def get_file(self, id):
+    def get_file_path(self, id):
         try:
             file = File.query.get(id)
 
@@ -21,13 +21,24 @@ class FileService(IFileService):
                 self.logger.error(f"Invalid file id: {id}")
                 raise Exception(f"Invalid file id: {id}")
 
-            # encode file data as base64 string
-            file_bytes = open(file.path, "rb").read()
+            return file
+        except Exception as e:
+            reason = getattr(e, "message", None)
+            self.logger.error(
+                "Failed to get file. Reason = {reason}".format(
+                    reason=(reason if reason else str(e))
+                )
+            )
+            raise e
+
+    def download_file(self, file_path):
+        try:  # encode file data as base64 string
+            file_bytes = open(file_path, "rb").read()
             encoded = b64encode(file_bytes).decode("utf-8")
 
             # extract extension and path
-            _, file_extension = os.path.splitext(file.path)
-            return DownloadFileDTO(id=id, file=encoded, ext=file_extension[1:])
+            _, file_extension = os.path.splitext(file_path)
+            return DownloadFileDTO(file=encoded, ext=file_extension[1:])
         except Exception as e:
             reason = getattr(e, "message", None)
             self.logger.error(

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -93,25 +93,30 @@ class StoryService(IStoryService):
             raise error
 
     def export_story_translation(self, id):
-        story_details = self.get_story_translation(id=id)
-        doc = docx.Document()
-        doc.add_heading(story_details["title"])
+        try:
+            story_details = self.get_story_translation(id=id)
+            doc = docx.Document()
+            doc.add_heading(story_details["title"])
 
-        for line in story_details["translation_contents"]:
-            doc.add_paragraph(line["translation_content"])
+            for line in story_details["translation_contents"]:
+                doc.add_paragraph(line["translation_content"])
 
-        upload_folder_path = os.getenv("UPLOAD_PATH")
+            upload_folder_path = os.getenv("UPLOAD_PATH")
 
-        upload_path = os.path.join(
-            upload_folder_path, secure_filename("downloadable-story-translation.docx")
-        )
-        doc.save(upload_path)
-        file_dto = FileDTO(path=upload_path)
-        self.logger.info(file_dto)
-        new_file = File(**file_dto.__dict__)
-        db.session.add(new_file)
-        db.session.commit()
-        return new_file.to_dict()
+            upload_path = os.path.join(
+                upload_folder_path,
+                secure_filename("downloadable-story-translation.docx"),
+            )
+            doc.save(upload_path)
+            file_dto = FileDTO(path=upload_path)
+            self.logger.info(file_dto)
+            new_file = File(**file_dto.__dict__)
+            db.session.add(new_file)
+            db.session.commit()
+            return new_file.to_dict()
+        except Exception as error:
+            self.logger.error(str(error))
+            raise error
 
     def create_translation(self, translation):
         try:

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -111,8 +111,6 @@ class StoryService(IStoryService):
             file_dto = FileDTO(path=upload_path)
             self.logger.info(file_dto)
             new_file = File(**file_dto.__dict__)
-            db.session.add(new_file)
-            db.session.commit()
             return new_file.to_dict()
         except Exception as error:
             self.logger.error(str(error))

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -1,9 +1,13 @@
+import os
+from base64 import b64encode
 from datetime import datetime, timedelta
 
 import docx
 from flask import current_app
 from sqlalchemy.orm import aliased
+from werkzeug.utils import secure_filename
 
+from ...graphql.types.file_type import FileDTO
 from ...graphql.types.story_type import (
     StageEnum,
     StoryTranslationContentResponseDTO,
@@ -12,6 +16,7 @@ from ...graphql.types.story_type import (
 )
 from ...models import db
 from ...models.comment import Comment
+from ...models.file import File
 from ...models.story import Story
 from ...models.story_all import StoryAll
 from ...models.story_content import StoryContent
@@ -86,6 +91,27 @@ class StoryService(IStoryService):
         except Exception as error:
             self.logger.error(str(error))
             raise error
+
+    def export_story_translation(self, id):
+        story_details = self.get_story_translation(id=id)
+        doc = docx.Document()
+        doc.add_heading(story_details["title"])
+
+        for line in story_details["translation_contents"]:
+            doc.add_paragraph(line["translation_content"])
+
+        upload_folder_path = os.getenv("UPLOAD_PATH")
+
+        upload_path = os.path.join(
+            upload_folder_path, secure_filename("downloadable-story-translation.docx")
+        )
+        doc.save(upload_path)
+        file_dto = FileDTO(path=upload_path)
+        self.logger.info(file_dto)
+        new_file = File(**file_dto.__dict__)
+        db.session.add(new_file)
+        db.session.commit()
+        return new_file.to_dict()
 
     def create_translation(self, translation):
         try:

--- a/backend/python/app/services/interfaces/file_service.py
+++ b/backend/python/app/services/interfaces/file_service.py
@@ -7,12 +7,12 @@ class IFileService(ABC):
     """
 
     @abstractmethod
-    def get_file(self, id):
+    def get_file_path(self, id):
         """Return a File and its contents based on id
 
         :param id: File id
-        :return: DownloadFileDTO containing file data
-        :rtype: DownloadFileDTO
+        :return: FileDTO, contains path and id of file
+        :rtype: FileDTO
         :raises Exception: id retrieval fails or base64 encoding fails
         """
         pass

--- a/frontend/src/APIClients/queries/FileQueries.ts
+++ b/frontend/src/APIClients/queries/FileQueries.ts
@@ -9,7 +9,6 @@ export type File = {
 export const GET_FILE = gql`
   query GetFile($id: Int!) {
     fileById(id: $id) {
-      id
       ext
       file
     }


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Export Story Translation](https://www.notion.so/uwblueprintexecs/Export-Story-Translation-89e4d88148824aecb5e6e72f843775dc)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- creates a new word doc, saves to db, returns the encoded string, and then deletes the file 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as an admin (angela merkel) 
2. [Try this query](http://localhost:5000/graphql?variables=null&operationName=undefined&query=query%20%7B%0A%20%20exportStoryTranslation(id%3A2)%7B%0A%20%20%20%20file%0A%20%20%7D%0A%7D) - see if that returns an encoded string and that file got deleted
3. To see if the file actually saved correctly, (testing process is a little sus rn but) comment out line 53 in `story_query.py`
4. Get the file id for the document (should be the last row in the files table)
5. Set the resume for Carl Sagan to the new file (`update users set resume=<file_id> where id = 1;`)
6. Go to http://localhost:3000/#/user/1 and download the resume 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- How do we want to format the document?
- What other information do we want to retrieve/add to the doc?
- Not sure if there's a way to use `create_file`

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
