### PR TITLE
Implement getLanguages query

### DIFF
--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -54,6 +54,10 @@ def resolve_export_story_translation(root, info, id):
     return file
 
 
+def resolve_languages(root, info):
+    return services["story"].get_languages()
+
+
 @require_authorization_by_role_gql({"Admin"})
 def resolve_story_translations(
     root, info, language, level, stage, story_title, story_id

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -38,6 +38,7 @@ from .queries.comment_query import resolve_comments_by_story_translation
 from .queries.file_query import resolve_file_by_id
 from .queries.story_query import (
     resolve_export_story_translation,
+    resolve_languages,
     resolve_stories,
     resolve_stories_available_for_translation,
     resolve_story_by_id,
@@ -158,6 +159,7 @@ class Query(graphene.ObjectType):
     export_story_translation = graphene.Field(
         DownloadFileDTO, id=graphene.Int(required=True)
     )
+    languages = graphene.Field(graphene.List(graphene.String))
 
     def resolve_comments_by_story_translation(
         root, info, story_translation_id, resolved=None
@@ -174,6 +176,9 @@ class Query(graphene.ObjectType):
 
     def resolve_story_by_id(root, info, id):
         return resolve_story_by_id(root, info, id)
+
+    def resolve_languages(root, info):
+        return resolve_languages(root, info)
 
     def resolve_users(
         root, info, isTranslators, language=None, level=None, name_or_email=None

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -18,6 +18,7 @@ from ...graphql.types.story_type import (
 from ...models import db
 from ...models.comment import Comment
 from ...models.file import File
+from ...models.language import Language
 from ...models.story import Story
 from ...models.story_all import StoryAll
 from ...models.story_content import StoryContent
@@ -966,6 +967,14 @@ class StoryService(IStoryService):
                 self.soft_delete_story_translation(translation.id)
 
             db.session.commit()
+        except Exception as error:
+            self.logger.error(error)
+            raise error
+
+    def get_languages(self):
+        try:
+            languages = Language.query.all()
+            return [language.language for language in languages]
         except Exception as error:
             self.logger.error(error)
             raise error

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -242,3 +242,10 @@ class IStoryService(ABC):
         Soft delete a story by setting is_deleted=True
         :param id: id of the story
         """
+
+    @abstractmethod
+    def get_languages(self):
+        """
+        Get a list of languages currently used in the platform
+        """
+        pass


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Implement getLanguages query](https://www.notion.so/uwblueprintexecs/Implement-getLanguages-query-9609930e7a2c4b1490ccdce8c8dc694a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- added query to get languages

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Rebuild containers and make sure database is up to date
2. Run [this query](http://localhost:5000/graphql?variables=null&operationName=GetLanguages&query=query%20GetLanguages%20%7B%0A%20%20languages%0A%7D%0A)
3. Verify response looks like:
```
{
  "data": {
    "languages": [
      "ARABIC",
      "ASANTE TWI",
      "ASSAMESE",
      "BENGALI",
      "BHILI",
      "CATALAN",
      "CHATINO",
      "DANISH",
      "DUTCH",
      "ENGLISH_UK",
      "ENGLISH_US",
      "ENGLISH_INDIAN",
      "ESPERANTO",
      "FRENCH",
      "GEORGIAN",
      "GERMAN",
      "GREEK",
      "GUJARATI",
      "HEBREW",
      "HINDI",
      "INDONESIAN",
      "ITALIAN",
      "JAPANESE",
      "KANNADA",
      "KAZAKH",
      "KHMER",
      "KOTAVA",
      "KURDISH",
      "KUTCHI",
      "LIDEPLA",
      "MALAYALAM",
      "MALTESE",
      "MANDARIN",
      "MARATHI",
      "NEPALI",
      "NORWEGIAN",
      "ORIYA",
      "POLISH",
      "PORTUGUESE",
      "PUNJABI",
      "ROMANIAN",
      "RUSSIAN",
      "SANSKRIT",
      "SANTALI",
      "SPANISH",
      "SWAHILI",
      "TAMANG",
      "TAMIL",
      "TELUGU",
      "TURKISH",
      "UKRAINIAN",
      "URDU"
    ]
  }
}
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does the query work as expected?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
