### PR TITLE
Fix: Allow admins to view disabled ReviewPage

### DIFF
--- a/frontend/src/components/admin/StoryTranslationsTable.tsx
+++ b/frontend/src/components/admin/StoryTranslationsTable.tsx
@@ -39,7 +39,6 @@ export type StoryTranslationsTableProps = {
   paginator: ReactNode;
   filters: { (data: string | null): void }[];
   loading: Boolean;
-  showStoryTitle?: Boolean;
   width?: string;
 };
 
@@ -48,7 +47,6 @@ const StoryTranslationsTable = ({
   paginator,
   filters,
   loading,
-  showStoryTitle = true,
   width = "95%",
 }: StoryTranslationsTableProps) => {
   const [confirmDeleteTranslation, setConfirmDeleteTranslation] =
@@ -117,13 +115,14 @@ const StoryTranslationsTable = ({
             : ""
         }
       >
-        {showStoryTitle && (
-          <Td>
-            <Link isExternal href={`#/story/${storyTranslationObj?.storyId}`}>
-              {storyTranslationObj?.title}
-            </Link>
-          </Td>
-        )}
+        <Td>
+          <Link
+            isExternal
+            href={`#/review/${storyTranslationObj?.storyId}/${storyTranslationObj?.storyTranslationId}`}
+          >
+            {storyTranslationObj?.title}
+          </Link>
+        </Td>
 
         <Td>
           <Badge
@@ -197,7 +196,7 @@ const StoryTranslationsTable = ({
           borderTop="1em solid transparent"
           borderBottom="0.5em solid transparent"
         >
-          {showStoryTitle && <Th>STORY TITLE</Th>}
+          <Th>STORY LINK</Th>
 
           <Th>LANGUAGE & LEVEL</Th>
           <Th>PROGRESS</Th>

--- a/frontend/src/components/pages/ManageStoryPage.tsx
+++ b/frontend/src/components/pages/ManageStoryPage.tsx
@@ -198,7 +198,6 @@ const ManageStoryPage = () => {
             storyTranslationSlice={pageResults}
             paginator={paginator}
             filters={[() => {}]}
-            showStoryTitle={false}
             width="100%"
           />
 

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -152,8 +152,11 @@ const ReviewPage = () => {
     },
   );
 
+  const isAdmin = authenticatedUser!!.role === "Admin";
+  const isDisabled = stage !== "REVIEW" || isAdmin;
   if (loading || reviewerId === -1) return <div />;
-  if (+authenticatedUser!!.id !== reviewerId) return <Redirect to="/404" />;
+  if (+authenticatedUser!!.id !== reviewerId && !isAdmin)
+    return <Redirect to="/404" />;
   return (
     <Flex
       height="100vh"
@@ -217,7 +220,7 @@ const ReviewPage = () => {
             <Tooltip
               hasArrow
               label={REVIEW_PAGE_TOOL_TIP_COPY}
-              isDisabled={stage === "REVIEW"}
+              isDisabled={isDisabled}
             >
               <Box>
                 <Button
@@ -225,7 +228,7 @@ const ReviewPage = () => {
                   size="secondary"
                   margin="0 10px 0"
                   width="250px"
-                  disabled={stage !== "REVIEW"}
+                  disabled={isDisabled}
                   onClick={
                     numApprovedLines === translatedStoryLines.length
                       ? openSubmitTranslationModal

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -220,7 +220,7 @@ const ReviewPage = () => {
             <Tooltip
               hasArrow
               label={REVIEW_PAGE_TOOL_TIP_COPY}
-              isDisabled={isDisabled}
+              isDisabled={!isDisabled}
             >
               <Box>
                 <Button

--- a/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
+++ b/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
@@ -294,13 +294,10 @@ const AssignedStoryTranslationsTable = ({
 
   const generateStoryTranslationLink = (translation: StoryTranslation) => {
     const suffix = `${translation.storyId}/${translation.storyTranslationId}`;
-    if (isAdmin) {
-      return `#/story/${translation.storyId}`;
+    if (isAdmin || getRole(translation) === "Reviewer") {
+      return `#/review/${suffix}`;
     }
-    if (getRole(translation) === "Translator") {
-      return `#/translation/${suffix}`;
-    }
-    return `#/review/${suffix}`;
+    return `#/translation/${suffix}`;
   };
 
   const lastEditedDate = (translation: StoryTranslation): Date | null => {


### PR DESCRIPTION
## Notion ticket link
https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=35a2478937d24f45b26f3a40c5539b24

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- redirect if user not reviewer and user not admin
- linked to review page on story translation tables

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as angela 
2. click on a link on manage story translations. observe that you can view the translation on the review page
3. click on a link on manage story translations. then click a link in the story translations. observe that you can view the translation on the review page
4. click on a user's link. then click a link in the story translations. observe that you can view the translation on the review page

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- happiness and fulfillment in life

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
