### PR TITLE
Multiselect excluded languages in Import Story

### DIFF
--- a/frontend/src/components/pages/ImportStoryPage.tsx
+++ b/frontend/src/components/pages/ImportStoryPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
 import Select from "react-select";
 import {
+  Badge,
   Box,
   Button,
   Flex,
@@ -21,6 +22,7 @@ import { colourStyles } from "../../theme/components/Select";
 import { getLanguagesQuery } from "../../APIClients/queries/LanguageQueries";
 
 const ImportStoryPage = () => {
+  const [excludedLanguages, setExcludedLanguages] = useState<string[]>([]);
   const [languageOptions, setLanguageOptions] = useState<string[]>([]);
 
   useQuery(getLanguagesQuery.string, {
@@ -33,6 +35,23 @@ const ImportStoryPage = () => {
   const options = languageOptions.map((lang) => {
     return { value: lang };
   });
+
+  const excludedLanguageBadges = excludedLanguages.map((lang: string) => (
+    <Badge key={lang} textTransform="none" marginBottom="15px">
+      {lang}
+      <Button
+        variant="clear"
+        size="clear"
+        onClick={() => {
+          const excludedLanguagesCopy = [...excludedLanguages];
+          excludedLanguagesCopy.splice(excludedLanguages.indexOf(lang), 1);
+          setExcludedLanguages(excludedLanguagesCopy);
+        }}
+      >
+        ✕
+      </Button>
+    </Badge>
+  ));
 
   return (
     <Flex direction="column" height="100vh" justifyContent="space-between">
@@ -103,6 +122,7 @@ const ImportStoryPage = () => {
               >
                 Languages to Exclude
               </FormLabel>
+              {excludedLanguageBadges}
               <Box width="300px">
                 <Select
                   components={{ DropdownIndicator }}
@@ -111,6 +131,10 @@ const ImportStoryPage = () => {
                   `}
                   id="languages"
                   options={options}
+                  onChange={(option: any) =>
+                    excludedLanguages.indexOf(option?.value) === -1 &&
+                    setExcludedLanguages([...excludedLanguages, option?.value])
+                  }
                   placeholder="Select one or more languages"
                   styles={colourStyles}
                 />


### PR DESCRIPTION
## Notion ticket link

https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=0555b5da6b0642b5aa9cfc4dc049a8cb

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- added excludedLanguages state
- each select adds to excludedLanguages 
- badges display excludedLanguages 
- badges can be discarded and removed from excludedLanguages 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as angela
2. go to http://localhost:3000/#/import-story
3. add some languages
4. remove some languages
5. try adding the same language again
6. play around

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
