### PR TITLE
Add my work filter on homepage

### DIFF
--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -185,6 +185,7 @@ export const buildHomePageStoriesQuery = (
                 translatorId
                 reviewerId
                 language
+                stage
                 ${STORY_FIELDS}
               }
             }

--- a/frontend/src/components/homepage/MyWorkFilter.tsx
+++ b/frontend/src/components/homepage/MyWorkFilter.tsx
@@ -1,0 +1,51 @@
+import React, { Dispatch, SetStateAction, useEffect } from "react";
+import { Box, Flex, Divider, Heading, useStyleConfig } from "@chakra-ui/react";
+
+import ButtonRadioGroup from "../utils/ButtonRadioGroup";
+import { StoryCardProps } from "./StoryCard";
+
+export type StoriesFilterFn = (story: StoryCardProps) => boolean;
+
+export type MyWorkFilterProps = {
+  setFilter: Dispatch<SetStateAction<StoriesFilterFn | null>>;
+};
+
+const MyWorkFilter = ({ setFilter }: MyWorkFilterProps) => {
+  const generateFilterFn = (stage: string) => {
+    return (story: StoryCardProps) => story?.stage === stage;
+  };
+
+  useEffect(() => {
+    // default to show stories in translation
+    setFilter(() => generateFilterFn("TRANSLATE"));
+  }, []);
+
+  const handleStageChange = (stage: string) => {
+    let filterStage = "PUBLISH";
+    if (stage === "In Translation") {
+      filterStage = "TRANSLATE";
+    } else if (stage === "In Review") {
+      filterStage = "REVIEW";
+    }
+    setFilter(() => generateFilterFn(filterStage));
+  };
+
+  const filterStyle = useStyleConfig("Filter");
+  return (
+    <Flex sx={filterStyle}>
+      <Heading size="lg">Filters</Heading>
+      <Divider marginTop="24px" marginBottom="18px" />
+      <Box>
+        <Heading size="sm">Progress</Heading>
+        <ButtonRadioGroup
+          name="Level"
+          options={["In Translation", "In Review", "Completed"]}
+          onChange={handleStageChange}
+          defaultValue="In Translation"
+        />
+      </Box>
+    </Flex>
+  );
+};
+
+export default MyWorkFilter;

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -35,6 +35,7 @@ export type StoryCardProps = {
   isMyTest: boolean;
   translatorId?: number;
   reviewerId?: number;
+  stage?: string;
 };
 
 const StoryCard = ({

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -14,6 +14,7 @@ import Header from "../navigation/Header";
 import { buildHomePageStoriesQuery } from "../../APIClients/queries/StoryQueries";
 import { parseApprovedLanguages } from "../../utils/Utils";
 import useQueryParams from "../../utils/hooks/useQueryParams";
+import MyWorkFilter, { StoriesFilterFn } from "../homepage/MyWorkFilter";
 
 enum HomepageOption {
   MyStories = 0,
@@ -62,8 +63,17 @@ const HomePage = () => {
   const [isTranslator, setIsTranslator] = useState<boolean>(true);
   const [level, setLevel] = useState<number>(1);
   const [stories, setStories] = useState<StoryCardProps[] | null>(null);
+  const [storiesFilter, setStoriesFilter] = useState<StoriesFilterFn | null>(
+    null,
+  );
 
   const [showScrollToTop, setShowScrollToTop] = useState(false);
+
+  useEffect(() => {
+    if (pageOption !== HomepageOption.MyStories) {
+      setStoriesFilter(null);
+    }
+  }, [pageOption]);
 
   useEffect(() => {
     const index = getPageOptionFromURL();
@@ -140,17 +150,21 @@ const HomePage = () => {
       <Header />
       <Divider />
       <Flex direction="row">
-        <Filter
-          approvedLanguagesTranslation={approvedLanguagesTranslation}
-          approvedLanguagesReview={approvedLanguagesReview}
-          level={level}
-          setLevel={setLevel}
-          language={language}
-          setLanguage={setLanguage}
-          role={isTranslator}
-          setIsTranslator={setIsTranslator}
-          isDisabled={pageOption !== HomepageOption.BrowseStories}
-        />
+        {pageOption === HomepageOption.MyStories ? (
+          <MyWorkFilter setFilter={setStoriesFilter} />
+        ) : (
+          <Filter
+            approvedLanguagesTranslation={approvedLanguagesTranslation}
+            approvedLanguagesReview={approvedLanguagesReview}
+            level={level}
+            setLevel={setLevel}
+            language={language}
+            setLanguage={setLanguage}
+            role={isTranslator}
+            setIsTranslator={setIsTranslator}
+            isDisabled={pageOption !== HomepageOption.BrowseStories}
+          />
+        )}
         <Flex
           direction="column"
           alignItems="center"
@@ -168,7 +182,9 @@ const HomePage = () => {
             value={tabHeaderOptions[pageOption]}
           />
           <StoryList
-            stories={stories}
+            stories={
+              storiesFilter ? stories?.filter(storiesFilter) ?? [] : stories
+            }
             displayMyStories={pageOption === HomepageOption.MyStories}
             displayMyTests={pageOption === HomepageOption.MyTests}
           />


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Add-My-Work-filter-1e54939fb0784090b9a7a94db0f5f1bd

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- created `MyWorkFilter.tsx` component
- filter stories on homepage based on stage (My Work tab only)

![image](https://user-images.githubusercontent.com/45080644/147890053-47bcc52f-5a98-47e6-9011-443f1f5496e4.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as any user
2. Observe that filter appears on "My Work" tab
3. Play around with the filter and verify that the stories are displayed correctly
4. Switch tabs and verify that the stage filter is not applied on other tabs

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
