### PR TITLE
Add unit tests for comment service

### DIFF
--- a/backend/python/app/graphql/mutations/comment_mutation.py
+++ b/backend/python/app/graphql/mutations/comment_mutation.py
@@ -49,23 +49,3 @@ class UpdateCommentById(graphene.Mutation):
         except Exception as e:
             error_message = getattr(e, "message", None)
             raise Exception(error_message if error_message else str(e))
-
-
-class UpdateComments(graphene.Mutation):
-    class Arguments:
-        comments_data = graphene.List(UpdateCommentRequestDTO)
-
-    ok = graphene.Boolean()
-    comments = graphene.Field(lambda: graphene.List(UpdateCommentResponseDTO))
-
-    @require_authorization_by_role_gql({"User", "Admin"})
-    def mutate(root, info, comments_data):
-        try:
-            comments_response = services["comment"].update_comments(
-                updated_comments=comments_data
-            )
-            ok = True
-            return UpdateComments(ok=ok, comments=comments_response)
-        except Exception as e:
-            error_message = getattr(e, "message", None)
-            raise Exception(error_message if error_message else str(e))

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -8,7 +8,7 @@ from .mutations.auth_mutation import (
     ResetPassword,
     SignUp,
 )
-from .mutations.comment_mutation import CreateComment, UpdateCommentById, UpdateComments
+from .mutations.comment_mutation import CreateComment, UpdateCommentById
 from .mutations.file_mutation import CreateFile
 from .mutations.story_mutation import (
     ApproveAllStoryTranslationContent,
@@ -78,7 +78,6 @@ class Mutation(graphene.ObjectType):
     assign_user_as_reviewer = AssignUserAsReviewer.Field()
     remove_reviewer_from_story_translation = RemoveReviewerFromStoryTranslation.Field()
     update_comment_by_id = UpdateCommentById.Field()
-    update_comments = UpdateComments.Field()
     update_story = UpdateStory.Field()
     update_story_translation_contents = UpdateStoryTranslationContents.Field()
     update_story_translation_content_status = (

--- a/backend/python/app/services/implementations/comment_service.py
+++ b/backend/python/app/services/implementations/comment_service.py
@@ -134,7 +134,7 @@ class CommentService(ICommentService):
             for key, value in updated_comment.__dict__.items():
                 setattr(comment, key, value)
 
-            if updated_comment["resolved"] == True:
+            if updated_comment.resolved == True:
                 thread_comments = Comment.query.filter_by(
                     story_translation_content_id=comment.story_translation_content_id
                 ).all()
@@ -166,20 +166,3 @@ class CommentService(ICommentService):
             raise error
 
         return comment
-
-    def update_comments(self, updated_comments):
-        try:
-            db.session.bulk_update_mappings(Comment, updated_comments)
-            db.session.commit()
-
-        except Exception as error:
-            reason = getattr(error, "message", None)
-            self.logger.error(
-                "Failed to update comment. Reason = {reason}".format(
-                    reason=(reason if reason else str(error))
-                )
-            )
-            raise error
-
-        # TODO: return updated comments as list of CommentResponseDTO's
-        return updated_comments

--- a/backend/python/app/services/interfaces/comment_service.py
+++ b/backend/python/app/services/interfaces/comment_service.py
@@ -38,14 +38,3 @@ class ICommentService(ABC):
         :raises Exception: if id of comment to be updated does not exist
         """
         pass
-
-    @abstractmethod
-    def update_comments(self, updated_comments):
-        """Bulk update existing Comment objects
-
-        :param updated_comments: list of UpdateCommentRequestDTO's
-        :return: list of UpdateCommentResponseDTO's
-        :rtype: [UpdateCommentResponseDTO]
-        :raises Exception: if id of comment to be updated does not exist
-        """
-        pass

--- a/backend/python/app/tests/helpers/comment_helpers.py
+++ b/backend/python/app/tests/helpers/comment_helpers.py
@@ -1,0 +1,27 @@
+from collections.abc import Mapping
+
+from ...models.comment import Comment
+from ...models.comment_all import CommentAll
+
+
+class CreateCommentDTO:
+    def __init__(self, story_translation_content_id, content):
+        self.story_translation_content_id = story_translation_content_id
+        self.content = content
+
+
+class UpdateCommentRequestDTO(Mapping):
+    def __init__(self, comment):
+        self.id = comment.id
+        self.resolved = comment.resolved
+        self.content = comment.content
+        self._dict = dict(id=comment.id, content=comment.content)
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        return len(self._dict)

--- a/backend/python/app/tests/helpers/comment_helpers.py
+++ b/backend/python/app/tests/helpers/comment_helpers.py
@@ -17,6 +17,7 @@ class UpdateCommentRequestDTO(Mapping):
         self.content = comment.content
         self._dict = dict(id=comment.id, content=comment.content)
 
+    # These functions are necessary for bulk_update_mappings to work
     def __getitem__(self, key):
         return self._dict[key]
 

--- a/backend/python/app/tests/services/test_comment_service.py
+++ b/backend/python/app/tests/services/test_comment_service.py
@@ -1,24 +1,105 @@
-def test_create_comment():
-    # Comment -> right fields, including index
-    pass
+import pytest
+
+from ...models.comment import Comment
+from ...models.comment_all import CommentAll
+from ..helpers.comment_helpers import CreateCommentDTO, UpdateCommentRequestDTO
+from ..helpers.db_helpers import db_session_add_commit_obj
+from ..helpers.story_translation_helpers import (
+    create_story_translation,
+    create_story_translation_contents,
+)
 
 
-def test_create_comment_does_nothing_if_max_query_returns_None():
-    pass
+def test_create_comment(app, db, services):
+    # Create Story and Story Translation
+    (
+        translator,
+        reviewer,
+        story_obj,
+        story_translation_obj,
+    ) = create_story_translation(db)
+    story_translation_contents = create_story_translation_contents(
+        db, story_translation_obj
+    )
+
+    # Single comment
+    comment = CreateCommentDTO(
+        story_translation_content_id=story_translation_contents[0]["id"],
+        content="literally 1984",
+    )
+    resp = services["comment"].create_comment(comment.__dict__, translator.id)
+    comment_obj = CommentAll.query.get(resp.id)
+
+    assert resp == comment_obj
+    assert comment_obj.comment_index == 0
+
+    # Multiple comments
+    comment_2 = CreateCommentDTO(
+        story_translation_content_id=story_translation_contents[0]["id"],
+        content="Orwellian State-Mandated Unit Tests",
+    )
+    resp_2 = services["comment"].create_comment(comment_2.__dict__, reviewer.id)
+    comment_obj_2 = CommentAll.query.get(resp_2.id)
+
+    assert resp_2 == comment_obj_2
+    assert comment_obj_2.comment_index == 1
 
 
-def test_update_comment():
-    pass
+def test_update_comment(app, db, services):
+    # Create Story and Story Translation
+    (
+        translator,
+        reviewer,
+        story_obj,
+        story_translation_obj,
+    ) = create_story_translation(db)
+    story_translation_contents = create_story_translation_contents(
+        db, story_translation_obj
+    )
+
+    comment = CreateCommentDTO(
+        story_translation_content_id=story_translation_contents[0]["id"],
+        content="Orwellian State-Mandated Unit Tests",
+    )
+    resp = services["comment"].create_comment(comment.__dict__, translator.id)
+    comment_obj = CommentAll.query.get(resp.id)
+
+    assert comment_obj.content == "Orwellian State-Mandated Unit Tests"
+
+    comment_2 = UpdateCommentRequestDTO(resp)
+    comment_2.content = "Big Brother is watching you"
+
+    resp_2 = services["comment"].update_comment(comment_2, translator.id)
+    comment_obj_2 = CommentAll.query.get(resp_2.id)
+
+    assert comment_obj_2.content == "Big Brother is watching you"
 
 
-def test_update_comment_invalid_id():
-    pass
+def test_update_comment_invalid_id(app, db, services):
+    # Create Story and Story Translation
+    (
+        translator,
+        reviewer,
+        story_obj,
+        story_translation_obj,
+    ) = create_story_translation(db)
+    story_translation_contents = create_story_translation_contents(
+        db, story_translation_obj
+    )
 
+    comment = CreateCommentDTO(
+        story_translation_content_id=story_translation_contents[0]["id"],
+        content="Orwellian State-Mandated Unit Tests",
+    )
+    resp = services["comment"].create_comment(comment.__dict__, translator.id)
+    comment_obj = CommentAll.query.get(resp.id)
 
-def test_update_comments():
-    pass
+    assert comment_obj.content == "Orwellian State-Mandated Unit Tests"
 
+    comment_2 = UpdateCommentRequestDTO(resp)
+    comment_2.content = "Big Brother is watching you"
+    comment_2.id = comment_2.id + 1
 
-def test_update_comments_invalid_ids():
-    # what if some are valid, others not?
-    pass
+    with pytest.raises(Exception) as e:
+        _ = services["comment"].update_comment(comment_2, translator.id)
+    assert "Comment with id=" in str(e.value)

--- a/backend/python/app/tests/services/test_comment_service.py
+++ b/backend/python/app/tests/services/test_comment_service.py
@@ -75,7 +75,7 @@ def test_update_comment(app, db, services):
     assert comment_obj_2.content == "Big Brother is watching you"
 
 
-def test_resolve_comment(app, db, services):
+def test_update_comment_resolve(app, db, services):
     # Create Story and Story Translation
     (
         translator,


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket ](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=d9efc1595f954086b7ece906ccdd62c4)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Add unit tests for story service
- Remove `update_comments` mutation in `comment_service`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Read through unit tests, check that they make sense
2. Make sure nothing is broken after removing  `update_comments` mutation in `comment_service`


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
