### PR TITLE
Show User Last Edited on AssignedStoryTranslations table

### DIFF
--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -87,6 +87,8 @@ class StoryTranslationResponseDTO(graphene.ObjectType):
     num_content_lines = graphene.Int()
     translator_name = graphene.String()
     reviewer_name = graphene.String()
+    translator_last_activity = graphene.DateTime()
+    reviewer_last_activity = graphene.DateTime()
 
 
 class StoryTranslationTestResponseDTO(graphene.ObjectType):

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -322,6 +322,8 @@ export const GET_STORY_TRANSLATIONS_BY_USER = (userId: number) => gql`
       language
       ${STORY_FIELDS}
       stage
+      translatorLastActivity
+      reviewerLastActivity
     }
   }
 `;

--- a/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
+++ b/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
@@ -297,6 +297,14 @@ const AssignedStoryTranslationsTable = ({
     return `#/review/${suffix}`;
   };
 
+  const lastEditedDate = (translation: StoryTranslation): Date | null => {
+    const lastEdited =
+      getRole(translation) === "Translator"
+        ? translation.translatorLastActivity
+        : translation.reviewerLastActivity;
+    return lastEdited ? new Date(lastEdited) : null;
+  };
+
   const tableBody = storyTranslations.map((translation: StoryTranslation) => (
     <Tr key={`${translation?.storyTranslationId}`}>
       <Td>
@@ -315,6 +323,7 @@ const AssignedStoryTranslationsTable = ({
         }`}</Badge>
       </Td>
       <Td>{convertStageTitleCase(translation.stage)}</Td>
+      <Td>{lastEditedDate(translation)?.toLocaleDateString?.()}</Td>
       {isAdmin && (
         <Td>
           <IconButton
@@ -356,6 +365,7 @@ const AssignedStoryTranslationsTable = ({
             <Th cursor="pointer" onClick={() => sort("stage")}>{`PROGRESS ${
               isAscendingStage ? "↑" : "↓"
             }`}</Th>
+            <Th>USER LAST EDITED</Th>
             {isAdmin && <Th width="7%">ACTION</Th>}
           </Tr>
         </Thead>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/show-User-Last-Edited-on-StoryTranslationTable-f413f04770164ec6a9bff4faa8021bb8

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- fetch `translator_last_activity` and `reviewer_last_activity` on `storyTranslationsByUser` query
- display date in new column

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl Sagan
2. Go to "To Kill a Mockingbird" and make some changes
3. Login as admin
4. Go to carl sagan's profile `/user/1`
5. Verify that date appears in assigned story translations table

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
