### PR TITLE
add is_rtl query for languages

### DIFF
--- a/backend/python/app/graphql/queries/language_query.py
+++ b/backend/python/app/graphql/queries/language_query.py
@@ -3,3 +3,7 @@ from ..service import services
 
 def resolve_languages(root, info):
     return services["language"].get_languages()
+
+
+def resolve_is_rtl(root, info, language):
+    return services["language"].get_is_rtl(language)

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -37,7 +37,7 @@ from .mutations.user_mutation import (
 )
 from .queries.comment_query import resolve_comments_by_story_translation
 from .queries.file_query import resolve_file_by_id
-from .queries.language_query import resolve_languages
+from .queries.language_query import resolve_is_rtl, resolve_languages
 from .queries.story_query import (
     resolve_export_story_translation,
     resolve_stories,
@@ -53,6 +53,7 @@ from .queries.story_query import (
 from .queries.user_query import resolve_user_by_email, resolve_user_by_id, resolve_users
 from .types.comment_type import CommentResponseDTO
 from .types.file_type import DownloadFileDTO, FileDTO
+from .types.language_type import LanguageIsRTLDTO
 from .types.story_type import (
     StoryResponseDTO,
     StoryTranslationConnection,
@@ -162,6 +163,7 @@ class Query(graphene.ObjectType):
         DownloadFileDTO, id=graphene.Int(required=True)
     )
     languages = graphene.Field(graphene.List(graphene.String))
+    is_rtl = graphene.Field(LanguageIsRTLDTO, language=graphene.String(required=True))
 
     def resolve_comments_by_story_translation(
         root, info, story_translation_id, resolved=None
@@ -181,6 +183,9 @@ class Query(graphene.ObjectType):
 
     def resolve_languages(root, info):
         return resolve_languages(root, info)
+
+    def resolve_is_rtl(root, info, language):
+        return resolve_is_rtl(root, info, language)
 
     def resolve_users(
         root, info, isTranslators, language=None, level=None, name_or_email=None

--- a/backend/python/app/graphql/types/language_type.py
+++ b/backend/python/app/graphql/types/language_type.py
@@ -5,3 +5,7 @@ class LanguageDTO(graphene.ObjectType):
     id = graphene.Int(required=True)
     language = graphene.String(required=True)
     is_rtl = graphene.Boolean(required=True)
+
+
+class LanguageIsRTLDTO(graphene.ObjectType):
+    is_rtl = graphene.Boolean(required=True)

--- a/backend/python/app/services/implementations/language_service.py
+++ b/backend/python/app/services/implementations/language_service.py
@@ -26,3 +26,17 @@ class LanguageService(ILanguageService):
         except Exception as error:
             self.logger.error(str(error))
             raise error
+
+    def get_is_rtl(self, language):
+        try:
+            to_check = Language.query.filter_by(language=language).first()
+
+            if not to_check:
+                raise Exception(
+                    "Language {language} not found".format(language=language)
+                )
+            else:
+                return {"is_rtl": to_check.is_rtl}
+        except Exception as error:
+            self.logger.error(str(error))
+            raise error

--- a/backend/python/app/services/interfaces/language_service.py
+++ b/backend/python/app/services/interfaces/language_service.py
@@ -23,3 +23,11 @@ class ILanguageService(ABC):
         :raises Exception: if language fails to save
         """
         pass
+
+    @abstractmethod
+    def get_is_rtl(self, language):
+        """
+        Return bool indicating if language is from right to left
+        :param language: language to be checked
+        :rtype: bool
+        """


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket ](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=91c5a6a68efb4c48a3147c8173d38161)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Add new `is_rtl` query for languages 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. go to GQL and run [this](http://localhost:5000/graphql?query=query%20IsRtl%20%7B%0A%20%20isRtl(language%3A%20%22ARABIC%22)%20%7B%0A%20%20%20%20isRtl%0A%20%20%7D%0A%7D&operationName=IsRtl), ensure it returns `true`
2. Also test with another language like MANDARIN which should return `false`

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- unifying quantum mechanics and general relativity 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
