### PR TITLE
Display completed story tests and review progress in StoryTestsTable

### DIFF
--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -64,11 +64,13 @@ def resolve_story_translations(
 
 
 @require_authorization_by_role_gql({"User", "Admin"})
-def resolve_story_translation_tests(root, info, language, level, stage, story_title):
+def resolve_story_translation_tests(
+    root, info, language, level, stage, story_title, submitted_only
+):
     user_id = get_user_id_from_request()
     user = services["user"].get_user_by_id(user_id)
     return services["story"].get_story_translation_tests(
-        user, language, level, stage, story_title
+        user, language, level, stage, story_title, submitted_only
     )
 
 

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -118,6 +118,7 @@ class Query(graphene.ObjectType):
         level=graphene.Int(),
         stage=graphene.String(),
         story_title=graphene.String(),
+        submitted_only=graphene.Boolean(),
     )
     story_translations_by_user = graphene.Field(
         graphene.List(StoryTranslationResponseDTO),
@@ -214,10 +215,17 @@ class Query(graphene.ObjectType):
         )
 
     def resolve_story_translation_tests(
-        root, info, language=None, level=None, stage=None, story_title=None, **kwargs
+        root,
+        info,
+        language=None,
+        level=None,
+        stage=None,
+        story_title=None,
+        submitted_only=False,
+        **kwargs
     ):
         return resolve_story_translation_tests(
-            root, info, language, level, stage, story_title
+            root, info, language, level, stage, story_title, submitted_only
         )
 
     def resolve_story_translation_by_id(root, info, id):

--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -106,6 +106,7 @@ class StoryTranslationTestResponseDTO(graphene.ObjectType):
     test_result = graphene.JSONString(required=False)
     test_feedback = graphene.String()
     translator_last_activity = graphene.DateTime()
+    reviewer_last_activity = graphene.DateTime()
 
 
 class StoryTranslationNode(graphene.ObjectType):

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 import docx
 from flask import current_app
+from sqlalchemy import or_
 from sqlalchemy.orm import aliased
 from werkzeug.utils import secure_filename
 
@@ -320,9 +321,17 @@ class StoryService(IStoryService):
         level=None,
         stage=None,
         story_title=None,
+        submitted_only=False,
     ):
         try:
             filters = [StoryTranslation.is_test]
+            if submitted_only:
+                filters.append(
+                    or_(
+                        StoryTranslation.stage == "REVIEW",
+                        StoryTranslation.stage == "PUBLISH",
+                    )
+                )
             if language is not None:
                 filters.append(StoryTranslation.language == language)
             if stage is not None:

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -97,7 +97,9 @@ class IStoryService(ABC):
         pass
 
     @abstractmethod
