### PR TITLE
Show progress percentage for story translations

### DIFF
--- a/backend/python/app/graphql/types/story_type.py
+++ b/backend/python/app/graphql/types/story_type.py
@@ -124,6 +124,9 @@ class StoryTranslationNode(graphene.ObjectType):
     reviewer_name = graphene.String()
     translator_last_activity = graphene.DateTime()
     reviewer_last_activity = graphene.DateTime()
+    num_translated_lines = graphene.Int()
+    num_approved_lines = graphene.Int()
+    num_content_lines = graphene.Int()
 
     class Meta:
         interfaces = (graphene.relay.Node,)

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -251,6 +251,7 @@ export type StoryTranslation = {
   reviewerName: string | null;
   numTranslatedLines: number;
   numApprovedLines: number;
+  numContentLines: number;
   translatorLastActivity: string | null;
   reviewerLastActivity: string | null;
 };
@@ -298,6 +299,9 @@ export const buildStoryTranslationsQuery = (
               reviewerName
               translatorLastActivity
               reviewerLastActivity
+              numTranslatedLines
+              numApprovedLines
+              numContentLines
             }
           }
           pageInfo {
@@ -324,6 +328,9 @@ export const GET_STORY_TRANSLATIONS_BY_USER = (userId: number) => gql`
       stage
       translatorLastActivity
       reviewerLastActivity
+      numTranslatedLines
+      numApprovedLines
+      numContentLines
     }
   }
 `;

--- a/frontend/src/components/admin/StoryTranslationsTable.tsx
+++ b/frontend/src/components/admin/StoryTranslationsTable.tsx
@@ -18,7 +18,7 @@ import {
 } from "@chakra-ui/react";
 import { StoryTranslation } from "../../APIClients/queries/StoryQueries";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
-import convertStageTitleCase from "../../utils/StageUtils";
+import { getStoryTranslationProgress } from "../../utils/StageUtils";
 import { getLevelVariant } from "../../utils/StatusUtils";
 import ConfirmationModal from "../utils/ConfirmationModal";
 import {
@@ -136,7 +136,7 @@ const StoryTranslationsTable = ({
             )} | Level ${storyTranslationObj?.level}`}
           </Badge>
         </Td>
-        <Td>{convertStageTitleCase(storyTranslationObj?.stage)}</Td>
+        <Td>{getStoryTranslationProgress(storyTranslationObj)}</Td>
         <Td>
           <Link isExternal href={`#/user/${storyTranslationObj?.translatorId}`}>
             {storyTranslationObj?.translatorName}

--- a/frontend/src/components/admin/TableFilter.tsx
+++ b/frontend/src/components/admin/TableFilter.tsx
@@ -152,12 +152,18 @@ const TableFilter = ({
         </Box>
         <Box marginLeft="15px">
           <Button
-            disabled={language == null && level == null && searchText == null}
+            disabled={
+              language == null &&
+              level == null &&
+              searchText == null &&
+              (!useStage || stage == null)
+            }
             colorScheme="blue"
             size="secondary"
             onClick={() => {
               setLanguage(null);
               setLevel(null);
+              setStage?.(null);
               setSearchText(null);
             }}
           >

--- a/frontend/src/components/homepage/PreviewModal.tsx
+++ b/frontend/src/components/homepage/PreviewModal.tsx
@@ -22,7 +22,7 @@ import {
   convertLanguageTitleCase,
 } from "../../utils/LanguageUtils";
 import { getLevelVariant } from "../../utils/StatusUtils";
-import convertStageTitleCase from "../../utils/StageUtils";
+import { convertStageTitleCase } from "../../utils/StageUtils";
 import {
   GET_STORY_CONTENTS,
   GET_STORY_AND_TRANSLATION_CONTENTS,

--- a/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
+++ b/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
@@ -26,7 +26,7 @@ import {
   UNASSIGN_REVIEWER,
 } from "../../APIClients/mutations/StoryMutations";
 import { getLevelVariant } from "../../utils/StatusUtils";
-import convertStageTitleCase from "../../utils/StageUtils";
+import { getStoryTranslationProgress } from "../../utils/StageUtils";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 import { ApprovedLanguagesMap, generateSortFn } from "../../utils/Utils";
 import ConfirmationModal from "../utils/ConfirmationModal";
@@ -328,7 +328,7 @@ const AssignedStoryTranslationsTable = ({
           translation.level
         }`}</Badge>
       </Td>
-      <Td>{convertStageTitleCase(translation.stage)}</Td>
+      <Td>{getStoryTranslationProgress(translation)}</Td>
       <Td>{lastEditedDate(translation)?.toLocaleDateString?.()}</Td>
       {isAdmin && (
         <Td>

--- a/frontend/src/utils/StageUtils.ts
+++ b/frontend/src/utils/StageUtils.ts
@@ -1,6 +1,7 @@
+import { StoryTranslation } from "../APIClients/queries/StoryQueries";
 import { convertStringTitleCase } from "./Utils";
 
-function convertStageTitleCase(stage: string) {
+export const convertStageTitleCase = (stage: string) => {
   switch (stage) {
     case "TRANSLATE":
       return "In Translation";
@@ -11,9 +12,9 @@ function convertStageTitleCase(stage: string) {
     default:
       return convertStringTitleCase(stage);
   }
-}
+};
 
-function convertTitleCaseToStage(stage: string) {
+export const convertTitleCaseToStage = (stage: string) => {
   switch (stage) {
     case "In Translation":
       return "TRANSLATE";
@@ -24,5 +25,20 @@ function convertTitleCaseToStage(stage: string) {
     default:
       return stage;
   }
-}
-export { convertStageTitleCase as default, convertTitleCaseToStage };
+};
+
+export const getStoryTranslationProgress = (translation: StoryTranslation) => {
+  const stage = convertStageTitleCase(translation.stage);
+  if (translation.stage === "PUBLISH") {
+    return stage;
+  }
+
+  const numProgressLines =
+    translation.stage === "TRANSLATE"
+      ? translation.numTranslatedLines
+      : translation.numApprovedLines;
+
+  const progress = (numProgressLines / translation.numContentLines) * 100;
+  const percentage = Math.round(Number.isNaN(progress) ? 0 : progress);
+  return `${stage} (${percentage}%)`;
+};


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Show-translate-or-review-on-StoryTranslationTable-85a6a0739c3a459a88aae5dfdb4ccf78

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- updated `get_story_translations` query to return num_translated_lines, num_approved_lines, and num_content_lines
- fetch + display progress in `StoryTranslationsTable.tsx` and `AssignedStoryTranslationsTable.tsx`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin
2. Observe that the progress % is shown for stories in translation + review
3. Go to any user's profile page
4. Verify that progress % is shown in the assigned story translations table


![p3](https://user-images.githubusercontent.com/45080644/147865653-e6c478ed-7b52-4428-af33-3a2fb63e8e05.PNG)
![p2](https://user-images.githubusercontent.com/45080644/147865651-e3cc73cd-7123-4511-811f-e8984cd9e850.PNG)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it appear correctly?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
