### PR TITLE
Fix: do not edit line status when creating comment

### DIFF
--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -248,8 +248,6 @@ const ReviewPage = () => {
           translatorName={translatorName}
           reviewerName={reviewerName}
           setCommentLine={setCommentLine}
-          setTranslatedStoryLines={setTranslatedStoryLines}
-          translatedStoryLines={translatedStoryLines}
         />
         {returnToTranslator && (
           <ConfirmationModal

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -316,8 +316,6 @@ const TranslationPage = () => {
             translatorName={translatorName}
             reviewerName={reviewerName}
             setCommentLine={setCommentLine}
-            setTranslatedStoryLines={setTranslatedStoryLines}
-            translatedStoryLines={translatedStoryLines}
           />
         )}
       </Flex>

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -6,7 +6,6 @@ import {
   buildCommentsQuery,
 } from "../../APIClients/queries/CommentQueries";
 import WIPComment from "./WIPComment";
-import { StoryLine } from "../translation/Autosave";
 import ExistingComment from "./ExistingComment";
 
 export type CommentPanelProps = {
@@ -17,8 +16,6 @@ export type CommentPanelProps = {
   commentLine: number;
   setCommentLine: (line: number) => void;
   storyTranslationContentId: number;
-  setTranslatedStoryLines: (storyLines: StoryLine[]) => void;
-  translatedStoryLines: StoryLine[];
 };
 
 const CommentsPanel = ({
@@ -29,8 +26,6 @@ const CommentsPanel = ({
   commentLine,
   storyTranslationContentId,
   setCommentLine,
-  setTranslatedStoryLines,
-  translatedStoryLines,
 }: CommentPanelProps) => {
   const [comments, setComments] = useState<CommentResponse[]>([]);
   const [filterIndex, setFilterIndex] = useState(2);
@@ -133,8 +128,6 @@ const CommentsPanel = ({
               updateCommentsAsResolved={updateCommentsAsResolved}
               comments={comments}
               setComments={setComments}
-              setTranslatedStoryLines={setTranslatedStoryLines}
-              translatedStoryLines={translatedStoryLines}
               threadHeadMap={threadHeadMap}
               updateThreadHeadMap={updateThreadHeadMap}
             />
@@ -198,8 +191,6 @@ const CommentsPanel = ({
           setCommentLine={setCommentLine}
           comments={comments}
           setComments={setComments}
-          setTranslatedStoryLines={setTranslatedStoryLines}
-          translatedStoryLines={translatedStoryLines}
           updateThreadHeadMap={updateThreadHeadMap}
         />
       )}

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -7,7 +7,6 @@ import {
   UpdateCommentResponse,
 } from "../../APIClients/mutations/CommentMutations";
 import { CommentResponse } from "../../APIClients/queries/CommentQueries";
-import { StoryLine } from "../translation/Autosave";
 
 export type ExistingCommentProps = {
   commentsStateIdx: number;
@@ -16,8 +15,6 @@ export type ExistingCommentProps = {
   updateCommentsAsResolved: (index: number) => void;
   comments: CommentResponse[];
   setComments: (comments: CommentResponse[]) => void;
-  translatedStoryLines: StoryLine[];
-  setTranslatedStoryLines: (storyLines: StoryLine[]) => void;
   WIPLineIndex: number;
   threadHeadMap: boolean[];
   updateThreadHeadMap: (cmts: CommentResponse[]) => void;
@@ -29,9 +26,7 @@ const ExistingComment = ({
   comment,
   updateCommentsAsResolved,
   setComments,
-  setTranslatedStoryLines,
   comments,
-  translatedStoryLines,
   threadHeadMap,
   updateThreadHeadMap,
 }: ExistingCommentProps) => {
@@ -150,8 +145,6 @@ const ExistingComment = ({
           setCommentLine={setReply}
           comments={comments}
           setComments={setComments}
-          setTranslatedStoryLines={setTranslatedStoryLines}
-          translatedStoryLines={translatedStoryLines}
           updateThreadHeadMap={updateThreadHeadMap}
         />
       )}

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -7,8 +7,6 @@ import {
   CREATE_COMMMENT,
 } from "../../APIClients/mutations/CommentMutations";
 import { CommentResponse } from "../../APIClients/queries/CommentQueries";
-import { StoryLine } from "../translation/Autosave";
-import { convertStatusTitleCase } from "../../utils/StatusUtils";
 import { insertSortedComments } from "../../utils/Utils";
 
 export type WIPCommentProps = {
@@ -17,8 +15,6 @@ export type WIPCommentProps = {
   setCommentLine: (line: number) => void;
   comments: CommentResponse[];
   setComments: (comments: CommentResponse[]) => void;
-  translatedStoryLines: StoryLine[];
-  setTranslatedStoryLines: (storyLines: StoryLine[]) => void;
   updateThreadHeadMap: (cmts: CommentResponse[]) => void;
 };
 
@@ -27,9 +23,7 @@ const WIPComment = ({
   WIPLineIndex,
   setCommentLine,
   setComments,
-  setTranslatedStoryLines,
   comments,
-  translatedStoryLines,
   updateThreadHeadMap,
 }: WIPCommentProps) => {
   const handleError = (errorMessage: string) => {
@@ -61,10 +55,6 @@ const WIPComment = ({
           result.data.createComment.comment,
         );
         setComments(newComments);
-        const updatedStoryLines = [...translatedStoryLines];
-        updatedStoryLines[WIPLineIndex - 1].status =
-          convertStatusTitleCase("ACTION_REQUIRED");
-        setTranslatedStoryLines(updatedStoryLines);
         updateThreadHeadMap(newComments);
       }
     } catch (err) {


### PR DESCRIPTION
## Notion ticket link

https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=bde38143a0bb45ebb08012c31f1a1d16

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- rip out modifying storytranslationcontent stuff in the comment panel + its components 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. log in as carl and open the great gatsby 
2. make new comments 
3. reply to comments
4. do other random comment things 
5. observe that statuses never change 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