-    def get_story_translation_tests(self, user, language, level, stage, story_title):
+    def get_story_translation_tests(
+        self, user, language, level, stage, story_title, submitted_only
+    ):
         """Return a list of story translation tests based on filters
 
         :param user: UserDTO
@@ -105,6 +107,7 @@ class IStoryService(ABC):
         :param level: level of story translation tests to filter by
         :param stage: stage of story translation tests to filter by
         :param story_title: story_title of story translation tests to filter by
+        :param submitted_only: indicates whether to return only tests that have been submitted
         :return: list of StoryTranslationTestResponseDTO's
         :rtype: list of StoryTranslationTestResponseDTO's
         """

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -348,6 +348,7 @@ export type StoryTranslationTest = {
   testResult: StoryTestResult | null;
   testFeedback: string;
   translatorLastActivity: Date;
+  reviewerLastActivity: Date | null;
 };
 
 export const buildStoryTranslationTestsQuery = (
@@ -355,11 +356,13 @@ export const buildStoryTranslationTestsQuery = (
   level?: number,
   stage?: string,
   storyTitle?: string,
+  submittedOnly?: boolean,
 ) => {
   let queryParams = language ? `language: "${language}", ` : "";
   queryParams += level ? `level: ${level}, ` : "";
   queryParams += stage ? `stage: "${stage}", ` : "";
   queryParams += storyTitle ? `storyTitle: "${storyTitle}", ` : "";
+  queryParams += submittedOnly ? `submittedOnly: true, ` : "";
   queryParams = queryParams ? `(${queryParams})` : "";
 
   return {
@@ -381,6 +384,7 @@ export const buildStoryTranslationTestsQuery = (
           testResult
           testFeedback
           translatorLastActivity
+          reviewerLastActivity
         }
       }
     `,

--- a/frontend/src/components/admin/ManageStoryTests.tsx
+++ b/frontend/src/components/admin/ManageStoryTests.tsx
@@ -24,13 +24,14 @@ const ManageStoryTests = () => {
     parseInt(level || "", 10) || 0,
     convertTitleCaseToStage(stage || ""),
     searchText || "",
+    true,
   );
 
   const { data } = useQuery(query.string, {
     fetchPolicy: "cache-and-network",
     onCompleted: () => {
       const result = [...data[query.fieldName]];
-      setStoryTests(result.filter((test) => test.stage === "REVIEW"));
+      setStoryTests(result);
     },
   });
 

--- a/frontend/src/components/admin/StoryTestsTable.tsx
+++ b/frontend/src/components/admin/StoryTestsTable.tsx
@@ -22,7 +22,7 @@ import {
   MANAGE_TESTS_TABLE_DELETE_TEST_CONFIRMATION,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
-import { generateSortFn } from "../../utils/Utils";
+import { generateSortFn, getStoryTestProgress } from "../../utils/Utils";
 import { StoryTranslationTest } from "../../APIClients/queries/StoryQueries";
 import {
   SoftDeleteStoryTranslationResponse,
@@ -48,6 +48,7 @@ const StoryTestsTable = ({
 }: StoryTestsTableProps) => {
   const [isAscendingName, setIsAscendingName] = useState(true);
   const [isAscendingDate, setIsAscendingDate] = useState(true);
+  const [isAscendingStage, setIsAscendingStage] = useState(true);
 
   const [confirmDeleteTranslation, setConfirmDeleteTranslation] =
     useState(false);
@@ -93,6 +94,14 @@ const StoryTestsTable = ({
       : reverseCompare - forwardCompare;
   };
 
+  const stageSort = (t1: StoryTranslationTest, t2: StoryTranslationTest) => {
+    const stageT1 = getStoryTestProgress(t1);
+    const stageT2 = getStoryTestProgress(t2);
+    return isAscendingStage
+      ? stageT1.localeCompare(stageT2)
+      : stageT2.localeCompare(stageT1);
+  };
+
   const sortDict: StoryTranslationTestsFieldSortDict = {
     name: {
       sortFn: generateSortFn<StoryTranslationTest>(
@@ -101,6 +110,11 @@ const StoryTestsTable = ({
       ),
       isAscending: isAscendingName,
       setIsAscending: setIsAscendingName,
+    },
+    stage: {
+      sortFn: stageSort,
+      isAscending: isAscendingStage,
+      setIsAscending: setIsAscendingStage,
     },
     date: {
       sortFn: dateSort,
@@ -143,22 +157,41 @@ const StoryTestsTable = ({
             }`}
           </Badge>
         </Td>
+        <Td>{getStoryTestProgress(storyTest)}</Td>
         <Td>
           {new Date(storyTest.translatorLastActivity).toLocaleDateString()}
         </Td>
         <Td>
-          <Button
-            borderRadius="8px"
-            colorScheme="blue"
-            size="secondary"
-            onClick={() =>
-              history.push(`/grade/${storyTest.storyId}/${storyTest.id}`)
-            }
-            width="110px"
-            marginRight="32px"
-          >
-            Grade
-          </Button>
+          {storyTest.stage === "PUBLISH" ? (
+            <Button
+              borderRadius="8px"
+              borderWidth="1px"
+              colorScheme="white"
+              size="secondary"
+              textColor="blue.100"
+              onClick={() =>
+                history.push(`/grade/${storyTest.storyId}/${storyTest.id}`)
+              }
+              width="110px"
+              marginRight="32px"
+            >
+              View Test
+            </Button>
+          ) : (
+            <Button
+              borderRadius="8px"
+              colorScheme="blue"
+              size="secondary"
+              onClick={() =>
+                history.push(`/grade/${storyTest.storyId}/${storyTest.id}`)
+              }
+              width="110px"
+              marginRight="32px"
+            >
+              Grade
+            </Button>
+          )}
+
           <IconButton
             aria-label={`Delete story test ${storyTest.id} for story ${storyTest.title}`}
             background="transparent"
@@ -190,6 +223,9 @@ const StoryTestsTable = ({
             isAscendingName ? "↑" : "↓"
           }`}</Th>
           <Th>LANGUAGE & LEVEL</Th>
+          <Th cursor="pointer" onClick={() => sort("stage")}>{`PROGRESS ${
+            isAscendingStage ? "↑" : "↓"
+          }`}</Th>
           <Th cursor="pointer" onClick={() => sort("date")}>{`DATE SUBMITTED ${
             isAscendingDate ? "↑" : "↓"
           }`}</Th>

--- a/frontend/src/utils/Utils.ts
+++ b/frontend/src/utils/Utils.ts
@@ -1,4 +1,5 @@
 import { CommentResponse } from "../APIClients/queries/CommentQueries";
+import { StoryTranslationTest } from "../APIClients/queries/StoryQueries";
 import { AdditionalExperiences } from "../APIClients/queries/UserQueries";
 import { StoryAssignStage } from "../constants/Enums";
 
@@ -97,4 +98,14 @@ export const getMessageFromStoryAssignStage = (
     default:
       return "";
   }
+};
+
+export const getStoryTestProgress = (test: StoryTranslationTest): string => {
+  if (test.stage === "REVIEW") {
+    return test.reviewerLastActivity ? "In Review" : "Not Reviewed";
+    // eslint-disable-next-line no-else-return
+  } else if (test.stage === "PUBLISH") {
+    return "Reviewed";
+  }
+  return "Not Submitted";
 };


### PR DESCRIPTION
Last PR of 2021!!

## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Modify-StoryTestTable-to-display-completed-tests-aac9883ed973401d96a81bd0194f7bcd

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- modified query to optionally return story tests in REVIEW and PUBLISH
- display review progress in StoryTests table

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as any user and start multiple story tests, submit for review
2. Login as admin and view the tests, play around with the grading flow
3. Verify that the review progress is reflected appropriately in the table

![image](https://user-images.githubusercontent.com/45080644/147844259-6a9afe5f-71a9-44fd-9247-c7d2813b85bb.png)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
