### PR TITLE
Make import story page functional

### DIFF
--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -201,3 +201,19 @@ export const SOFT_DELETE_STORY = gql`
 `;
 
 export type SoftDeleteStoryResponse = { ok: boolean };
+
+export const IMPORT_STORY = gql`
+  mutation ImportStory($storyFile: Upload!, $storyDetails: StoryRequestDTO!) {
+    importStory(storyFile: $storyFile, storyDetails: $storyDetails) {
+      story {
+        id
+      }
+    }
+  }
+`;
+
+export type ImportStoryResponse = {
+  story: {
+    id: number;
+  };
+};

--- a/frontend/src/components/pages/ImportStoryPage.tsx
+++ b/frontend/src/components/pages/ImportStoryPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { useQuery } from "@apollo/client";
+import { useHistory } from "react-router-dom";
+import { useQuery, useMutation } from "@apollo/client";
 import Select from "react-select";
 import {
   Badge,
@@ -9,21 +10,38 @@ import {
   FormControl,
   FormLabel,
   Heading,
+  IconButton,
   Input,
   Link,
   Text,
   Textarea,
 } from "@chakra-ui/react";
 import { Icon } from "@chakra-ui/icon";
-import { MdArrowBackIosNew, MdFolder } from "react-icons/md";
+import { MdArrowBackIosNew, MdDelete, MdFolder } from "react-icons/md";
 import DropdownIndicator from "../utils/DropdownIndicator";
 import Header from "../navigation/Header";
 import { colourStyles } from "../../theme/components/Select";
 import { getLanguagesQuery } from "../../APIClients/queries/LanguageQueries";
+import {
+  IMPORT_STORY,
+  ImportStoryResponse,
+} from "../../APIClients/mutations/StoryMutations";
+import { levelOptions } from "../../constants/Levels";
 
 const ImportStoryPage = () => {
+  const [dragOver, setDragOver] = useState(false);
   const [excludedLanguages, setExcludedLanguages] = useState<string[]>([]);
   const [languageOptions, setLanguageOptions] = useState<string[]>([]);
+  const [storyFile, setStoryFile] = useState<File | null>(null);
+  const [title, setTitle] = useState<string>("");
+  const [description, setDescription] = useState<string>("");
+  const [level, setLevel] = useState<number | null>(null);
+  const [youtubeLink, setYoutubeLink] = useState<string>("");
+
+  const history = useHistory();
+  const [importStory] = useMutation<{
+    importStory: ImportStoryResponse;
+  }>(IMPORT_STORY);
 
   useQuery(getLanguagesQuery.string, {
     fetchPolicy: "cache-and-network",
@@ -31,6 +49,85 @@ const ImportStoryPage = () => {
       setLanguageOptions(data.languages);
     },
   });
+
+  const onFileUpload = (e: any) => {
+    setStoryFile(e.target.files[0]);
+  };
+
+  const onFileDelete = () => {
+    setStoryFile(null);
+  };
+
+  const onDragEnter = (e: any) => {
+    e.preventDefault();
+    setDragOver(true);
+  };
+
+  const onDragLeave = (e: any) => {
+    e.preventDefault();
+    setDragOver(false);
+  };
+
+  const onDragOver = (e: any) => {
+    e.preventDefault();
+    if (
+      e.dataTransfer.items &&
+      e.dataTransfer.items.length === 1 &&
+      e.dataTransfer.items[0].kind === "file"
+    ) {
+      e.dataTransfer.dropEffect = "copy";
+    }
+  };
+
+  const onFileDrop = (e: any) => {
+    e.preventDefault();
+    setDragOver(false);
+    if (
+      e.dataTransfer.items &&
+      e.dataTransfer.items.length === 1 &&
+      e.dataTransfer.items[0].kind === "file"
+    ) {
+      const newStoryFile = e.dataTransfer.items[0].getAsFile();
+      if (
+        newStoryFile.type ===
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      ) {
+        setStoryFile(newStoryFile);
+      } else {
+        console.log("Incorrect file type");
+      }
+    } else if (e.dataTransfer.files && e.dataTransfer.files.length === 1) {
+      const newStoryFile = e.dataTransfer.files[0];
+      if (
+        newStoryFile.type ===
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      ) {
+        setStoryFile(newStoryFile);
+      }
+    }
+  };
+  const submitForm = async () => {
+    if (!(storyFile && title && description && level && youtubeLink)) {
+      window.alert("Please fill out all required fields.");
+      return;
+    }
+
+    const result = await importStory({
+      variables: {
+        storyFile,
+        storyDetails: {
+          title,
+          description,
+          youtubeLink,
+          level,
+        },
+      },
+    });
+    if (result.data) {
+      const storyId = result.data.importStory.story.id;
+      history.push(`/story/${storyId}`);
+    }
+  };
 
   const options = languageOptions.map((lang) => {
     return { value: lang };
@@ -79,7 +176,13 @@ const ImportStoryPage = () => {
               <FormLabel fontWeight="bold" htmlFor="title" marginBottom="15px">
                 Title
               </FormLabel>
-              <Input id="title" size="md" type="text" />
+              <Input
+                id="title"
+                size="md"
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+              />
             </FormControl>
             <FormControl isRequired marginTop="40px">
               <FormLabel
@@ -89,9 +192,15 @@ const ImportStoryPage = () => {
               >
                 Description
               </FormLabel>
-              <Textarea id="description" height="150px" type="text" />
+              <Textarea
+                id="description"
+                height="150px"
+                type="text"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
             </FormControl>
-            <FormControl marginTop="40px">
+            <FormControl marginTop="40px" isRequired>
               <FormLabel fontWeight="bold" htmlFor="level" marginBottom="15px">
                 Level
               </FormLabel>
@@ -101,6 +210,10 @@ const ImportStoryPage = () => {
                   id="level"
                   placeholder="Select level"
                   styles={colourStyles}
+                  options={levelOptions}
+                  onChange={(option: any) => setLevel(option?.value || "")}
+                  getOptionLabel={(option: any) => `Level ${option.value}`}
+                  value={level ? { value: level } : null}
                 />
               </Box>
             </FormControl>
@@ -112,7 +225,13 @@ const ImportStoryPage = () => {
               >
                 Youtube Link
               </FormLabel>
-              <Input id="youtube-link" size="md" type="text" />
+              <Input
+                id="youtube-link"
+                size="md"
+                type="text"
+                value={youtubeLink}
+                onChange={(e) => setYoutubeLink(e.target.value)}
+              />
             </FormControl>
             <FormControl marginTop="40px">
               <FormLabel
@@ -172,34 +291,87 @@ const ImportStoryPage = () => {
                 internationally important languages.
               </Text>
             </Box>
-            <FormControl isRequired marginTop="40px">
-              <FormLabel
-                fontWeight="bold"
-                htmlFor="upload-file"
-                marginBottom="15px"
-              >
+            <Flex direction="column" flex={1} marginTop="40px">
+              <Heading size="sm">
                 Upload file
-              </FormLabel>
-              <Box
-                backgroundColor="blue.50"
-                border="1px solid"
-                borderColor="blue.100"
-                borderRadius="10px"
-                padding="60px 120px"
-                textAlign="center"
+                <span
+                  role="presentation"
+                  className="chakra-form__required-indicator css-1ssjhh"
+                >
+                  *
+                </span>
+              </Heading>{" "}
+              <Flex
+                align="center"
+                background="blue.50"
+                border={dragOver ? "2px dashed" : "2px solid"}
+                // this is blue.100 at 50% opacity
+                borderColor="rgba(29, 108, 165, 0.5)"
+                direction="column"
+                height="250px"
+                justify="center"
+                onDragEnter={(e: any) => onDragEnter(e)}
+                onDragLeave={(e: any) => onDragLeave(e)}
+                onDragOver={(e: any) => onDragOver(e)}
+                onDrop={(e: any) => onFileDrop(e)}
+                opacity={dragOver ? "50%" : "100%"}
+                rounded="md"
               >
-                <Icon as={MdFolder} color="blue.100" height={16} width={16} />
-                <Text fontSize="sm" marginBottom="15px">
-                  Drag & drop your files here (.docx)
+                <Icon
+                  aria-label="Folder icon"
+                  as={MdFolder}
+                  background="transparent"
+                  color="blue.100"
+                  height={16}
+                  marginBottom="8px"
+                  pointerEvents="none"
+                  width={16}
+                />
+                <Text pointerEvents="none">
+                  Drag & drop your file here (.docx)
                 </Text>
-                <Button colorScheme="blue" textTransform="capitalize">
-                  Browse Files
-                </Button>
-              </Box>
-            </FormControl>
-            <Text fontWeight="bold" marginTop="40px">
-              Uploaded files
-            </Text>
+                <FormControl
+                  pointerEvents={dragOver ? "none" : "auto"}
+                  width="160px"
+                >
+                  <FormLabel
+                    cursor="pointer"
+                    htmlFor="browse-files"
+                    marginTop="16px"
+                  >
+                    <Button colorScheme="blue" pointerEvents="none">
+                      Browse Files
+                    </Button>
+                  </FormLabel>
+                  <Input
+                    accept=".docx,.pdf"
+                    hidden
+                    id="browse-files"
+                    onChange={(e) => onFileUpload(e)}
+                    type="file"
+                  />
+                </FormControl>
+              </Flex>
+              <Heading marginTop="40px" size="sm">
+                Uploaded file
+              </Heading>
+              <Text marginBottom="10px">
+                Drag & drop a file or browse files to upload a story.
+              </Text>
+              {storyFile && (
+                <Flex key={storyFile.name}>
+                  <Text marginTop="10px">{storyFile.name}</Text>
+                  <IconButton
+                    aria-label="Delete icon"
+                    background="transparent"
+                    icon={<Icon as={MdDelete} height={5} width={5} />}
+                    marginTop="3px"
+                    onClick={() => onFileDelete()}
+                    width="fit-content"
+                  />
+                </Flex>
+              )}
+            </Flex>
           </Flex>
         </Flex>
       </Flex>
@@ -215,7 +387,11 @@ const ImportStoryPage = () => {
           <Button colorScheme="blue" marginRight="20px" variant="blueOutline">
             PREVIEW STORY
           </Button>
-          <Button colorScheme="blue" marginRight="90px">
+          <Button
+            colorScheme="blue"
+            marginRight="90px"
+            onClick={() => submitForm()}
+          >
             IMPORT STORY
           </Button>
         </Box>

--- a/frontend/src/components/pages/ImportStoryPage.tsx
+++ b/frontend/src/components/pages/ImportStoryPage.tsx
@@ -120,6 +120,7 @@ const ImportStoryPage = () => {
           description,
           youtubeLink,
           level,
+          translatedLanguages: excludedLanguages,
         },
       },
     });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,19 +1,19 @@
 body {
   margin: 0;
-  font-family: 'Noto Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+    "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
 
 :root {
-  --dark-blue: #1D6CA5;
+  --dark-blue: #1d6ca5;
   --interactive-grey: #606062;
 }
 
@@ -22,14 +22,14 @@ code {
 }
 
 ::-webkit-scrollbar-track {
-  background: #EDEDED;
+  background: #ededed;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #C4C4C4;
+  background: #c4c4c4;
 }
 
 ::-webkit-scrollbar-thumb:hover {
   /* Don't know what colour we want here */
-  background: #B3B3B3;
+  background: #b3b3b3;
 }

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -14,6 +14,7 @@ import Textarea from "./components/Textarea";
 
 const customTheme = extendTheme({
   fonts: {
+    heading: `"Noto Sans"`,
     body: `"Noto Sans"`,
   },
   config: {


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Make import story page functional](https://www.notion.so/uwblueprintexecs/Make-import-story-page-functional-1efdd94431684af68a257d71e98c9ed1)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added functionality to import story page
- Also slipped a very small change to use Noto for headings 
- Also some CSS linting made it into the PR, I just left it there but can remove it?

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Log in as angela
2. Go to http://localhost:3000/#/story/15
3. Try uploading a story 
4. Check that it works! 
5. Check that you are redirected to the story page

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
