### PR TITLE
Add “This test has been graded” tooptip to GradingPage

### DIFF
--- a/frontend/src/components/translation/TranslationTable.tsx
+++ b/frontend/src/components/translation/TranslationTable.tsx
@@ -11,6 +11,7 @@ import { IS_RTL } from "../../APIClients/queries/LanguageQueries";
 import {
   TRANSLATION_PAGE_TOOL_TIP_COPY,
   REVIEW_PAGE_TOOL_TIP_COPY,
+  REVIEW_TEST_TOOL_TIP_COPY,
 } from "../../utils/Copy";
 
 export type TranslationTableProps = {
@@ -72,7 +73,6 @@ const TranslationTable = ({
     setStoryTranslationContentId!!(storyTranslationContentId);
   };
 
-  const showStatusColumn = !isTest || isReviewable;
   const [isRTL, setIsRTL] = useState<boolean>(true);
 
   useQuery(IS_RTL(translatedLanguage), {
@@ -126,55 +126,55 @@ const TranslationTable = ({
             </Flex>
           </Tooltip>
         )}
-        {showStatusColumn && (
-          <Flex
-            direction="column"
-            width="160px"
-            marginLeft="12px"
-            marginTop="10px"
-            marginRight={isTest ? `${STATUS_COLUMN_MARGIN_OFFSET}px` : "8px"}
-          >
-            {isReviewable ? (
-              <StatusBadge
-                translatedStoryLines={translatedStoryLines}
-                setTranslatedStoryLines={setTranslatedStoryLines}
-                storyLine={storyLine}
-                numApprovedLines={numApprovedLines!!}
-                setNumApprovedLines={setNumApprovedLines!!}
-                numGradedLines={numGradedLines}
-                setNumGradedLines={setNumGradedLines}
-                isTest={isTest}
-              />
-            ) : (
-              <Tooltip
-                hasArrow
-                label={REVIEW_PAGE_TOOL_TIP_COPY}
-                isDisabled={editable || !reviewPage}
+        <Flex
+          direction="column"
+          width="160px"
+          marginLeft="12px"
+          marginTop="10px"
+          marginRight={isTest ? `${STATUS_COLUMN_MARGIN_OFFSET}px` : "8px"}
+        >
+          {isReviewable ? (
+            <StatusBadge
+              translatedStoryLines={translatedStoryLines}
+              setTranslatedStoryLines={setTranslatedStoryLines}
+              storyLine={storyLine}
+              numApprovedLines={numApprovedLines!!}
+              setNumApprovedLines={setNumApprovedLines!!}
+              numGradedLines={numGradedLines}
+              setNumGradedLines={setNumGradedLines}
+              isTest={isTest}
+            />
+          ) : (
+            <Tooltip
+              hasArrow
+              label={
+                isTest ? REVIEW_TEST_TOOL_TIP_COPY : REVIEW_PAGE_TOOL_TIP_COPY
+              }
+              isDisabled={editable || !reviewPage}
+            >
+              <Badge
+                textTransform="capitalize"
+                variant={getStatusVariant(storyLine.status)}
+                marginBottom="10px"
               >
-                <Badge
-                  textTransform="capitalize"
-                  variant={getStatusVariant(storyLine.status)}
-                  marginBottom="10px"
-                >
-                  {storyLine.status}
-                </Badge>
-              </Tooltip>
-            )}
-            {commentLine! > -1 && (
-              <Button
-                variant="addComment"
-                onClick={() =>
-                  handleCommentButton(
-                    displayLineNumber,
-                    storyLine.storyTranslationContentId!!,
-                  )
-                }
-              >
-                Comment
-              </Button>
-            )}
-          </Flex>
-        )}
+                {storyLine.status}
+              </Badge>
+            </Tooltip>
+          )}
+          {commentLine! > -1 && (
+            <Button
+              variant="addComment"
+              onClick={() =>
+                handleCommentButton(
+                  displayLineNumber,
+                  storyLine.storyTranslationContentId!!,
+                )
+              }
+            >
+              Comment
+            </Button>
+          )}
+        </Flex>
       </Flex>
     );
   });
@@ -218,7 +218,7 @@ const TranslationTable = ({
             )}
           </Text>
         </Flex>
-        {showStatusColumn && <StatusHeader />}
+        <StatusHeader />
       </Flex>
       {storyCells}
     </Flex>

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -130,3 +130,5 @@ export const USER_PROFILE_PAGE_SAVE_CHANGES_CONFIRMATION =
   "If you entered a new email, you will be automatically signed out and your profile will be associated with the new email you have entered.";
 
 export const USER_PROFILE_PAGE_SAVE_CHANGES_BUTTON = "I'm sure, save changes";
+
+export const REVIEW_TEST_TOOL_TIP_COPY = "This test has already been graded.";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add “This test has been graded” tooptip to GradingPage](https://www.notion.so/uwblueprintexecs/Add-This-test-has-been-graded-tooptip-to-GradingPage-cd7e14d5375746d2bfb9d8d7dbf2f522)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Show status column
- Added tool tip to status badges

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl
2. Add and submit some tests
3. Login as Angela
4. Grade the tests
5. View the graded tests
6. Hover over status badges in status column, there should be a tool tip that says "This test has already been graded."

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?
- Is code ok?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
