### PR TITLE
Add feedback modal to fail grade flow

### DIFF
--- a/frontend/src/components/onboarding/AssignTestGradeModal.tsx
+++ b/frontend/src/components/onboarding/AssignTestGradeModal.tsx
@@ -17,7 +17,6 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
-  Textarea,
 } from "@chakra-ui/react";
 
 import {
@@ -33,6 +32,7 @@ import {
 import ConfirmationModal from "../utils/ConfirmationModal";
 import DropdownIndicator from "../utils/DropdownIndicator";
 import Block from "./Block";
+import TestFeedbackModal from "./TestFeedbackModal";
 
 export type AssignTestGradeModalProps = {
   isOpen: boolean;
@@ -92,14 +92,14 @@ const AssignTestGradeModal = ({
   };
 
   return (
-    <Modal
-      isOpen={isOpen}
-      motionPreset="slideInBottom"
-      onClose={onClose}
-      size="4xl"
-    >
-      <ModalOverlay />
-      {!enterFeedback && (
+    <>
+      <Modal
+        isOpen={isOpen && !enterFeedback}
+        motionPreset="slideInBottom"
+        onClose={onClose}
+        size="4xl"
+      >
+        <ModalOverlay />
         <ModalContent paddingLeft="32px">
           <ModalCloseButton
             marginLeft="auto"
@@ -216,59 +216,16 @@ const AssignTestGradeModal = ({
             </Flex>
           </ModalBody>
         </ModalContent>
-      )}
-      {enterFeedback && (
-        <ModalContent paddingLeft="32px">
-          <ModalCloseButton
-            marginLeft="auto"
-            marginRight="8px"
-            marginTop="8px"
-            position="static"
-          />
-          <ModalHeader paddingTop="20px">
-            <Heading as="h3" size="lg">
-              Feedback to User
-            </Heading>
-          </ModalHeader>
-          <ModalBody paddingBottom="36px">
-            <Grid width="100%" marginBottom="24px">
-              <GridItem marginBottom="24px" paddingRight="32px" rowStart={1}>
-                <Text>
-                  Provide any feedback or comments to the user in the box below
-                  (Optional)
-                </Text>
-                <Textarea
-                  height="285px"
-                  margin="8px 0"
-                  onChange={(e) => setTestFeedback(e.target.value)}
-                  placeholder="Enter your feedback here..."
-                  value={testFeedback}
-                />
-              </GridItem>
-            </Grid>
-            <Flex marginRight="28px" justifyContent="flex-end">
-              <Button
-                colorScheme="blue"
-                fontSize="14px"
-                marginRight="20px"
-                onClick={() => setEnterFeedback(false)}
-                variant="blueOutline"
-                width="120px"
-              >
-                Back
-              </Button>
-              <Button
-                colorScheme="blue"
-                fontSize="14px"
-                onClick={() => setSendAssignGrade(true)}
-                width="120px"
-              >
-                Continue
-              </Button>
-            </Flex>
-          </ModalBody>
-        </ModalContent>
-      )}
+      </Modal>
+      <TestFeedbackModal
+        isOpen={isOpen && enterFeedback}
+        isCentered={false}
+        testFeedback={testFeedback}
+        setTestFeedback={setTestFeedback}
+        onBack={() => setEnterFeedback(false)}
+        onConfirm={() => setSendAssignGrade(true)}
+        confirmString="Continue"
+      />
       <ConfirmationModal
         buttonMessage={ASSIGN_USER_LEVEL_BUTTON}
         confirmation={sendAssignGrade}
@@ -276,7 +233,7 @@ const AssignTestGradeModal = ({
         onClose={() => setSendAssignGrade(false)}
         onConfirmationClick={assignTestLevel}
       />
-    </Modal>
+    </>
   );
 };
 

--- a/frontend/src/components/onboarding/FailUserModal.tsx
+++ b/frontend/src/components/onboarding/FailUserModal.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { useMutation } from "@apollo/client";
+import { useHistory } from "react-router-dom";
+import {
+  FINISH_GRADING_STORY_TRANSLATION,
+  FinishGradingStoryTranslationResponse,
+} from "../../APIClients/mutations/StoryMutations";
+import {
+  GRADING_PAGE_FAIL_USER_CONFIRMATION,
+  GRADING_PAGE_FAIL_USER_BUTTON,
+} from "../../utils/Copy";
+import ConfirmationModal from "../utils/ConfirmationModal";
+import TestFeedbackModal from "./TestFeedbackModal";
+
+export type FailUserModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  storyTranslationId: number;
+};
+
+const FailUserModal = ({
+  isOpen,
+  onClose,
+  storyTranslationId,
+}: FailUserModalProps) => {
+  const [enterFeedback, setEnterFeedback] = useState<boolean>(false);
+  const [testFeedback, setTestFeedback] = useState<string>("");
+
+  const history = useHistory();
+
+  const [finishGradingStoryTranslation] = useMutation<{
+    finishGradingStoryTranslation: FinishGradingStoryTranslationResponse;
+  }>(FINISH_GRADING_STORY_TRANSLATION);
+
+  const failGrade = async (feedback: string) => {
+    const result = await finishGradingStoryTranslation({
+      variables: {
+        storyTranslationTestId: storyTranslationId,
+        testFeedback: feedback,
+        testResult: "{}",
+      },
+    });
+    if (result.data?.finishGradingStoryTranslation.ok) {
+      history.push("/?tab=4");
+    } else {
+      window.alert("Could not mark story translation as failed.");
+    }
+  };
+
+  return (
+    <>
+      <ConfirmationModal
+        confirmation={isOpen && !enterFeedback}
+        onConfirmationClick={() => setEnterFeedback(true)}
+        onClose={onClose}
+        confirmationMessage={GRADING_PAGE_FAIL_USER_CONFIRMATION}
+        buttonMessage={GRADING_PAGE_FAIL_USER_BUTTON}
+      />
+      <TestFeedbackModal
+        isCentered
+        isOpen={isOpen && enterFeedback}
+        testFeedback={testFeedback}
+        setTestFeedback={setTestFeedback}
+        onConfirm={() => {
+          failGrade(testFeedback);
+          setEnterFeedback(false);
+          onClose();
+        }}
+      />
+    </>
+  );
+};
+
+export default FailUserModal;

--- a/frontend/src/components/onboarding/TestFeedbackModal.tsx
+++ b/frontend/src/components/onboarding/TestFeedbackModal.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import {
+  Button,
+  Flex,
+  Grid,
+  GridItem,
+  Heading,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  Textarea,
+} from "@chakra-ui/react";
+
+export type TestFeedbackModalProps = {
+  isOpen: boolean;
+  isCentered: boolean;
+  testFeedback: string;
+  setTestFeedback: (newFeedback: string) => void;
+  onBack?: () => void;
+  onConfirm: () => void;
+  confirmString?: string;
+};
+
+const TestFeedbackModal = ({
+  isOpen,
+  isCentered,
+  testFeedback,
+  setTestFeedback,
+  onBack,
+  onConfirm,
+  confirmString = "Confirm",
+}: TestFeedbackModalProps) => {
+  return (
+    <Modal
+      isCentered={isCentered}
+      isOpen={isOpen}
+      motionPreset="slideInBottom"
+      onClose={() => {}}
+      size="4xl"
+    >
+      <ModalOverlay />
+      <ModalContent paddingLeft="32px">
+        <ModalHeader paddingTop="20px">
+          <Heading as="h3" size="lg">
+            Feedback to User
+          </Heading>
+        </ModalHeader>
+        <ModalBody paddingBottom="36px">
+          <Grid width="100%" marginBottom="24px">
+            <GridItem marginBottom="24px" paddingRight="32px" rowStart={1}>
+              <Text>
+                Provide any feedback or comments to the user in the box below
+                (Optional)
+              </Text>
+              <Textarea
+                height="285px"
+                margin="8px 0"
+                onChange={(e) => setTestFeedback(e.target.value)}
+                placeholder="Enter your feedback here..."
+                value={testFeedback}
+              />
+            </GridItem>
+          </Grid>
+          <Flex marginRight="28px" justifyContent="flex-end">
+            {onBack && (
+              <Button
+                colorScheme="blue"
+                fontSize="14px"
+                marginRight="20px"
+                onClick={onBack}
+                variant="blueOutline"
+                width="120px"
+              >
+                Back
+              </Button>
+            )}
+            <Button
+              colorScheme="blue"
+              fontSize="14px"
+              onClick={onConfirm}
+              width="120px"
+            >
+              {confirmString}
+            </Button>
+          </Flex>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default TestFeedbackModal;

--- a/frontend/src/components/pages/StoryTestGradingPage.tsx
+++ b/frontend/src/components/pages/StoryTestGradingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { useQuery, useMutation } from "@apollo/client";
+import { useQuery } from "@apollo/client";
 import { Box, Text, Divider, Flex, Button, Tooltip } from "@chakra-ui/react";
 import { useParams, Redirect, useHistory } from "react-router-dom";
 
@@ -12,17 +12,10 @@ import { GET_STORY_AND_TRANSLATION_CONTENTS } from "../../APIClients/queries/Sto
 import FontSizeSlider from "../translation/FontSizeSlider";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 import Header from "../navigation/Header";
-import ConfirmationModal from "../utils/ConfirmationModal";
-import {
-  REVIEW_PAGE_TOOL_TIP_COPY,
-  GRADING_PAGE_FAIL_USER_CONFIRMATION,
-  GRADING_PAGE_FAIL_USER_BUTTON,
-} from "../../utils/Copy";
-import {
-  FINISH_GRADING_STORY_TRANSLATION,
-  FinishGradingStoryTranslationResponse,
-} from "../../APIClients/mutations/StoryMutations";
+import { REVIEW_PAGE_TOOL_TIP_COPY } from "../../utils/Copy";
+
 import AssignTestGradeModal from "../onboarding/AssignTestGradeModal";
+import FailUserModal from "../onboarding/FailUserModal";
 
 type StoryTestGradingPageProps = {
   storyIdParam: string | undefined;
@@ -57,8 +50,6 @@ const StoryTestGradingPage = () => {
   const [level, setLevel] = useState<number>(0);
   const [language, setLanguage] = useState<string>("");
   const [stage, setStage] = useState<string>("");
-  // TODO: implement feedback flow for failing users
-  const [testFeedback] = useState<string>("");
 
   const [failUser, setFailUser] = useState(false);
   const [assignGrade, setAssignGrade] = useState(false);
@@ -101,25 +92,6 @@ const StoryTestGradingPage = () => {
   };
 
   const history = useHistory();
-
-  const [finishGradingStoryTranslation] = useMutation<{
-    finishGradingStoryTranslation: FinishGradingStoryTranslationResponse;
-  }>(FINISH_GRADING_STORY_TRANSLATION);
-
-  const failGrade = async (feedback: string | null) => {
-    const result = await finishGradingStoryTranslation({
-      variables: {
-        storyTranslationTestId: storyTranslationId,
-        testFeedback: feedback,
-        testResult: "{}",
-      },
-    });
-    if (result.data?.finishGradingStoryTranslation.ok) {
-      history.push("/");
-    } else {
-      window.alert("Could not mark story translation as failed.");
-    }
-  };
 
   const { loading } = useQuery(
     GET_STORY_AND_TRANSLATION_CONTENTS(storyId, storyTranslationId),
@@ -260,12 +232,10 @@ const StoryTestGradingPage = () => {
             </Flex>
           </Flex>
         </Flex>
-        <ConfirmationModal
-          confirmation={failUser}
-          onConfirmationClick={() => failGrade(testFeedback)}
+        <FailUserModal
+          isOpen={failUser}
           onClose={closeFailUserModal}
-          confirmationMessage={GRADING_PAGE_FAIL_USER_CONFIRMATION}
-          buttonMessage={GRADING_PAGE_FAIL_USER_BUTTON}
+          storyTranslationId={storyTranslationId}
         />
         <AssignTestGradeModal
           isOpen={assignGrade}


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Add-feedback-modal-to-fail-grade-flow-4a2ca39f3279424a95fa4cb5ecae2170

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- create `FailUserModal.tsx` to encapsulate fail user flow

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login to any user and start new story test
2. Submit for review
3. Login as admin and grade story test
4. Click "Fail user" and verify that feedback modal appears after clicking "I'm sure"
5. Play around with the flow (closing modals, confirmation, etc.)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
