### PR TITLE
Implement export story translation flow

### DIFF
--- a/backend/python/app/services/implementations/file_service.py
+++ b/backend/python/app/services/implementations/file_service.py
@@ -91,7 +91,8 @@ class FileService(IFileService):
         try:
             os.remove(file)
             f = File.query.filter(File.path == file).order_by(File.id.desc()).first()
-            db.session.delete(f)
+            if f:
+                db.session.delete(f)
         except Exception as error:
             self.logger.error(str(error))
             raise error

--- a/frontend/src/APIClients/queries/FileQueries.ts
+++ b/frontend/src/APIClients/queries/FileQueries.ts
@@ -1,7 +1,6 @@
 import { gql } from "@apollo/client";
 
 export type File = {
-  id: number;
   file: string;
   ext: string;
 };
@@ -14,3 +13,22 @@ export const GET_FILE = gql`
     }
   }
 `;
+
+export const getFileQuery = {
+  fieldName: "fileById",
+  string: GET_FILE,
+};
+
+export const EXPORT_STORY_TRANSLATION = gql`
+  query ExportStoryTranslation($id: Int!) {
+    exportStoryTranslation(id: $id) {
+      ext
+      file
+    }
+  }
+`;
+
+export const exportStoryTranslationQuery = {
+  fieldName: "exportStoryTranslation",
+  string: EXPORT_STORY_TRANSLATION,
+};

--- a/frontend/src/components/admin/StoryTranslationsTable.tsx
+++ b/frontend/src/components/admin/StoryTranslationsTable.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useState } from "react";
 import { useMutation } from "@apollo/client";
 import { Icon } from "@chakra-ui/icon";
-import { MdDelete } from "react-icons/md";
+import { MdDelete, MdOutlineFileDownload } from "react-icons/md";
 import {
   Badge,
   IconButton,
@@ -13,6 +13,8 @@ import {
   Th,
   Td,
   TableCaption,
+  Tooltip,
+  Box,
 } from "@chakra-ui/react";
 import { StoryTranslation } from "../../APIClients/queries/StoryQueries";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
@@ -24,10 +26,13 @@ import {
   SoftDeleteStoryTranslationResponse,
 } from "../../APIClients/mutations/StoryMutations";
 import {
+  EXPORT_TOOL_TIP_COPY,
   MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_BUTTON,
   MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_CONFIRMATION,
 } from "../../utils/Copy";
 import EmptyTable from "./EmptyTable";
+import { useFileDownload } from "../../utils/FileUtils";
+import { exportStoryTranslationQuery } from "../../APIClients/queries/FileQueries";
 
 export type StoryTranslationsTableProps = {
   storyTranslationSlice: StoryTranslation[];
@@ -53,6 +58,11 @@ const StoryTranslationsTable = ({
   const [deleteStoryTranslation] = useMutation<{
     response: SoftDeleteStoryTranslationResponse;
   }>(SOFT_DELETE_STORY_TRANSLATION);
+
+  const [downloadFile] = useFileDownload(
+    "story-translation",
+    exportStoryTranslationQuery,
+  );
 
   const closeModal = () => {
     setIdToDelete(0);
@@ -139,6 +149,27 @@ const StoryTranslationsTable = ({
         </Td>
         <Td>{lastEditedDate(storyTranslationObj)?.toLocaleDateString?.()}</Td>
         <Td>
+          <Tooltip
+            hasArrow
+            label={EXPORT_TOOL_TIP_COPY}
+            isDisabled={storyTranslationObj.stage === "PUBLISH"}
+            placement="top"
+          >
+            <Box width="fit-content">
+              <IconButton
+                aria-label={`Export story translation ${storyTranslationObj?.storyTranslationId}`}
+                background="transparent"
+                icon={<Icon as={MdOutlineFileDownload} />}
+                width="fit-content"
+                isDisabled={storyTranslationObj.stage !== "PUBLISH"}
+                onClick={() =>
+                  downloadFile(storyTranslationObj.storyTranslationId)
+                }
+              />
+            </Box>
+          </Tooltip>
+        </Td>
+        <Td>
           <IconButton
             aria-label={`Delete story translation ${storyTranslationObj?.storyTranslationId} for story ${storyTranslationObj?.title}`}
             background="transparent"
@@ -173,6 +204,7 @@ const StoryTranslationsTable = ({
           <Th>TRANSLATOR</Th>
           <Th>REVIEWER</Th>
           <Th>LAST EDITED</Th>
+          <Th>EXPORT</Th>
           <Th>ACTION</Th>
         </Tr>
       </Thead>

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -41,6 +41,7 @@ import AssignedStoryTranslationsTable from "../userProfile/AssignedStoryTranslat
 import { StoryAssignStage } from "../../constants/Enums";
 import InfoAlert from "../utils/InfoAlert";
 import { useFileDownload } from "../../utils/FileUtils";
+import { getFileQuery } from "../../APIClients/queries/FileQueries";
 
 type UserProfilePageProps = {
   userId: string;
@@ -79,7 +80,7 @@ const UserProfilePage = () => {
 
   const history = useHistory();
 
-  const [downloadFile] = useFileDownload(resumeId, "resume");
+  const [downloadFile] = useFileDownload("resume", getFileQuery);
 
   const { loading, error } = useQuery(GET_USER(parseInt(userId, 10)), {
     fetchPolicy: "cache-and-network",
@@ -165,7 +166,7 @@ const UserProfilePage = () => {
                 User Files
               </Heading>
               {/* TODO: replace file name */}
-              <Button variant="link" onClick={() => downloadFile()}>
+              <Button variant="link" onClick={() => downloadFile(resumeId)}>
                 resume.pdf
               </Button>
             </>

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -109,3 +109,5 @@ export const DEMOTE_LEVEL_CONFIRMATION =
   "By lowering the level at this language, the user will no longer be able to start translating or reviewing story translations at this level, in this language. The user will continue having access to any ongoing story translations at this level, in this langauge.";
 
 export const DEMOTE_LEVEL_BUTTON = "I'm sure, lower level";
+
+export const EXPORT_TOOL_TIP_COPY = "Translation not complete";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Implement-export-story-translation-flow-4a0a41104fa647369290e77c128cf7a6

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- added "export" column to `StoryTranslationsTable.tsx`, disabled if translation is not completed
- modified `useFileDownload` hook to make it more reusable

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. in the db, run `UPDATE story_translations set stage='REVIEW' where id=13;`
2. Login as `planetread+dwightdeisenhower@uwblueprint.org`
3. Mark all as approved and submit translation
4. Login as admin
5. Verify that export column appears in "Manage Story Translations" table
6. observe that exporting is disabled for all non-completed translations
7. go to page 2
8. click on export button in row with id = 13
9. observe story translation being exported!!
10. click on `The Great Gatsby` title and verify that the column appears in the story page also


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
