### PR TITLE
Enable redirecting to specific homepage tab

### DIFF
--- a/frontend/src/components/utils/ButtonRadioGroup.tsx
+++ b/frontend/src/components/utils/ButtonRadioGroup.tsx
@@ -48,6 +48,7 @@ export type ButtonRadioGroupProps = {
   options: string[];
   onChange: (newState: string) => void;
   dependentValue?: string;
+  value?: string;
 };
 
 function ButtonRadioGroup({
@@ -60,6 +61,7 @@ function ButtonRadioGroup({
   options,
   dependentValue,
   onChange,
+  value,
 }: ButtonRadioGroupProps) {
   const { getRootProps, getRadioProps, setValue } = useRadioGroup({
     name,
@@ -76,19 +78,25 @@ function ButtonRadioGroup({
     }
   }, [dependentValue]);
 
+  useEffect(() => {
+    if (value) {
+      setValue(value);
+    }
+  }, [value]);
+
   return (
     <Flex direction={stacked ? "column" : "row"} {...group}>
-      {options.map((value) => {
-        const radio = getRadioProps({ value });
+      {options.map((val) => {
+        const radio = getRadioProps({ value: val });
         return (
           <RadioCard
-            key={value}
+            key={val}
             size={size}
             unselectedVariant={unselectedVariant}
             {...radio}
             isDisabled={isDisabled}
           >
-            {value}
+            {val}
           </RadioCard>
         );
       })}

--- a/frontend/src/utils/hooks/useQueryParams.tsx
+++ b/frontend/src/utils/hooks/useQueryParams.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+// A custom hook to parse URL query strings
+const useQueryParams = () => {
+  const { search } = useLocation();
+
+  return React.useMemo(() => new URLSearchParams(search), [search]);
+};
+
+export default useQueryParams;


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Enable-redirecting-to-specific-homepage-tab-41fe40b2d2dc424d9a0c4bb7170fa612

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- refactored `HomePage.tsx` to use an enum for navigation instead of two booleans
- created hook to fetch URL query params

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as any non-admin user
2. Click on the tabs to navigate between different pages, verify that the URL changes
3. Try entering `/?tab=1` or any other id, verify that the correct page is shown (My Work = 0)
4. Play around with the navigation, verify that it works as normal

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?
- is ther any janky edge case behaviour?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
