### PR TITLE
Open WIP comment under bottom of thread on reply

### DIFF
--- a/frontend/src/components/review/CommentThread.tsx
+++ b/frontend/src/components/review/CommentThread.tsx
@@ -9,24 +9,29 @@ import {
 } from "../../APIClients/mutations/CommentMutations";
 
 export type CommentThreadProps = {
-  comment: CommentResponse;
   comments: CommentResponse[];
+  commentsIdx: number;
+  reviewerName: string;
   setComments: (comments: CommentResponse[]) => void;
-  threadReplies: CommentResponse[];
   updateCommentsAsResolved: (index: number) => void;
   updateThreadHeadMap: (cmts: CommentResponse[]) => void;
-  userName: string;
+  threadHeadMap: boolean[];
+  translatorId: number;
+  translatorName: string;
 };
 
 const CommentThread = ({
-  comment,
   comments,
+  commentsIdx,
+  reviewerName,
   setComments,
-  threadReplies,
   updateCommentsAsResolved,
   updateThreadHeadMap,
-  userName,
+  threadHeadMap,
+  translatorId,
+  translatorName,
 }: CommentThreadProps) => {
+  const comment = comments[commentsIdx];
   const {
     content,
     id,
@@ -34,10 +39,15 @@ const CommentThread = ({
     resolved,
     storyTranslationContentId: stcId,
   } = comment;
-  const handleError = (errorMessage: string) => {
-    // eslint-disable-next-line no-alert
-    alert(errorMessage);
-  };
+
+  const threadReplies = [];
+  for (
+    let i = commentsIdx + 1;
+    i < comments.length && !threadHeadMap[i];
+    i += 1
+  ) {
+    threadReplies.push(comments[i]);
+  }
 
   const [reply, setReply] = useState(-1);
   const [storyTranslationContentId, setStoryTranslationContentId] =
@@ -46,6 +56,16 @@ const CommentThread = ({
   const [updateComment] = useMutation<{
     updateCommentById: UpdateCommentResponse;
   }>(UPDATE_COMMENT_BY_ID);
+
+  const handleReply = () => {
+    setStoryTranslationContentId(storyTranslationContentId);
+    setReply(storyContentId);
+  };
+
+  const handleError = (errorMessage: string) => {
+    // eslint-disable-next-line no-alert
+    alert(errorMessage);
+  };
 
   const resolveExistingComment = async () => {
     try {
@@ -67,15 +87,10 @@ const CommentThread = ({
       if (typeof err === "string") {
         handleError(err);
       } else {
-        console.log(err);
+        window.alert(err);
         handleError("Error occurred, please try again.");
       }
     }
-  };
-
-  const handleReply = () => {
-    setStoryTranslationContentId(storyTranslationContentId);
-    setReply(storyContentId);
   };
 
   return (
@@ -86,18 +101,22 @@ const CommentThread = ({
         isFirstReply={false}
         isThreadHead
         resolveExistingComment={resolveExistingComment}
-        userName={userName}
+        userName={
+          translatorId === comment.userId ? translatorName : reviewerName
+        }
       />
       {threadReplies.map(function (threadReply: CommentResponse, i: number) {
         return (
           <ExistingComment
             comment={threadReply}
-            handleReply={handleReply}
             isFirstReply={i === 0}
             isThreadHead={false}
             key={threadReply.id}
-            resolveExistingComment={resolveExistingComment}
-            userName={userName}
+            userName={
+              translatorId === threadReply.userId
+                ? translatorName
+                : reviewerName
+            }
           />
         );
       })}

--- a/frontend/src/components/review/CommentThread.tsx
+++ b/frontend/src/components/review/CommentThread.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from "react";
+import { useMutation } from "@apollo/client";
+import ExistingComment from "./ExistingComment";
+import WIPComment from "./WIPComment";
+import { CommentResponse } from "../../APIClients/queries/CommentQueries";
+import {
+  UPDATE_COMMENT_BY_ID,
+  UpdateCommentResponse,
+} from "../../APIClients/mutations/CommentMutations";
+
+export type CommentThreadProps = {
+  comment: CommentResponse;
+  comments: CommentResponse[];
+  setComments: (comments: CommentResponse[]) => void;
+  threadReplies: CommentResponse[];
+  updateCommentsAsResolved: (index: number) => void;
+  updateThreadHeadMap: (cmts: CommentResponse[]) => void;
+  userName: string;
+};
+
+const CommentThread = ({
+  comment,
+  comments,
+  setComments,
+  threadReplies,
+  updateCommentsAsResolved,
+  updateThreadHeadMap,
+  userName,
+}: CommentThreadProps) => {
+  const {
+    content,
+    id,
+    lineIndex: storyContentId,
+    resolved,
+    storyTranslationContentId: stcId,
+  } = comment;
+  const handleError = (errorMessage: string) => {
+    // eslint-disable-next-line no-alert
+    alert(errorMessage);
+  };
+
+  const [reply, setReply] = useState(-1);
+  const [storyTranslationContentId, setStoryTranslationContentId] =
+    useState(stcId);
+
+  const [updateComment] = useMutation<{
+    updateCommentById: UpdateCommentResponse;
+  }>(UPDATE_COMMENT_BY_ID);
+
+  const resolveExistingComment = async () => {
+    try {
+      if (!resolved) {
+        const commentData = {
+          id,
+          resolved: true,
+          content,
+        };
+
+        const result = await updateComment({
+          variables: { commentData },
+        });
+        if (result.data?.updateCommentById.ok) {
+          updateCommentsAsResolved(id);
+        }
+      }
+    } catch (err) {
+      if (typeof err === "string") {
+        handleError(err);
+      } else {
+        console.log(err);
+        handleError("Error occurred, please try again.");
+      }
+    }
+  };
+
+  const handleReply = () => {
+    setStoryTranslationContentId(storyTranslationContentId);
+    setReply(storyContentId);
+  };
+
+  return (
+    <>
+      <ExistingComment
+        comment={comment}
+        handleReply={handleReply}
+        isFirstReply={false}
+        isThreadHead
+        resolveExistingComment={resolveExistingComment}
+        userName={userName}
+      />
+      {threadReplies.map(function (threadReply: CommentResponse, i: number) {
+        return (
+          <ExistingComment
+            comment={threadReply}
+            handleReply={handleReply}
+            isFirstReply={i === 0}
+            isThreadHead={false}
+            key={threadReply.id}
+            resolveExistingComment={resolveExistingComment}
+            userName={userName}
+          />
+        );
+      })}
+      {reply > -1 && (
+        <WIPComment
+          comments={comments}
+          isReply
+          setCommentLine={setReply}
+          setComments={setComments}
+          storyTranslationContentId={storyTranslationContentId}
+          updateThreadHeadMap={updateThreadHeadMap}
+          WIPLineIndex={reply + 1}
+        />
+      )}
+    </>
+  );
+};
+
+export default CommentThread;

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -113,39 +113,39 @@ const CommentsPanel = ({
 
   const CommentsList = () => {
     if (comments.length > 0) {
-      const commentThreads = [];
-      for (let i = 0; i < comments.length; i += 1) {
-        if (threadHeadMap[i]) {
-          const comment = comments[i];
-          const threadReplies = [];
-          while (i + 1 < comments.length && !threadHeadMap[i + 1]) {
-            i += 1;
-            threadReplies.push(comments[i]);
-          }
-          commentThreads.push(
-            <CommentThread
-              comment={comment}
-              comments={comments}
-              key={comment.id}
-              setComments={setComments}
-              threadReplies={threadReplies}
-              updateCommentsAsResolved={updateCommentsAsResolved}
-              updateThreadHeadMap={updateThreadHeadMap}
-              userName={
-                translatorId === comment.userId ? translatorName : reviewerName
-              }
-            />,
-          );
-        }
-      }
-      return <Box>{commentThreads}</Box>;
+      return (
+        <Box>
+          {comments.map(function (comment: CommentResponse, i: number) {
+            if (threadHeadMap[i]) {
+              return (
+                <CommentThread
+                  comments={comments}
+                  commentsIdx={i}
+                  key={comment.id}
+                  reviewerName={reviewerName}
+                  setComments={setComments}
+                  updateCommentsAsResolved={updateCommentsAsResolved}
+                  updateThreadHeadMap={updateThreadHeadMap}
+                  threadHeadMap={threadHeadMap}
+                  translatorId={translatorId}
+                  translatorName={translatorName}
+                />
+              );
+            }
+            return null;
+          })}
+        </Box>
+      );
     }
-    return (
-      <Text variant="comment">
-        Looks like there aren&apos;t any comments yet! Select the Comment button
-        above to begin leaving comments.
-      </Text>
-    );
+    if (commentLine <= 0) {
+      return (
+        <Text variant="comment">
+          Looks like there aren&apos;t any comments yet! Select the Comment
+          button above to begin leaving comments.
+        </Text>
+      );
+    }
+    return null;
   };
 
   const filterOptionsComponent = filterOptions.map((op) => (

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -5,8 +5,8 @@ import {
   CommentResponse,
   buildCommentsQuery,
 } from "../../APIClients/queries/CommentQueries";
+import CommentThread from "./CommentThread";
 import WIPComment from "./WIPComment";
-import ExistingComment from "./ExistingComment";
 
 export type CommentPanelProps = {
   storyTranslationId: number;
@@ -113,27 +113,32 @@ const CommentsPanel = ({
 
   const CommentsList = () => {
     if (comments.length > 0) {
-      return (
-        <Box>
-          {/* TODO: show correct placement of the WIPComment component once existing comment is displayed */}
-          {comments.map((comment: CommentResponse, i: number) => (
-            <ExistingComment
+      const commentThreads = [];
+      for (let i = 0; i < comments.length; i += 1) {
+        if (threadHeadMap[i]) {
+          const comment = comments[i];
+          const threadReplies = [];
+          while (i + 1 < comments.length && !threadHeadMap[i + 1]) {
+            i += 1;
+            threadReplies.push(comments[i]);
+          }
+          commentThreads.push(
+            <CommentThread
+              comment={comment}
+              comments={comments}
               key={comment.id}
-              commentsStateIdx={i}
+              setComments={setComments}
+              threadReplies={threadReplies}
+              updateCommentsAsResolved={updateCommentsAsResolved}
+              updateThreadHeadMap={updateThreadHeadMap}
               userName={
                 translatorId === comment.userId ? translatorName : reviewerName
               }
-              comment={comment}
-              WIPLineIndex={commentLine}
-              updateCommentsAsResolved={updateCommentsAsResolved}
-              comments={comments}
-              setComments={setComments}
-              threadHeadMap={threadHeadMap}
-              updateThreadHeadMap={updateThreadHeadMap}
-            />
-          ))}
-        </Box>
-      );
+            />,
+          );
+        }
+      }
+      return <Box>{commentThreads}</Box>;
     }
     return (
       <Text variant="comment">
@@ -186,12 +191,13 @@ const CommentsPanel = ({
       </Flex>
       {commentLine > 0 && (
         <WIPComment
-          WIPLineIndex={commentLine}
-          storyTranslationContentId={storyTranslationContentId}
-          setCommentLine={setCommentLine}
           comments={comments}
+          isReply={false}
+          setCommentLine={setCommentLine}
           setComments={setComments}
+          storyTranslationContentId={storyTranslationContentId}
           updateThreadHeadMap={updateThreadHeadMap}
+          WIPLineIndex={commentLine}
         />
       )}
       <CommentsList />

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -1,100 +1,30 @@
-import React, { useState } from "react";
-import { useMutation } from "@apollo/client";
+import React from "react";
 import { Text, Flex, Button } from "@chakra-ui/react";
-import WIPComment from "./WIPComment";
-import {
-  UPDATE_COMMENT_BY_ID,
-  UpdateCommentResponse,
-} from "../../APIClients/mutations/CommentMutations";
 import { CommentResponse } from "../../APIClients/queries/CommentQueries";
 
 export type ExistingCommentProps = {
-  commentsStateIdx: number;
-  userName: string;
   comment: CommentResponse;
-  updateCommentsAsResolved: (index: number) => void;
-  comments: CommentResponse[];
-  setComments: (comments: CommentResponse[]) => void;
-  WIPLineIndex: number;
-  threadHeadMap: boolean[];
-  updateThreadHeadMap: (cmts: CommentResponse[]) => void;
+  handleReply: () => void;
+  isFirstReply: boolean;
+  isThreadHead: boolean;
+  resolveExistingComment: () => void;
+  userName: string;
 };
 
 const ExistingComment = ({
-  commentsStateIdx,
-  userName,
   comment,
-  updateCommentsAsResolved,
-  setComments,
-  comments,
-  threadHeadMap,
-  updateThreadHeadMap,
+  handleReply,
+  isFirstReply,
+  isThreadHead,
+  resolveExistingComment,
+  userName,
 }: ExistingCommentProps) => {
-  const {
-    id,
-    resolved,
-    content,
-    time,
-    lineIndex: storyContentId,
-    commentIndex,
-    storyTranslationContentId: stcId,
-  } = comment;
-  const handleError = (errorMessage: string) => {
-    // eslint-disable-next-line no-alert
-    alert(errorMessage);
-  };
-
-  const [reply, setReply] = useState(-1);
-  const [storyTranslationContentId, setStoryTranslationContentId] =
-    useState(stcId);
-
-  const [updateComment] = useMutation<{
-    updateCommentById: UpdateCommentResponse;
-  }>(UPDATE_COMMENT_BY_ID);
-
-  const resolveExistingComment = async () => {
-    try {
-      if (!resolved) {
-        const commentData = {
-          id,
-          resolved: true,
-          content,
-        };
-
-        const result = await updateComment({
-          variables: { commentData },
-        });
-        if (result.data?.updateCommentById.ok) {
-          updateCommentsAsResolved(id);
-        }
-      }
-    } catch (err) {
-      if (typeof err === "string") {
-        handleError(err);
-      } else {
-        console.log(err);
-        handleError("Error occurred, please try again.");
-      }
-    }
-  };
-
-  const handleReply = () => {
-    setStoryTranslationContentId(storyTranslationContentId);
-    setReply(storyContentId);
-  };
+  const { content, lineIndex: storyContentId, resolved, time } = comment;
 
   const newTime = new Date(time);
   const displayTime = new Date(
     newTime.getTime() - newTime.getTimezoneOffset() * 60000,
   );
-
-  const isThreadHead = commentIndex === 0 || threadHeadMap[commentsStateIdx];
-  const isFirstReply =
-    !threadHeadMap[commentsStateIdx] &&
-    threadHeadMap[commentsStateIdx - 1] &&
-    comments[commentsStateIdx - 1].storyTranslationContentId ===
-      storyTranslationContentId;
-  const isLive = !resolved && isThreadHead;
 
   return (
     <Flex
@@ -127,7 +57,7 @@ const ExistingComment = ({
         {content}
       </Text>
       <Flex>
-        {isThreadHead && isLive && (
+        {!resolved && isThreadHead && (
           <>
             <Button onClick={() => handleReply()} variant="commentLabel">
               Reply
@@ -138,16 +68,6 @@ const ExistingComment = ({
           </>
         )}
       </Flex>
-      {reply > -1 && (
-        <WIPComment
-          WIPLineIndex={reply + 1}
-          storyTranslationContentId={storyTranslationContentId}
-          setCommentLine={setReply}
-          comments={comments}
-          setComments={setComments}
-          updateThreadHeadMap={updateThreadHeadMap}
-        />
-      )}
     </Flex>
   );
 };

--- a/frontend/src/components/review/ExistingComment.tsx
+++ b/frontend/src/components/review/ExistingComment.tsx
@@ -4,10 +4,10 @@ import { CommentResponse } from "../../APIClients/queries/CommentQueries";
 
 export type ExistingCommentProps = {
   comment: CommentResponse;
-  handleReply: () => void;
+  handleReply?: () => void;
   isFirstReply: boolean;
   isThreadHead: boolean;
-  resolveExistingComment: () => void;
+  resolveExistingComment?: () => void;
   userName: string;
 };
 
@@ -59,7 +59,10 @@ const ExistingComment = ({
       <Flex>
         {!resolved && isThreadHead && (
           <>
-            <Button onClick={() => handleReply()} variant="commentLabel">
+            <Button
+              onClick={handleReply ? () => handleReply() : undefined}
+              variant="commentLabel"
+            >
               Reply
             </Button>
             <Button onClick={resolveExistingComment} variant="commentLabel">

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from "react";
 import { useMutation } from "@apollo/client";
-import { Flex, Button, Textarea } from "@chakra-ui/react";
+import { Button, Flex, Text, Textarea } from "@chakra-ui/react";
 import AuthContext from "../../contexts/AuthContext";
 import {
   CreateCommentResponse,
@@ -10,20 +10,22 @@ import { CommentResponse } from "../../APIClients/queries/CommentQueries";
 import { insertSortedComments } from "../../utils/Utils";
 
 export type WIPCommentProps = {
-  storyTranslationContentId: number;
-  WIPLineIndex: number;
-  setCommentLine: (line: number) => void;
   comments: CommentResponse[];
+  isReply: boolean;
+  setCommentLine: (line: number) => void;
   setComments: (comments: CommentResponse[]) => void;
+  storyTranslationContentId: number;
   updateThreadHeadMap: (cmts: CommentResponse[]) => void;
+  WIPLineIndex: number;
 };
 
 const WIPComment = ({
-  storyTranslationContentId,
-  WIPLineIndex,
+  comments,
+  isReply,
   setCommentLine,
   setComments,
-  comments,
+  storyTranslationContentId,
+  WIPLineIndex,
   updateThreadHeadMap,
 }: WIPCommentProps) => {
   const handleError = (errorMessage: string) => {
@@ -78,27 +80,30 @@ const WIPComment = ({
       padding="14px 14px"
       width="300px"
     >
-      <b>Line {WIPLineIndex}</b>
-      <p>{name}</p>
+      <Text fontWeight="bold" marginBottom="10px">
+        {isReply && "Replying to"} Line {WIPLineIndex}
+      </Text>
+      <Text marginBottom="10px">{name}</Text>
       <Textarea
-        value={text}
+        margin="10px 0"
         onChange={(e) => setText(e.target.value)}
-        margin="8px 0"
-        placeholder="Comment or add others with @"
+        placeholder="Add a comment"
+        value={text}
       />
       <Flex direction="row">
         <Button
-          size="secondary"
           colorScheme="blue"
-          onClick={createNewComment}
           isDisabled={text.length < 1}
+          marginRight="10px"
+          onClick={createNewComment}
+          size="secondary"
         >
           Comment
         </Button>
         <Button
+          onClick={() => setCommentLine(-1)}
           size="secondary"
           variant="blueOutline"
-          onClick={() => setCommentLine(-1)}
         >
           Cancel
         </Button>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Open WIP comment under bottom of thread on reply](https://www.notion.so/uwblueprintexecs/Open-WIP-comment-under-bottom-of-thread-on-reply-18773f3eda68496892e0308f73e9577a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Created new CommentThread component which contains the thread head, replies, and wip comment (located below the existing replies)
- CommentThread component created by splitting up the ExistingComment component

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl
2. View Great Gatsby translation
3. Reply to a comment
4. Observe that WIPComment appears below existing replies

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?
- Is the code readable?
- Does the implementation make sense?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
