### PR TITLE
Fix: clear + refresh window when tokens are expired

### DIFF
--- a/backend/python/app/graphql/mutations/auth_mutation.py
+++ b/backend/python/app/graphql/mutations/auth_mutation.py
@@ -135,21 +135,6 @@ class LoginWithGoogle(graphene.Mutation):
             raise Exception(error_message if error_message else str(e))
 
 
-class Logout(graphene.Mutation):
-    class Arguments:
-        userId = graphene.ID(required=True)
-
-    ok = graphene.Boolean()
-
-    def mutate(root, info, userId):
-        try:
-            services["auth"].revoke_tokens(userId)
-            return Logout(ok=True)
-        except Exception as e:
-            error_message = getattr(e, "message", None)
-            return Exception(error_message if error_message else str(e))
-
-
 class SignUp(graphene.Mutation):
     class Arguments:
         first_name = graphene.String(required=True)

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -3,7 +3,6 @@ import graphene
 from .mutations.auth_mutation import (
     Login,
     LoginWithGoogle,
-    Logout,
     Refresh,
     ResetPassword,
     SignUp,
@@ -74,7 +73,6 @@ class Mutation(graphene.ObjectType):
     update_user_by_id = UpdateUserByID.Field()
     login = Login.Field()
     login_with_google = LoginWithGoogle.Field()
-    logout = Logout.Field()
     signup = SignUp.Field()
     refresh = Refresh.Field()
     assign_user_as_reviewer = AssignUserAsReviewer.Field()

--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -6,7 +6,6 @@ import {
 import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
 import { AuthenticatedUser } from "../contexts/AuthContext";
 import {
-  LogoutResponse,
   ResetPasswordResponse,
   RefreshResponse,
 } from "./mutations/AuthMutations";
@@ -93,25 +92,7 @@ const signup = async (
   return user;
 };
 
-type LogoutFunction = (
-  options: MutationFunctionOptions<
-    { logout: LogoutResponse },
-    OperationVariables
-  >,
-) => Promise<FetchResult<{ logout: LogoutResponse }>>;
-
-const logout = async (
-  userId: string | undefined,
-  logoutFunction: LogoutFunction,
-): Promise<boolean> => {
-  try {
-    await logoutFunction({ variables: { userId } });
-    localStorage.removeItem(AUTHENTICATED_USER_KEY);
-    return true;
-  } catch (error) {
-    return false;
-  }
-};
+const logout = () => localStorage.removeItem(AUTHENTICATED_USER_KEY);
 
 type ResetPasswordFunction = (
   options: MutationFunctionOptions<

--- a/frontend/src/APIClients/mutations/AuthMutations.ts
+++ b/frontend/src/APIClients/mutations/AuthMutations.ts
@@ -32,18 +32,6 @@ export const LOGIN_WITH_GOOGLE = gql`
   }
 `;
 
-export const LOGOUT = gql`
-  mutation Logout($userId: ID!) {
-    logout(userId: $userId) {
-      ok
-    }
-  }
-`;
-
-export interface LogoutResponse {
-  ok: boolean;
-}
-
 export const REFRESH = gql`
   mutation Refresh {
     refresh {

--- a/frontend/src/components/auth/Logout.tsx
+++ b/frontend/src/components/auth/Logout.tsx
@@ -1,31 +1,18 @@
-import React, { useContext, useEffect } from "react";
-import { useMutation } from "@apollo/client";
+import React, { useContext } from "react";
 import { Text } from "@chakra-ui/react";
 import { Icon } from "@chakra-ui/icon";
 import { MdIosShare } from "react-icons/md";
 import AuthContext from "../../contexts/AuthContext";
-import {
-  LOGOUT,
-  LogoutResponse,
-} from "../../APIClients/mutations/AuthMutations";
 import authAPIClient from "../../APIClients/AuthAPIClient";
 
 const Logout = () => {
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);
-  const [logout, { error }] = useMutation<{ logout: LogoutResponse }>(LOGOUT);
 
-  const onLogOutClick = async () => {
-    await authAPIClient.logout(String(authenticatedUser?.id), logout);
+  const onLogOutClick = () => {
+    authAPIClient.logout();
     setAuthenticatedUser(null);
   };
-
-  useEffect(() => {
-    if (error) {
-      // TODO: Implement Error State
-      // eslint-disable-next-line no-alert
-      alert(error);
-    }
-  }, [error]);
 
   return (
     <Text color="black" onClick={onLogOutClick} variant="link">


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

aight so theres two potential causes to issues people (eg @lynn-kim @Puepis @jennchenn ) were seeing yesterday night
1. refreshing tokens too often makes firebase upset
2. auth tokens might get cleared from local storage if a token is expired, but unless a page is refreshed or an error is thrown, the gql request will still go through and come back with errors

I was able to explicitly encounter 2, but not 1. heres what I did to try to fix things:
- tokens are never refreshed along side a request. ie, if you log in at 3:30, you'll be booted by 4:30 no matter what
- reload the window + throw an error if an expired token is encountered during a gql request

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. checkout main (NOT THIS BRANCH)
2. login in non-incognito. keep the tab open
  i. you can continue dev work in a different browser (eg firefox) or in incognito

new for this ticket
3. click around and try to get stuck. I tested getting the browse stories tab stuck in loading for ever, and seeing firebase issues over the network
4. checkout this branch
5. reload/refresh your page
  i. if you accidentally deleted your tab, no problemo. when you open localhost:3000 you should still be brought to the login page
6. observe redirect to login page and cleared cookies

retesting from previous [clear cookie ticket](https://github.com/uwblueprint/planet-read/pull/295)
3. come back to this ticket in an hour. observe that you're stuck as outlined on the ticket
4. checkout this branch
5. reload/refresh your page
  i. if you accidentally deleted your tab, no problemo. when you open localhost:3000 you should still be brought to the login page
6. observe redirect to login page and cleared cookies

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work
- lmk any other observations deets when you encounter problems. I find the errors coming back from firebase to be somewhat misleading at times (eg, expired token errors when theres actually no token getting passed at all)

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
