### PR TITLE
Use get_language query in all language options

### DIFF
--- a/backend/python/app/services/implementations/language_service.py
+++ b/backend/python/app/services/implementations/language_service.py
@@ -12,6 +12,7 @@ class LanguageService(ILanguageService):
     def get_languages(self):
         try:
             languages = Language.query.all()
+            languages.sort(key=lambda language: language.language)
             return [language.language for language in languages]
         except Exception as error:
             self.logger.error(error)

--- a/frontend/src/APIClients/queries/LanguageQueries.ts
+++ b/frontend/src/APIClients/queries/LanguageQueries.ts
@@ -1,0 +1,10 @@
+import { gql } from "@apollo/client";
+
+const GET_LANGUAGES = () =>
+  gql`
+    query GetLanguages {
+      languages
+    }
+  `;
+
+export default GET_LANGUAGES;

--- a/frontend/src/components/admin/TableFilter.tsx
+++ b/frontend/src/components/admin/TableFilter.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Select from "react-select";
 import { MdSearch } from "react-icons/md";
 import { Icon } from "@chakra-ui/icon";
@@ -13,13 +13,15 @@ import {
   Stack,
   Tooltip,
 } from "@chakra-ui/react";
-import { languageOptions } from "../../constants/Languages";
+import { useQuery } from "@apollo/client";
+
 import { levelOptions } from "../../constants/Levels";
 import { stageOptions } from "../../constants/Stage";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 import { FILTER_TOOL_TIP_COPY } from "../../utils/Copy";
 import DropdownIndicator from "../utils/DropdownIndicator";
 import { colourStyles } from "../../theme/components/Select";
