### PR TITLE
Add delete user tool tip on UserTable

### DIFF
--- a/frontend/src/components/admin/UsersTable.tsx
+++ b/frontend/src/components/admin/UsersTable.tsx
@@ -10,6 +10,7 @@ import {
   Tr,
   Th,
   Td,
+  Tooltip,
   IconButton,
 } from "@chakra-ui/react";
 import { useMutation } from "@apollo/client";
@@ -19,6 +20,7 @@ import { getLevelVariant } from "../../utils/StatusUtils";
 import {
   MANAGE_USERS_TABLE_DELETE_USER_BUTTON,
   MANAGE_USERS_TABLE_DELETE_USER_CONFIRMATION,
+  DELETE_USER,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
 import {
@@ -118,13 +120,15 @@ const UsersTable = ({
       </Td>
       <Td>{generateBadges(approvedLanguages[index])}</Td>
       <Td>
-        <IconButton
-          aria-label={`Delete user ${userObj?.firstName} ${userObj?.lastName}`}
-          background="transparent"
-          icon={<Icon as={MdDelete} />}
-          width="fit-content"
-          onClick={() => openModal(parseInt(userObj?.id!, 10))}
-        />
+        <Tooltip hasArrow label={DELETE_USER} placement="top">
+          <IconButton
+            aria-label={`Delete user ${userObj?.firstName} ${userObj?.lastName}`}
+            background="transparent"
+            icon={<Icon as={MdDelete} />}
+            width="fit-content"
+            onClick={() => openModal(parseInt(userObj?.id!, 10))}
+          />
+        </Tooltip>
       </Td>
     </Tr>
   ));

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -121,4 +121,4 @@ export const DEMOTE_LEVEL_BUTTON = "I'm sure, lower level";
 
 export const EXPORT_TOOL_TIP_COPY = "Translation not complete";
 
-export const DELETE_USER = "Delete user.";
+export const DELETE_USER = "Delete user";

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -120,3 +120,5 @@ export const DEMOTE_LEVEL_CONFIRMATION =
 export const DEMOTE_LEVEL_BUTTON = "I'm sure, lower level";
 
 export const EXPORT_TOOL_TIP_COPY = "Translation not complete";
+
+export const DELETE_USER = "Delete user.";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[tooltip](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=7165106552f34e67aab3905b6ef938f5)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Add tooltip to delete user icon 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to admin page and see Manage Translators and Manage Reviewers 
2. Ensure that the tooltip is displayed when mouse hovers over the delete icon 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- theoretical computer science 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
