### PR TITLE
Don't set stage when assigning reviewer

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -458,7 +458,6 @@ class StoryService(IStoryService):
         ):
             story_translation = StoryTranslation.query.get(story_translation["id"])
             story_translation.reviewer_id = user.id
-            story_translation.stage = "REVIEW"
             db.session.commit()
         else:
             self.logger.error("User can't be assigned as a reviewer")


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[assign_user_as_reviewer should not change story translation stage](https://www.notion.so/uwblueprintexecs/assign_user_as_reviewer-should-not-change-story-translation-stage-5f769d3cd38b48ad83dfa3c159585308)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Removes line that sets story translation stage to review

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin, grab auth token 
2. Try assigning a reviewer http://localhost:5000/graphql?variables=null&operationName=undefined&query=mutation%20%7B%0A%20%20assignUserAsReviewer(storyTranslationId%3A6%2C%20userId%3A4)%7B%0A%20%20%20%20story%7B%0A%20%20%20%20%20%20translatorId%0A%20%20%20%20%20%20stage%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D 
3. Check that story stage has not changed 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
