### PR TITLE
Show alert after removing user from story translation

### DIFF
--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../APIClients/queries/StoryQueries";
 import {
   ApprovedLanguagesMap,
+  getMessageFromStoryAssignStage,
   parseApprovedLanguages,
   parseUserBackground,
 } from "../../utils/Utils";
@@ -201,11 +202,7 @@ const UserProfilePage = () => {
             (storyAssignStage !== StoryAssignStage.INITIAL ? (
               <InfoAlert
                 colour="orange.50"
-                message={
-                  storyAssignStage === StoryAssignStage.SUCCESS
-                    ? "A new story was assigned to the user."
-                    : "No stories were assigned to the user."
-                }
+                message={getMessageFromStoryAssignStage(storyAssignStage)}
               />
             ) : (
               <Flex height="50px" />

--- a/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
+++ b/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
@@ -282,7 +282,13 @@ const AssignedStoryTranslationsTable = ({
     if (err !== null) {
       window.alert(err);
     } else {
-      window.location.reload();
+      setStoryAssignStage(StoryAssignStage.REMOVED);
+      setStoryTranslations(
+        storyTranslations!.filter(
+          (t) => t.storyTranslationId !== storyTranslation.storyTranslationId,
+        ),
+      );
+      resetAlertTimeout();
     }
   };
 

--- a/frontend/src/constants/Enums.ts
+++ b/frontend/src/constants/Enums.ts
@@ -9,4 +9,5 @@ export enum StoryAssignStage {
   INITIAL,
   SUCCESS,
   CANCELLED,
+  REMOVED,
 }

--- a/frontend/src/utils/Utils.ts
+++ b/frontend/src/utils/Utils.ts
@@ -1,5 +1,6 @@
 import { CommentResponse } from "../APIClients/queries/CommentQueries";
 import { AdditionalExperiences } from "../APIClients/queries/UserQueries";
+import { StoryAssignStage } from "../constants/Enums";
 
 export const convertStringTitleCase = (s: string) =>
   s[0] + s.substring(1).toLowerCase();
@@ -81,4 +82,19 @@ export const truncate = (num: number, decimals: number): string => {
   }
   const re = new RegExp(`^-?\\d+(?:.\\d{0,${decimals || -1}})?`);
   return num.toString().match(re)![0];
+};
+
+export const getMessageFromStoryAssignStage = (
+  stage: StoryAssignStage,
+): string => {
+  switch (stage) {
+    case StoryAssignStage.SUCCESS:
+      return "A new story was assigned to the user.";
+    case StoryAssignStage.CANCELLED:
+      return "No stories were assigned to the user.";
+    case StoryAssignStage.REMOVED:
+      return "The user has been removed from the story translation.";
+    default:
+      return "";
+  }
 };


### PR DESCRIPTION
…slation

## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Delete-story-translation-toast-on-Assigned-Story-Translations-table-does-not-appear-fda48ebff79b4b5a8b94b6c7fae189f2

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- modified `StoryAssignStage` enum to handle user removal
- display alert and update local state after removing user from translation

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin
2. Go to any user page
3. Remove user from any story translation
4. Verify that page does not reload and row is removed + appropriate alert is shown

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
