### PR TITLE
Disable buttons when stage is not review

### DIFF
--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -225,7 +225,7 @@ const ReviewPage = () => {
                   size="secondary"
                   margin="0 10px 0"
                   width="250px"
-                  disabled={stage === "TRANSLATE"}
+                  disabled={stage !== "REVIEW"}
                   onClick={
                     numApprovedLines === translatedStoryLines.length
                       ? openSubmitTranslationModal

--- a/frontend/src/components/pages/StoryTestGradingPage.tsx
+++ b/frontend/src/components/pages/StoryTestGradingPage.tsx
@@ -252,7 +252,7 @@ const StoryTestGradingPage = () => {
                   <Button
                     colorScheme="red"
                     variant="outline"
-                    disabled={stage === "TRANSLATE"}
+                    disabled={stage !== "REVIEW"}
                     onClick={openFailUserModal}
                   >
                     Fail User
@@ -267,7 +267,7 @@ const StoryTestGradingPage = () => {
                 <Box marginLeft="24px" marginRight="20px">
                   <Button
                     colorScheme="blue"
-                    disabled={stage === "TRANSLATE"}
+                    disabled={stage !== "REVIEW"}
                     onClick={openAssignGradeModal}
                   >
                     Assign Level{" "}


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Disable SUBMIT TRANSLATION button if stage ≠ REVIEW](https://www.notion.so/uwblueprintexecs/Disable-SUBMIT-TRANSLATION-button-if-stage-REVIEW-97bcecb4df35421dbd3faa937d439b2b)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Disable buttons for grading and submitting if the story stage is not REVIEW

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as a translator and go to a story translation that you are reviewing 
2. Check that a story translation in the translation stage has a disabled submit translation button
3. Move the story to review, check that the button is enabled
4. Login as admin
5. Repeat the steps with a story test

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