+import GET_LANGUAGES from "../../APIClients/queries/LanguageQueries";
 
 export type TableFilterProps = {
   language: string | null;
@@ -66,6 +68,18 @@ const TableFilter = ({
   useStage = false,
   searchBarPlaceholder = "",
 }: TableFilterProps) => {
+  const [languageOptions, setLanguageOptions] = useState<any[]>([]);
+
+  useQuery(GET_LANGUAGES(), {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      const languageArray = data.languages.map((val: string) => ({
+        value: val,
+      }));
+      setLanguageOptions(languageArray);
+    },
+  });
+
   return (
     <Flex direction="column">
       <Flex

--- a/frontend/src/components/pages/ImportStoryPage.tsx
+++ b/frontend/src/components/pages/ImportStoryPage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Select from "react-select";
 import {
   Box,
@@ -14,13 +14,26 @@ import {
 } from "@chakra-ui/react";
 import { Icon } from "@chakra-ui/icon";
 import { MdArrowBackIosNew, MdFolder } from "react-icons/md";
+import { useQuery } from "@apollo/client";
+
 import DropdownIndicator from "../utils/DropdownIndicator";
 import Header from "../navigation/Header";
 import { colourStyles } from "../../theme/components/Select";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
-import { languageOptions } from "../../constants/Languages";
+import GET_LANGUAGES from "../../APIClients/queries/LanguageQueries";
 
 const ImportStoryPage = () => {
+  const [languageOptions, setLanguageOptions] = useState<any[]>([]);
+  useQuery(GET_LANGUAGES(), {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      const languageArray = data.languages.map((val: string) => ({
+        value: val,
+      }));
+      setLanguageOptions(languageArray);
+    },
+  });
+
   return (
     <Flex direction="column" height="100vh" justifyContent="space-between">
       <Header />

--- a/frontend/src/components/userProfile/AdminNewLanguageModal.tsx
+++ b/frontend/src/components/userProfile/AdminNewLanguageModal.tsx
@@ -16,12 +16,13 @@ import {
   GridItem,
   useStyleConfig,
 } from "@chakra-ui/react";
+import { useQuery } from "@apollo/client";
 
-import { languageOptions } from "../../constants/Languages";
 import { levelOptions } from "../../constants/Levels";
 import { roleOptions } from "../../constants/Roles";
 
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
+import GET_LANGUAGES from "../../APIClients/queries/LanguageQueries";
 import { ApprovedLanguagesMap } from "../../utils/Utils";
 import DropdownIndicator from "../utils/DropdownIndicator";
 import { colourStyles } from "../../theme/components/Select";
@@ -50,6 +51,17 @@ const AdminNewLanguageModal = ({
   const [role, setRole] = useState<string | null>(null);
   const [language, setLanguage] = useState<string | null>(null);
   const [level, setLevel] = useState<number | null>(null);
+  const [languageOptions, setLanguageOptions] = useState<any[]>([]);
+
+  useQuery(GET_LANGUAGES(), {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      const languageArray = data.languages.map((val: string) => ({
+        value: val,
+      }));
+      setLanguageOptions(languageArray);
+    },
+  });
 
   const currentApprovedLanguages = new Set(
     Object.keys(

--- a/frontend/src/components/userProfile/UserNewLanguageModal.tsx
+++ b/frontend/src/components/userProfile/UserNewLanguageModal.tsx
@@ -13,11 +13,13 @@ import {
   Text,
   Tooltip,
 } from "@chakra-ui/react";
+import { useQuery } from "@apollo/client";
+
 import { ApprovedLanguagesMap } from "../../utils/Utils";
 import { colourStyles } from "../../theme/components/Select";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
 import DropdownIndicator from "../utils/DropdownIndicator";
-import { languageOptions } from "../../constants/Languages";
+import GET_LANGUAGES from "../../APIClients/queries/LanguageQueries";
 
 export type UserNewLanguageModalProps = {
   onSubmit: (newLanguage: string) => void;
@@ -32,6 +34,17 @@ const UserNewLanguageModal = ({
   isOpen,
   onClose,
 }: UserNewLanguageModalProps) => {
+  const [languageOptions, setLanguageOptions] = useState<any[]>([]);
+  useQuery(GET_LANGUAGES(), {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      const languageArray = data.languages.map((val: string) => ({
+        value: val,
+      }));
+      setLanguageOptions(languageArray);
+    },
+  });
+
   const [newLanguage, setNewLanguage] = useState<string>("");
   const unapprovedLanguageOptions = languageOptions.filter(function (obj) {
     return (

--- a/frontend/src/components/userProfile/UserProfileForm.tsx
+++ b/frontend/src/components/userProfile/UserProfileForm.tsx
@@ -14,9 +14,11 @@ import {
 } from "@chakra-ui/react";
 import { Icon } from "@chakra-ui/icon";
 import { MdDelete, MdFolder } from "react-icons/md";
+import { useQuery } from "@apollo/client";
+
 import DropdownIndicator from "../utils/DropdownIndicator";
 import { convertLanguageTitleCase } from "../../utils/LanguageUtils";
-import { languageOptions } from "../../constants/Languages";
+import GET_LANGUAGES from "../../APIClients/queries/LanguageQueries";
 
 export type UserProfileFormProps = {
   isSignup?: boolean;
@@ -43,6 +45,16 @@ const UserProfileForm = ({
 }: UserProfileFormProps) => {
   const [file, setFile] = useState<File | null>(null);
   const [dragOver, setDragOver] = useState(false);
+  const [languageOptions, setLanguageOptions] = useState<any[]>([]);
+  useQuery(GET_LANGUAGES(), {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      const languageArray = data.languages.map((val: string) => ({
+        value: val,
+      }));
+      setLanguageOptions(languageArray);
+    },
+  });
 
   const onDragEnter = (e: any) => {
     e.preventDefault();


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket ](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=fda39b39ab4543e799e6377c17e3ab7c)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Add sort to languages in `get_languages` service before returning 
- Use `get_languages` query in Approved Languages & Levels table on user profile page for **admins**
- Use `get_languages` query in Language filters for **admins** 
- Use `get_languages` query in Approved Languages & Levels table on user profile page for **users**
- Use `get_languages` query in Import Story Page
- Use `get_languages` query in User Profile Form

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. [Add a new language](http://localhost:5000/graphql?query=mutation%20%7B%0A%20%20addLanguage(language%3A%22Python%22%2C%20isRtl%3A%20false)%7B%0A%20%20%20%20ok%0A%20%20%20%20language%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20language%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=undefined)
2. Go to five places mentioned above in Implementation description and check that this new language is on the drop down

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- There are no other places where we currently use 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
