### PR TITLE
Hide resume when null

### DIFF
--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -161,7 +161,7 @@ const UserProfilePage = () => {
             Last active on
           </Heading>
           <Text>TODO</Text>
-          {isAdmin && (
+          {isAdmin && resumeId && (
             <>
               <Heading size="sm" marginTop="36px">
                 User Files


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[if user has no resume, hide resume on admin view of user profile][(https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d](https://www.notion.so/uwblueprintexecs/if-user-has-no-resume-hide-resume-on-admin-view-of-user-profile-63841962768b4fe3a96f4d71280d6149))

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Hide the resume and file section if resume is null 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as angela merkel
2. Navigate to any user without a resume 
3. Make sure resume does work for users with resume

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
