### PR TITLE
HOTFIX: Soft Delete Stories

### DIFF
--- a/frontend/src/components/pages/ManageStoryPage.tsx
+++ b/frontend/src/components/pages/ManageStoryPage.tsx
@@ -117,13 +117,13 @@ const ManageStoryPage = () => {
 
   const callSoftDeleteStoryMutation = async () => {
     try {
-      history.push("/");
-      window.location.reload();
       await softDeleteStory({
         variables: {
           id: parseInt(storyIdParam, 10),
         },
       });
+      history.push("/");
+      window.location.reload();
     } catch (error) {
       window.alert(`Error occurred, please try again. Error: ${error}`);
     }

--- a/frontend/src/components/pages/ManageStoryPage.tsx
+++ b/frontend/src/components/pages/ManageStoryPage.tsx
@@ -122,8 +122,7 @@ const ManageStoryPage = () => {
           id: parseInt(storyIdParam, 10),
         },
       });
-      history.push("/");
-      window.location.reload();
+      window.location.href = "/#/?tab=1";
     } catch (error) {
       window.alert(`Error occurred, please try again. Error: ${error}`);
     }


### PR DESCRIPTION
Change order of page redirction and reload to be AFTER calling mutation

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- I messed up the order in which we call the mutation and reload the page for soft deletes, oops

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Soft delete story, make sure nothing breaks and you are redirected to the admin page

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
