### PR TITLE
Display translator_last_activity in Date Submitted Col in StoryTestsT…

### DIFF
--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -105,7 +105,7 @@ class StoryTranslationTestResponseDTO(graphene.ObjectType):
     test_grade = graphene.Int()
     test_result = graphene.JSONString(required=False)
     test_feedback = graphene.String()
-    date_submitted = graphene.DateTime()
+    translator_last_activity = graphene.DateTime()
 
 
 class StoryTranslationNode(graphene.ObjectType):

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -347,7 +347,7 @@ export type StoryTranslationTest = {
   testGrade: number;
   testResult: StoryTestResult | null;
   testFeedback: string;
-  dateSubmitted: Date;
+  translatorLastActivity: Date;
 };
 
 export const buildStoryTranslationTestsQuery = (
@@ -380,7 +380,7 @@ export const buildStoryTranslationTestsQuery = (
           testGrade
           testResult
           testFeedback
-          dateSubmitted
+          translatorLastActivity
         }
       }
     `,

--- a/frontend/src/components/admin/StoryTestsTable.tsx
+++ b/frontend/src/components/admin/StoryTestsTable.tsx
@@ -84,8 +84,8 @@ const StoryTestsTable = ({
    * ascending/descending order
    */
   const dateSort = (t1: StoryTranslationTest, t2: StoryTranslationTest) => {
-    const dateT1 = t1.dateSubmitted;
-    const dateT2 = t2.dateSubmitted;
+    const dateT1 = t1.translatorLastActivity;
+    const dateT2 = t2.translatorLastActivity;
     const forwardCompare = +(dateT2 > dateT1); // 1 if dateT2 > dateT1
     const reverseCompare = +(dateT1 > dateT2); // 1 if dateT1 > dateT2
     return isAscendingDate
@@ -143,7 +143,9 @@ const StoryTestsTable = ({
             }`}
           </Badge>
         </Td>
-        <Td>{storyTest.dateSubmitted?.toLocaleDateString()}</Td>
+        <Td>
+          {new Date(storyTest.translatorLastActivity).toLocaleDateString()}
+        </Td>
         <Td>
           <Button
             borderRadius="8px"


### PR DESCRIPTION
…able

## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Display translator_last_activity in Date Submitted Col in StoryTestsTable](https://www.notion.so/uwblueprintexecs/Display-translator_last_activity-in-Date-Submitted-Col-in-StoryTestsTable-ded32909f16a466d802d269dd2a2b148)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Changed `dateSubmitted` to `translatorLastActivity` on the backend

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl (or another translator)
2. Level up and add a few new languages
3. Submit the tests for review (remember the order in which you submitted)
4. Login as Angela
5. Go to manage tests
6. Observe that the date submitted column is populated and correct (note that the time zone is UTC)
7. Sort the tests by date submitted (ascending and descending) and check that order is correct

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?
- Is the code ok?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
