### PR TITLE
Remove box shadow for filter if it's disabled

### DIFF
--- a/frontend/src/components/homepage/Filter.tsx
+++ b/frontend/src/components/homepage/Filter.tsx
@@ -86,6 +86,10 @@ const Filter = ({
 
   const filterStyle = useStyleConfig("Filter");
   const disabledStyle = useStyleConfig("Disabled");
+
+  if (isDisabled) {
+    filterStyle.boxShadow = "none";
+  }
   return (
     <Flex sx={filterStyle}>
       {!isDisabled && (


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Remove-filter-component-shadow-when-filter-is-disabled-on-My-Work-My-Tests-3467406a468e44599431b7fc58903c1d

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- remove box shadow if filter is disabled

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as any user, verify that filter shadow doesn't show on "My Work" and "My Tests"

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
