### PR TITLE
Make user's profile page functional

### DIFF
--- a/backend/python/app/services/implementations/user_service.py
+++ b/backend/python/app/services/implementations/user_service.py
@@ -1,5 +1,4 @@
 import firebase_admin.auth
-import time
 from flask import current_app
 from flask.globals import current_app
 

--- a/backend/python/app/services/implementations/user_service.py
+++ b/backend/python/app/services/implementations/user_service.py
@@ -1,4 +1,5 @@
 import firebase_admin.auth
+import time
 from flask import current_app
 from flask.globals import current_app
 

--- a/frontend/src/APIClients/mutations/UserMutations.ts
+++ b/frontend/src/APIClients/mutations/UserMutations.ts
@@ -35,6 +35,22 @@ export type UpdateUserApprovedLanguagesResponse = {
   };
 };
 
+export const UPDATE_ME = gql`
+  mutation Updateme($userData: UpdateUserDTO!, $resume: Upload) {
+    updateMe(user: $userData, resume: $resume) {
+      user {
+        id
+      }
+    }
+  }
+`;
+
+export type UpdateMeResponse = {
+  user: {
+    id: number;
+  };
+};
+
 export const COMPLETE_SIGN_UP = gql`
   mutation CompleteSignUp(
     $userData: UpdateUserDTO!

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -271,19 +271,38 @@ const UserProfilePage = () => {
         <Flex direction="column" margin="40px" flex={1}>
           {/* TODO: use different state for email & fullname since currently the sidebar also gets modified */}
           {!isAdmin && (
-            <UserProfileForm
-              email={tempEmail}
-              experience={tempLanguageExperience}
-              fullName={tempFullName}
-              isSignup={false}
-              qualifications={tempEducationalQualification}
-              setEducationalQualification={setTempEducationalQualification}
-              setEmail={setTempEmail}
-              setFullName={setTempFullName}
-              setLanguage={setLanguage}
-              setLanguageExperience={setTempLanguageExperience}
-              updateResume={updateResume}
-            />
+            <Box>
+              <UserProfileForm
+                email={tempEmail}
+                experience={tempLanguageExperience}
+                fullName={tempFullName}
+                isSignup={false}
+                qualifications={tempEducationalQualification}
+                setEducationalQualification={setTempEducationalQualification}
+                setEmail={setTempEmail}
+                setFullName={setTempFullName}
+                setLanguage={setLanguage}
+                setLanguageExperience={setTempLanguageExperience}
+                updateResume={updateResume}
+              />
+              <Flex marginTop="35px">
+                <Button
+                  colorScheme="blue"
+                  marginRight="20px"
+                  onClick={() => cancelChanges()}
+                  variant="blueOutline"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  colorScheme="blue"
+                  onClick={() => openSaveChangesModal()}
+                  transform="rotate(180deg)"
+                >
+                  Save Changes
+                </Button>
+              </Flex>
+            </Box>
           )}
           <Flex justifyContent="space-between" margin="40px 0 10px 0">
             <Heading size="lg"> Approved Languages & Levels </Heading>
@@ -381,32 +400,6 @@ const UserProfilePage = () => {
             </>
           )}
         </Flex>
-      </Flex>
-      <Flex
-        alignItems="center"
-        boxShadow="0 0 12px -9px rgba(0, 0, 0, 0.7)"
-        direction="row"
-        height="90px"
-        justify="flex-end"
-        padding="20px 30px"
-      >
-        <Box>
-          <Button
-            colorScheme="blue"
-            marginRight="20px"
-            onClick={() => cancelChanges()}
-            variant="blueOutline"
-          >
-            Cancel
-          </Button>
-          <Button
-            colorScheme="blue"
-            marginRight="10px"
-            onClick={() => openSaveChangesModal()}
-          >
-            Save Changes
-          </Button>
-        </Box>
       </Flex>
       {confirmDeleteUser && (
         <ConfirmationModal

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -229,8 +229,16 @@ const UserProfilePage = () => {
   const cancelChanges = () => {
     setTempFullName(fullName);
     setTempEmail(email);
-    setTempEducationalQualification(educationalQualification);
-    setTempLanguageExperience(languageExperience);
+    setTempEducationalQualification(
+      additionalExperiences?.educationalQualification
+        ? additionalExperiences?.educationalQualification
+        : "",
+    );
+    setTempLanguageExperience(
+      additionalExperiences?.languageExperience
+        ? additionalExperiences?.languageExperience
+        : "",
+    );
   };
 
   const filterStyle = useStyleConfig("Filter");
@@ -289,16 +297,12 @@ const UserProfilePage = () => {
                 <Button
                   colorScheme="blue"
                   marginRight="20px"
-                  onClick={() => cancelChanges()}
+                  onClick={cancelChanges}
                   variant="blueOutline"
                 >
                   Cancel
                 </Button>
-                <Button
-                  colorScheme="blue"
-                  onClick={() => openSaveChangesModal()}
-                  transform="rotate(180deg)"
-                >
+                <Button colorScheme="blue" onClick={openSaveChangesModal}>
                   Save Changes
                 </Button>
               </Flex>
@@ -393,7 +397,7 @@ const UserProfilePage = () => {
                 margin="10px 0px"
                 width="250px"
                 variant="outline"
-                onClick={() => openModal()}
+                onClick={openModal}
               >
                 Delete User
               </Button>
@@ -416,7 +420,7 @@ const UserProfilePage = () => {
           confirmation={confirmSaveChanges}
           confirmationMessage={USER_PROFILE_PAGE_SAVE_CHANGES_CONFIRMATION}
           onClose={closeSaveChangesModal}
-          onConfirmationClick={() => saveChanges()}
+          onConfirmationClick={saveChanges}
         />
       )}
     </Flex>

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from "react";
 import { useParams, useHistory, Redirect } from "react-router-dom";
 import {
+  Box,
   Button,
   Flex,
   Heading,
@@ -16,10 +17,14 @@ import UserProfileForm from "../userProfile/UserProfileForm";
 import {
   SoftDeleteUserResponse,
   SOFT_DELETE_USER,
+  UpdateMeResponse,
+  UPDATE_ME,
 } from "../../APIClients/mutations/UserMutations";
 import {
   MANAGE_USERS_TABLE_DELETE_USER_BUTTON,
   MANAGE_USERS_TABLE_DELETE_USER_CONFIRMATION,
+  USER_PROFILE_PAGE_SAVE_CHANGES_BUTTON,
+  USER_PROFILE_PAGE_SAVE_CHANGES_CONFIRMATION,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
 import {
@@ -43,13 +48,14 @@ import { StoryAssignStage } from "../../constants/Enums";
 import InfoAlert from "../utils/InfoAlert";
 import { useFileDownload } from "../../utils/FileUtils";
 import { getFileQuery } from "../../APIClients/queries/FileQueries";
+import authAPIClient from "../../APIClients/AuthAPIClient";
 
 type UserProfilePageProps = {
   userId: string;
 };
 
 const UserProfilePage = () => {
-  const { authenticatedUser } = useContext(AuthContext);
+  const { authenticatedUser, setAuthenticatedUser } = useContext(AuthContext);
   const { userId } = useParams<UserProfilePageProps>();
   const isAdmin = authenticatedUser!!.role === "Admin";
 
@@ -90,6 +96,15 @@ const UserProfilePage = () => {
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   const [resume, setResume] = useState<File | null>(null);
 
+  const [tempFullName, setTempFullName] = useState<string>("");
+  const [tempEmail, setTempEmail] = useState<string>("");
+  const [tempEducationalQualification, setTempEducationalQualification] =
+    useState<string>("");
+  const [tempLanguageExperience, setTempLanguageExperience] =
+    useState<string>("");
+
+  const [confirmSaveChanges, setConfirmSaveChanges] = useState(false);
+
   const history = useHistory();
 
   const [downloadFile] = useFileDownload("resume", getFileQuery);
@@ -117,6 +132,21 @@ const UserProfilePage = () => {
       setAdditionalExperiences(
         parseUserBackground(user?.additionalExperiences),
       );
+      setTempFullName(`${user?.firstName} ${user?.lastName}`);
+      setTempEmail(user?.email!);
+      const tempAdditionalExperiences = parseUserBackground(
+        user?.additionalExperiences,
+      );
+      setTempEducationalQualification(
+        tempAdditionalExperiences?.educationalQualification
+          ? tempAdditionalExperiences?.educationalQualification
+          : "",
+      );
+      setTempLanguageExperience(
+        tempAdditionalExperiences?.languageExperience
+          ? tempAdditionalExperiences?.languageExperience
+          : "",
+      );
     },
   });
 
@@ -131,12 +161,24 @@ const UserProfilePage = () => {
     response: SoftDeleteUserResponse;
   }>(SOFT_DELETE_USER);
 
+  const [updateMe] = useMutation<{
+    response: UpdateMeResponse;
+  }>(UPDATE_ME);
+
   const closeModal = () => {
     setConfirmDeleteUser(false);
   };
 
   const openModal = () => {
     setConfirmDeleteUser(true);
+  };
+
+  const closeSaveChangesModal = () => {
+    setConfirmSaveChanges(false);
+  };
+
+  const openSaveChangesModal = () => {
+    setConfirmSaveChanges(true);
   };
 
   const callSoftDeleteUserMutation = async () => {
@@ -151,6 +193,44 @@ const UserProfilePage = () => {
 
   const updateResume = (updatedResume: File | null) => {
     setResume(updatedResume);
+  };
+
+  const saveChanges = async () => {
+    try {
+      const [firstName, lastName] = tempFullName.split(" ");
+      const tempAdditionalExperiences = {
+        educationalQualification: tempEducationalQualification,
+        languageExperience: tempLanguageExperience,
+      };
+      const stringTempAddExp = JSON.stringify(tempAdditionalExperiences);
+      const userData = {
+        firstName,
+        lastName,
+        email: tempEmail,
+        additionalExperiences: stringTempAddExp,
+      };
+      await updateMe({
+        variables: {
+          userData,
+          resume,
+        },
+      });
+      if (email === tempEmail) {
+        window.location.reload();
+      } else {
+        authAPIClient.logout();
+        setAuthenticatedUser(null);
+      }
+    } catch (err) {
+      window.alert(err);
+    }
+  };
+
+  const cancelChanges = () => {
+    setTempFullName(fullName);
+    setTempEmail(email);
+    setTempEducationalQualification(educationalQualification);
+    setTempLanguageExperience(languageExperience);
   };
 
   const filterStyle = useStyleConfig("Filter");
@@ -192,14 +272,16 @@ const UserProfilePage = () => {
           {/* TODO: use different state for email & fullname since currently the sidebar also gets modified */}
           {!isAdmin && (
             <UserProfileForm
+              email={tempEmail}
+              experience={tempLanguageExperience}
+              fullName={tempFullName}
               isSignup={false}
-              fullName={fullName}
-              email={email}
-              setFullName={setFullName}
-              setEmail={setEmail}
+              qualifications={tempEducationalQualification}
+              setEducationalQualification={setTempEducationalQualification}
+              setEmail={setTempEmail}
+              setFullName={setTempFullName}
               setLanguage={setLanguage}
-              setEducationalQualification={setEducationalQualification}
-              setLanguageExperience={setLanguageExperience}
+              setLanguageExperience={setTempLanguageExperience}
               updateResume={updateResume}
             />
           )}
@@ -300,6 +382,32 @@ const UserProfilePage = () => {
           )}
         </Flex>
       </Flex>
+      <Flex
+        alignItems="center"
+        boxShadow="0 0 12px -9px rgba(0, 0, 0, 0.7)"
+        direction="row"
+        height="90px"
+        justify="flex-end"
+        padding="20px 30px"
+      >
+        <Box>
+          <Button
+            colorScheme="blue"
+            marginRight="20px"
+            onClick={() => cancelChanges()}
+            variant="blueOutline"
+          >
+            Cancel
+          </Button>
+          <Button
+            colorScheme="blue"
+            marginRight="10px"
+            onClick={() => openSaveChangesModal()}
+          >
+            Save Changes
+          </Button>
+        </Box>
+      </Flex>
       {confirmDeleteUser && (
         <ConfirmationModal
           confirmation={confirmDeleteUser}
@@ -307,6 +415,15 @@ const UserProfilePage = () => {
           onConfirmationClick={callSoftDeleteUserMutation}
           confirmationMessage={MANAGE_USERS_TABLE_DELETE_USER_CONFIRMATION}
           buttonMessage={MANAGE_USERS_TABLE_DELETE_USER_BUTTON}
+        />
+      )}
+      {confirmSaveChanges && (
+        <ConfirmationModal
+          buttonMessage={USER_PROFILE_PAGE_SAVE_CHANGES_BUTTON}
+          confirmation={confirmSaveChanges}
+          confirmationMessage={USER_PROFILE_PAGE_SAVE_CHANGES_CONFIRMATION}
+          onClose={closeSaveChangesModal}
+          onConfirmationClick={() => saveChanges()}
         />
       )}
     </Flex>

--- a/frontend/src/components/userProfile/UserProfileForm.tsx
+++ b/frontend/src/components/userProfile/UserProfileForm.tsx
@@ -19,25 +19,29 @@ import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 import { languageOptions } from "../../constants/Languages";
 
 export type UserProfileFormProps = {
-  isSignup?: boolean;
-  fullName: string;
   email: string;
-  setFullName: (name: string) => void;
-  setEmail: (email: string) => void;
-  setLanguage: (language: string) => void;
+  experience?: string;
+  fullName: string;
+  isSignup?: boolean;
+  qualifications?: string;
   setEducationalQualification: (email: string) => void;
+  setEmail: (email: string) => void;
+  setFullName: (name: string) => void;
+  setLanguage: (language: string) => void;
   setLanguageExperience: (email: string) => void;
   updateResume: (resume: File | null) => void;
 };
 
 const UserProfileForm = ({
-  isSignup = true,
-  fullName,
   email,
-  setFullName,
-  setEmail,
-  setLanguage,
+  experience,
+  fullName,
+  isSignup = true,
+  qualifications,
   setEducationalQualification,
+  setEmail,
+  setFullName,
+  setLanguage,
   setLanguageExperience,
   updateResume,
 }: UserProfileFormProps) => {
@@ -141,6 +145,7 @@ const UserProfileForm = ({
           <Textarea
             height="150px"
             type="qualifications"
+            value={qualifications}
             onChange={(e) => setEducationalQualification(e.target.value)}
           />
           <Heading marginTop="24px" size="sm">
@@ -149,6 +154,7 @@ const UserProfileForm = ({
           <Textarea
             height="150px"
             type="experience"
+            value={experience}
             onChange={(e) => setLanguageExperience(e.target.value)}
           />
         </FormControl>

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -125,3 +125,8 @@ export const DELETE_USER = "Delete user";
 
 export const VIEW_FAILED_GRADE_ALERT =
   "User failed this test. No changes to approved languages were applied.";
+
+export const USER_PROFILE_PAGE_SAVE_CHANGES_CONFIRMATION =
+  "If you entered a new email, you will be automatically signed out and your profile will be associated with the new email you have entered.";
+
+export const USER_PROFILE_PAGE_SAVE_CHANGES_BUTTON = "I'm sure, save changes";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Make user's profile page functional](https://www.notion.so/uwblueprintexecs/Make-user-s-profile-page-functional-fff5c71f952a4c7ea3b766fca52b3b7a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Implemented save changes and cancel buttons

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl (or another user)
2. Make changes to profile
3. Cancel changes
4. Changes should be gone
5. Make changes to profile (excluding email)
6. Save changes and confirm modal
7. Changes should be saved and page refreshed
8. Make changes to profile (including email)
9. Save changes  and confirm modal
10. Changes should be saved and user signed out (note that you will need to sign in with the new email)
11. Experiment with changing different fields, cancelling and saving in different orders, and closing the confirmation modal

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does ui look ok? (e.g. modal message, _button placement_)
- Does code look ok?
- Does it work as expected?
- Should the confirmation modal appear even when no changes were made to the user's email (since the message only pertains to changed email)?
- Note that the name in the `UserModal` (accessible from the header) was not changed because I couldn't figure out how to update the `authenticatedUser`. If this change must be made, I can work on it some more

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
