### PR TITLE
Implement user background section on UserProfilePage

### DIFF
--- a/frontend/src/APIClients/queries/UserQueries.ts
+++ b/frontend/src/APIClients/queries/UserQueries.ts
@@ -20,7 +20,13 @@ export type User = {
   resume: number;
   approvedLanguagesTranslation: string;
   approvedLanguagesReview: string;
+  additionalExperiences: string;
 } | null;
+
+export type AdditionalExperiences = {
+  languageExperience: string;
+  educationalQualification: string;
+};
 
 export const GET_USER = (id: number) =>
   gql`
@@ -29,6 +35,7 @@ export const GET_USER = (id: number) =>
           id: ${id}
         ) {
           ${USER_FIELDS}
+          additionalExperiences
         }
       }
   `;

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -1,6 +1,13 @@
 import React, { useContext, useState } from "react";
 import { useParams, useHistory, Redirect } from "react-router-dom";
-import { Button, Flex, Heading, Text, useStyleConfig } from "@chakra-ui/react";
+import {
+  Button,
+  Flex,
+  Heading,
+  Text,
+  Textarea,
+  useStyleConfig,
+} from "@chakra-ui/react";
 import { useQuery, useMutation } from "@apollo/client";
 
 import AuthContext from "../../contexts/AuthContext";
@@ -18,7 +25,11 @@ import {
   NEW_BOOK_TEST_ADDED_MESSAGE,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
-import { GET_USER, User } from "../../APIClients/queries/UserQueries";
+import {
+  AdditionalExperiences,
+  GET_USER,
+  User,
+} from "../../APIClients/queries/UserQueries";
 import {
   GET_STORY_TRANSLATIONS_BY_USER,
   StoryTranslation,
@@ -26,6 +37,7 @@ import {
 import {
   ApprovedLanguagesMap,
   parseApprovedLanguages,
+  parseUserBackground,
 } from "../../utils/Utils";
 import ApprovedLanguagesTable from "../admin/ApprovedLanguagesTable";
 import AssignedStoryTranslationsTable from "../userProfile/AssignedStoryTranslationsTable";
@@ -61,6 +73,8 @@ const UserProfilePage = () => {
   const [storyTranslations, setStoryTranslations] = useState<
     StoryTranslation[]
   >([]);
+  const [additionalExperiences, setAdditionalExperiences] =
+    useState<AdditionalExperiences | null>(null);
 
   const [approvedLanguagesTranslation, setApprovedLanguagesTranslation] =
     useState<ApprovedLanguagesMap>();
@@ -97,6 +111,9 @@ const UserProfilePage = () => {
         `Translator ${
           Object.keys(reviewLanguages).length > 0 ? "& Reviewer" : ""
         }`,
+      );
+      setAdditionalExperiences(
+        parseUserBackground(user?.additionalExperiences),
       );
     },
   });
@@ -261,8 +278,42 @@ const UserProfilePage = () => {
           />
           {isAdmin && (
             <>
-              <Heading size="sm" marginTop="56px">
-                Delete user
+              <Heading size="lg" marginTop="56px" marginBottom="20px">
+                User Background
+              </Heading>
+              <Heading size="md" variant="subtitle" marginBottom="10px">
+                Educational Qualifications
+              </Heading>
+              <Textarea
+                isDisabled
+                variant="disabled"
+                height="150px"
+                borderWidth="3px"
+                resize="none"
+                value={additionalExperiences?.educationalQualification ?? ""}
+              />
+              <Heading
+                size="md"
+                variant="subtitle"
+                marginTop="26px"
+                marginBottom="10px"
+              >
+                Language Experience
+              </Heading>
+              <Textarea
+                isDisabled
+                variant="disabled"
+                height="150px"
+                borderWidth="3px"
+                resize="none"
+                value={additionalExperiences?.languageExperience ?? ""}
+              />
+            </>
+          )}
+          {isAdmin && (
+            <>
+              <Heading size="md" fontWeight="500" marginTop="56px">
+                Delete User
               </Heading>
               <Text>
                 Permanently delete this user and all data associated with them.

--- a/frontend/src/theme/components/Heading.ts
+++ b/frontend/src/theme/components/Heading.ts
@@ -14,6 +14,10 @@ const Heading = {
     light: {
       fontWeight: "400",
     },
+    subtitle: {
+      fontWeight: "500",
+      color: "gray.400",
+    },
   },
 };
 export default Heading;

--- a/frontend/src/theme/components/Textarea.ts
+++ b/frontend/src/theme/components/Textarea.ts
@@ -15,6 +15,11 @@ const Textarea = {
       margin: "12px",
       padding: "10px",
     },
+    disabled: {
+      opacity: "100%",
+      backgroundColor: "white",
+      cursor: "not-allowed",
+    },
   },
 };
 export default Textarea;

--- a/frontend/src/utils/Utils.ts
+++ b/frontend/src/utils/Utils.ts
@@ -1,4 +1,5 @@
 import { CommentResponse } from "../APIClients/queries/CommentQueries";
+import { AdditionalExperiences } from "../APIClients/queries/UserQueries";
 
 export const convertStringTitleCase = (s: string) =>
   s[0] + s.substring(1).toLowerCase();
@@ -9,6 +10,19 @@ export const parseApprovedLanguages = (
   input: string | undefined,
 ): ApprovedLanguagesMap => {
   return input ? JSON.parse(input.trim().replace(/'/g, '"')) : {};
+};
+
+export const parseUserBackground = (
+  input: string | undefined | null,
+): AdditionalExperiences => {
+  const additionalExperiences = input
+    ? JSON.parse(input.trim().replace(/'/g, '"'))
+    : {};
+  return {
+    languageExperience: additionalExperiences.languageExperience ?? "",
+    educationalQualification:
+      additionalExperiences.educationalQualification ?? "",
+  };
 };
 
 export const embedLink = (originalYoutubeLink: string): string => {


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Add-User-Background-section-to-admin-view-of-profile-page-19ec0e7c82e1491c9349e6aaaa662c08

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- fetch additionalExperiences in `userById` query
- add User Background section in admin view of `UserProfilePage.tsx`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. manually set user additional_experiences by going into the DB: `docker exec -it planet-read_db_1 /bin/bash -c "mysql -u root -proot"` and using: ```update users set additional_experiences = JSON_MERGE_PATCH(COALESCE(`additional_experiences`, "{}"), '{"languageExperience": "Test language experience string", "educationalQualification": "Test educational qualifications string"}') where id = 1;```
2. Login as admin and go to Carl Sagan's profile `/user/1`
3. Verify that user background section appears and appropriate strings are displayed
4. Sanity check: login as Carl Sagan and verify that user background section does not appear

![image](https://user-images.githubusercontent.com/45080644/147702653-a4080108-88f0-4a13-8079-549ca3c4df03.png)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
