### PR TITLE
Add tooltip to View Results modal

### DIFF
--- a/frontend/src/components/onboarding/AssignTestGradeModal.tsx
+++ b/frontend/src/components/onboarding/AssignTestGradeModal.tsx
@@ -17,6 +17,7 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
+  Tooltip,
 } from "@chakra-ui/react";
 
 import InfoAlert from "../utils/InfoAlert";
@@ -30,6 +31,7 @@ import {
   ASSIGN_USER_LEVEL_CONFIRMATION,
   ASSIGN_USER_LEVEL_BUTTON,
   VIEW_FAILED_GRADE_ALERT,
+  GRADED_TEST_ASSIGN_LEVEL_TOOL_TIP_COPY,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
 import DropdownIndicator from "../utils/DropdownIndicator";
@@ -122,25 +124,32 @@ const AssignTestGradeModal = ({
           rowStart={2}
         >
           <Heading size="sm">Assign Level</Heading>
-          <Box width="80%">
-            <Select
-              isDisabled={isDisabled}
-              placeholder="Assign level"
-              options={levelOptions}
-              onChange={(option: any) =>
-                setTranslatorLevel(parseInt(option.value, 10))
-              }
-              getOptionLabel={(option: any) => option.value}
-              value={
-                displayTranslatorLevel
-                  ? { value: `${displayTranslatorLevel}` }
-                  : null
-              }
-              styles={colourStyles}
-              components={{ DropdownIndicator }}
-            />
-          </Box>
+          <Tooltip
+            hasArrow
+            label={GRADED_TEST_ASSIGN_LEVEL_TOOL_TIP_COPY}
+            isDisabled={!isDisabled}
+          >
+            <Box width="80%">
+              <Select
+                isDisabled={isDisabled}
+                placeholder="Assign level"
+                options={levelOptions}
+                onChange={(option: any) =>
+                  setTranslatorLevel(parseInt(option.value, 10))
+                }
+                getOptionLabel={(option: any) => option.value}
+                value={
+                  displayTranslatorLevel
+                    ? { value: `${displayTranslatorLevel}` }
+                    : null
+                }
+                styles={colourStyles}
+                components={{ DropdownIndicator }}
+              />
+            </Box>
+          </Tooltip>
         </GridItem>
+
         <GridItem
           colSpan={3}
           marginBottom="24px"
@@ -155,10 +164,16 @@ const AssignTestGradeModal = ({
             width="100%"
             onChange={() => setAssignReviewerLevel(!assignReviewerLevel)}
           >
-            <Text>
-              I would like to grant the <strong>Reviewer</strong> role to this
-              user.
-            </Text>
+            <Tooltip
+              hasArrow
+              label={GRADED_TEST_ASSIGN_LEVEL_TOOL_TIP_COPY}
+              isDisabled={!isDisabled}
+            >
+              <Text>
+                I would like to grant the <strong>Reviewer</strong> role to this
+                user.
+              </Text>
+            </Tooltip>
           </Checkbox>
         </GridItem>
         {(assignReviewerLevel || defaultReviewerLevel !== null) && (

--- a/frontend/src/components/onboarding/TestFeedbackModal.tsx
+++ b/frontend/src/components/onboarding/TestFeedbackModal.tsx
@@ -12,7 +12,10 @@ import {
   ModalOverlay,
   Text,
   Textarea,
+  Tooltip,
 } from "@chakra-ui/react";
+
+import { GRADED_TEST_ASSIGN_LEVEL_TOOL_TIP_COPY } from "../../utils/Copy";
 
 export type TestFeedbackModalProps = {
   isOpen: boolean;
@@ -52,22 +55,28 @@ const TestFeedbackModal = ({
         </ModalHeader>
         <ModalBody paddingBottom="36px">
           <Grid width="100%" marginBottom="24px">
-            <GridItem marginBottom="24px" paddingRight="32px" rowStart={1}>
-              {!isDisabled && (
-                <Text>
-                  Provide any feedback or comments to the user in the box below
-                  (Optional)
-                </Text>
-              )}
-              <Textarea
-                disabled={isDisabled}
-                height="285px"
-                margin="8px 0"
-                onChange={(e) => setTestFeedback(e.target.value)}
-                placeholder="Enter your feedback here..."
-                value={testFeedback}
-              />
-            </GridItem>
+            <Tooltip
+              hasArrow
+              label={GRADED_TEST_ASSIGN_LEVEL_TOOL_TIP_COPY}
+              isDisabled={!isDisabled}
+            >
+              <GridItem marginBottom="24px" paddingRight="32px" rowStart={1}>
+                {!isDisabled && (
+                  <Text>
+                    Provide any feedback or comments to the user in the box
+                    below (Optional)
+                  </Text>
+                )}
+                <Textarea
+                  disabled={isDisabled}
+                  height="285px"
+                  margin="8px 0"
+                  onChange={(e) => setTestFeedback(e.target.value)}
+                  placeholder="Enter your feedback here..."
+                  value={testFeedback}
+                />
+              </GridItem>
+            </Tooltip>
           </Grid>
           <Flex marginRight="28px" justifyContent="flex-end">
             {onBack && (

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -130,3 +130,6 @@ export const USER_PROFILE_PAGE_SAVE_CHANGES_CONFIRMATION =
   "If you entered a new email, you will be automatically signed out and your profile will be associated with the new email you have entered.";
 
 export const USER_PROFILE_PAGE_SAVE_CHANGES_BUTTON = "I'm sure, save changes";
+
+export const GRADED_TEST_ASSIGN_LEVEL_TOOL_TIP_COPY =
+  "The results of the test cannot be altered.";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add tooltip to View Results modal](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=1c23d05559874283a1136897b05362be)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Add tooltip to Assign Level, Assign ad Reviewer, and Feedback section on the results modal

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Create and complete a test as a user 
2. Grade the test as admin and finalize the grade 
3. View results of test and ensure that the tooltip appears in three aforementioned areas 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- bending the moral arc of the universe towards justice

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
