### PR TITLE
Enable redirecting to specific admin tab

### DIFF
--- a/frontend/src/components/navigation/Header.tsx
+++ b/frontend/src/components/navigation/Header.tsx
@@ -14,7 +14,7 @@ import UserModal from "./UserModal";
 import AuthContext from "../../contexts/AuthContext";
 
 export enum AdminPageOption {
-  StoryTranslations = 1,
+  StoryTranslations = 0,
   Stories,
   Translators,
   Reviewers,
@@ -37,14 +37,9 @@ const AdminPageOptionToStr = [
 export type HeaderProps = {
   title?: string;
   adminPageOption?: AdminPageOption;
-  setAdminPageOption?: (val: AdminPageOption) => void;
 };
 
-const Header = ({
-  title,
-  adminPageOption,
-  setAdminPageOption,
-}: HeaderProps) => {
+const Header = ({ title, adminPageOption }: HeaderProps) => {
   const { authenticatedUser } = useContext(AuthContext);
 
   const { id, firstName, lastName, role, approvedLanguagesReview } =
@@ -63,12 +58,11 @@ const Header = ({
   };
 
   const adminTabs =
-    adminPageOption &&
-    setAdminPageOption &&
+    adminPageOption !== undefined &&
     AdminPageOptionToStr.map((adminPageOp: AdminPageOptionPair) => (
       <Button
         onClick={() => {
-          setAdminPageOption(adminPageOp.op);
+          window.location.href = `/#/?tab=${adminPageOp.op}`;
         }}
         variant={adminPageOption === adminPageOp.op ? "headerSelect" : "header"}
       >
@@ -100,7 +94,7 @@ const Header = ({
           {title}
         </Heading>
       )}
-      {adminPageOption && setAdminPageOption && (
+      {adminPageOption !== undefined && (
         <Flex alignItems="flex-end">{adminTabs}</Flex>
       )}
       <Flex

--- a/frontend/src/components/pages/AdminPage.tsx
+++ b/frontend/src/components/pages/AdminPage.tsx
@@ -1,14 +1,31 @@
-import React, { useState } from "react";
+import React from "react";
 import Header, { AdminPageOption } from "../navigation/Header";
 import ManageStoryTranslations from "../admin/ManageStoryTranslations";
 import ManageStories from "../admin/ManageStories";
 import ManageUsers from "../admin/ManageUsers";
 import ManageStoryTests from "../admin/ManageStoryTests";
+import useQueryParams from "../../utils/hooks/useQueryParams";
 
 const AdminPage = () => {
-  const [adminPageOption, setAdminPageOption] = useState(
-    AdminPageOption.StoryTranslations,
-  );
+  const queryParams = useQueryParams();
+
+  const getPageOptionFromURL = () => {
+    const tab: string | null = queryParams.get("tab");
+    if (!tab || Number.isNaN(parseInt(tab, 10))) {
+      return AdminPageOption.StoryTranslations;
+    }
+
+    const index = parseInt(tab, 10);
+    return index >= AdminPageOption.StoryTranslations &&
+      index <= AdminPageOption.Tests
+      ? index
+      : -1;
+  };
+
+  const adminPageOption = getPageOptionFromURL();
+  if (adminPageOption === -1) {
+    window.location.href = "/";
+  }
   const bodyComponent = (adminPgOption: AdminPageOption) => {
     switch (adminPgOption) {
       case AdminPageOption.StoryTranslations:
@@ -27,10 +44,7 @@ const AdminPage = () => {
   };
   return (
     <>
-      <Header
-        adminPageOption={adminPageOption}
-        setAdminPageOption={setAdminPageOption}
-      />
+      <Header adminPageOption={adminPageOption} />
       {bodyComponent(adminPageOption)}
     </>
   );


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Enable-redirecting-to-specific-admin-tab-7fa84a9e6015421892895c0647086af2

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- implement redirecting to admin tab based on URL query param

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin
2. Click through header tabs, verify that the URL changes
3. Try setting URL manually, verify that it works 
4. Sanity check: login as non-admin user and verify that header doesn't show admin tabs

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
