### PR TITLE
Implement admin add language modal

### DIFF
--- a/frontend/src/APIClients/mutations/LanguageMutations.ts
+++ b/frontend/src/APIClients/mutations/LanguageMutations.ts
@@ -1,0 +1,15 @@
+import { gql } from "@apollo/client";
+
+export type Languages = string[];
+
+export const ADD_LANGUAGE = gql`
+  mutation AddLanguage($language: String!, $isRtl: Boolean!) {
+    addLanguage(language: $language, isRtl: $isRtl) {
+      ok
+    }
+  }
+`;
+
+export type AddLanguageResponse = {
+  ok: boolean;
+};

--- a/frontend/src/components/admin/AddLanguageModal.tsx
+++ b/frontend/src/components/admin/AddLanguageModal.tsx
@@ -1,0 +1,218 @@
+import React, { useState } from "react";
+import { useQuery, useMutation } from "@apollo/client";
+import Select from "react-select";
+
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Table,
+  Text,
+  Tbody,
+  Tr,
+  Td,
+  useStyleConfig,
+} from "@chakra-ui/react";
+
+import {
+  ADD_LANGUAGE,
+  AddLanguageResponse,
+} from "../../APIClients/mutations/LanguageMutations";
+import {
+  ADD_LANGUAGE_SUCCESS_HEADING,
+  ADD_LANGUAGE_SUCCESS_CONFIRMATION,
+  CONFIRM_OK,
+} from "../../utils/Copy";
+
+import { scriptDirectionOptions } from "../../constants/Languages";
+import ConfirmationModal from "../utils/ConfirmationModal";
+import DropdownIndicator from "../utils/DropdownIndicator";
+import { colourStyles } from "../../theme/components/Select";
+import { getLanguagesQuery } from "../../APIClients/queries/LanguageQueries";
+
+export type AddLanguageModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const AddLanguageModal = ({ isOpen, onClose }: AddLanguageModalProps) => {
+  const [language, setLanguage] = useState<string>("");
+  const [languageOptions, setLanguageOptions] = useState<string[]>([]);
+  const [isRtl, setIsRtl] = useState<boolean | null>(null);
+  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState<boolean>(false);
+
+  const disabledStyle = useStyleConfig("Disabled");
+  const [addLanguage] = useMutation<{
+    addLanguage: AddLanguageResponse;
+  }>(ADD_LANGUAGE);
+
+  const onConfirmationModalClose = () => {
+    setLanguageOptions([...languageOptions, language]);
+    setLanguage("");
+    setIsRtl(null);
+    setIsSuccessModalOpen(false);
+    onClose();
+  };
+
+  const useAddLanguage = async () => {
+    try {
+      const result = await addLanguage({ variables: { language, isRtl } });
+      if (!result.data?.addLanguage.ok) {
+        window.alert("Error creating new language!");
+        onConfirmationModalClose();
+      }
+      setIsSuccessModalOpen(true);
+    } catch (err) {
+      window.alert(err);
+      onConfirmationModalClose();
+    }
+  };
+
+  useQuery(getLanguagesQuery.string, {
+    fetchPolicy: "cache-and-network",
+    onCompleted: (data) => {
+      setLanguageOptions(data.languages);
+    },
+  });
+
+  const languageTableBody = languageOptions.map(
+    (lang: string, index: number) => (
+      <Tr
+        borderTop={index === 0 ? "1em solid transparent" : ""}
+        borderBottom={
+          index === languageOptions.length - 1 ? "1em solid transparent" : ""
+        }
+        key={lang}
+      >
+        <Td>{lang}</Td>
+      </Tr>
+    ),
+  );
+
+  const getScriptDirectionSelectValue = () => {
+    if (isRtl === null) {
+      return null;
+    }
+    if (isRtl) {
+      return { value: "Right-to-left" };
+    }
+    return { value: "Left-to-right" };
+  };
+
+  return (
+    <>
+      <Modal
+        isOpen={isOpen}
+        motionPreset="slideInBottom"
+        onClose={onClose}
+        size="6xl"
+      >
+        <ModalOverlay />
+        <ModalContent paddingLeft="32px">
+          <ModalCloseButton
+            marginLeft="auto"
+            marginRight="8px"
+            marginTop="8px"
+            position="static"
+          />
+          <ModalHeader paddingTop="20px">
+            <Heading as="h3" size="lg">
+              Add New Language
+            </Heading>
+          </ModalHeader>
+          <ModalBody paddingBottom="36px">
+            <Flex justifyContent="space-between">
+              <Flex direction="column" width="40%" margin="10px">
+                <Heading as="h4" size="sm" marginBottom="3px">
+                  Add New Language
+                </Heading>
+                <Text marginBottom="3px">
+                  Please enter the name of the new language.
+                </Text>
+                <Input
+                  id="new-language"
+                  type="text"
+                  value={language}
+                  onChange={(event) => setLanguage(event.target.value)}
+                  placeholder="Enter new language"
+                  marginBottom="10px"
+                />
+                <Heading as="h4" size="sm" marginBottom="3px">
+                  Script Direction
+                </Heading>
+                <Text marginBottom="3px">
+                  Please enter the direction of the script. For example, English
+                  is left-to-right and Arabic is right-to-left.
+                </Text>
+                <Box
+                  width="80%"
+                  sx={language === "" ? disabledStyle : undefined}
+                >
+                  <Select
+                    placeholder="Select Script Direction"
+                    options={scriptDirectionOptions}
+                    onChange={(option: any) =>
+                      setIsRtl(option.value === "Right-to-left")
+                    }
+                    getOptionLabel={(option: any) => option.value}
+                    value={getScriptDirectionSelectValue()}
+                    styles={colourStyles}
+                    components={{ DropdownIndicator }}
+                    isDisabled={language === ""}
+                  />
+                </Box>
+              </Flex>
+              <Flex direction="column" margin="10px" width="50%">
+                <Heading as="h4" size="sm">
+                  Existing Languages
+                </Heading>
+                <Box overflow="auto" height="300px" padding="10px">
+                  <Table
+                    borderRadius="12px"
+                    boxShadow="0px 0px 2px grey"
+                    margin="auto"
+                    size="sm"
+                    theme="gray"
+                    variant="striped"
+                    width="100%"
+                  >
+                    <Tbody>{languageTableBody}</Tbody>
+                  </Table>
+                </Box>
+              </Flex>
+            </Flex>
+            <Flex marginRight="28px" justifyContent="flex-end">
+              <Button
+                fontSize="14px"
+                colorScheme="blue"
+                width="120px"
+                isDisabled={language === "" || isRtl === null}
+                onClick={useAddLanguage}
+              >
+                Confirm
+              </Button>
+            </Flex>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+      <ConfirmationModal
+        buttonMessage={CONFIRM_OK}
+        confirmation={isSuccessModalOpen && isOpen}
+        confirmationHeading={ADD_LANGUAGE_SUCCESS_HEADING}
+        confirmationMessage={ADD_LANGUAGE_SUCCESS_CONFIRMATION}
+        onClose={onConfirmationModalClose}
+        onConfirmationClick={onConfirmationModalClose}
+      />
+    </>
+  );
+};
+
+export default AddLanguageModal;

--- a/frontend/src/components/admin/AddLanguageModal.tsx
+++ b/frontend/src/components/admin/AddLanguageModal.tsx
@@ -107,6 +107,11 @@ const AddLanguageModal = ({ isOpen, onClose }: AddLanguageModalProps) => {
     return { value: "Left-to-right" };
   };
 
+  const languageAlreadyExists =
+    languageOptions
+      .map((lang) => lang.toLowerCase())
+      .indexOf(language.toLowerCase()) !== -1;
+
   return (
     <>
       <Modal
@@ -137,8 +142,16 @@ const AddLanguageModal = ({ isOpen, onClose }: AddLanguageModalProps) => {
                 <Text marginBottom="3px">
                   Please enter the name of the new language.
                 </Text>
+                {languageAlreadyExists && (
+                  <Text marginBottom="3px" color="red.100">
+                    This language already exists.
+                  </Text>
+                )}
                 <Input
                   id="new-language"
+                  isInvalid={languageAlreadyExists}
+                  errorBorderColor="red.100"
+                  focusBorderColor={languageAlreadyExists ? "red.100" : ""}
                   type="text"
                   value={language}
                   onChange={(event) => setLanguage(event.target.value)}
@@ -154,7 +167,11 @@ const AddLanguageModal = ({ isOpen, onClose }: AddLanguageModalProps) => {
                 </Text>
                 <Box
                   width="80%"
-                  sx={language === "" ? disabledStyle : undefined}
+                  sx={
+                    languageAlreadyExists || language === ""
+                      ? disabledStyle
+                      : undefined
+                  }
                 >
                   <Select
                     placeholder="Select Script Direction"
@@ -166,7 +183,7 @@ const AddLanguageModal = ({ isOpen, onClose }: AddLanguageModalProps) => {
                     value={getScriptDirectionSelectValue()}
                     styles={colourStyles}
                     components={{ DropdownIndicator }}
-                    isDisabled={language === ""}
+                    isDisabled={languageAlreadyExists || language === ""}
                   />
                 </Box>
               </Flex>
@@ -174,11 +191,14 @@ const AddLanguageModal = ({ isOpen, onClose }: AddLanguageModalProps) => {
                 <Heading as="h4" size="sm">
                   Existing Languages
                 </Heading>
-                <Box overflow="auto" height="300px" padding="10px">
+                <Box
+                  borderRadius="10px"
+                  boxShadow="0px 0px 2px grey"
+                  height="300px"
+                  overflow="auto"
+                >
                   <Table
-                    borderRadius="12px"
-                    boxShadow="0px 0px 2px grey"
-                    margin="auto"
+                    marginTop="-10px"
                     size="sm"
                     theme="gray"
                     variant="striped"
@@ -194,7 +214,9 @@ const AddLanguageModal = ({ isOpen, onClose }: AddLanguageModalProps) => {
                 fontSize="14px"
                 colorScheme="blue"
                 width="120px"
-                isDisabled={language === "" || isRtl === null}
+                isDisabled={
+                  languageAlreadyExists || language === "" || isRtl === null
+                }
                 onClick={useAddLanguage}
               >
                 Confirm

--- a/frontend/src/components/admin/ManageStoryTranslations.tsx
+++ b/frontend/src/components/admin/ManageStoryTranslations.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
-import { Box, Flex, Heading, Link } from "@chakra-ui/react";
+import { Box, Flex, Heading } from "@chakra-ui/react";
 import { Icon } from "@chakra-ui/icon";
-import { MdLogout } from "react-icons/md";
+import { MdLibraryAdd } from "react-icons/md";
 import Statistic from "./Statistic";
 import StoryTranslationsTable from "./StoryTranslationsTable";
 import TableFilter from "./TableFilter";
@@ -14,6 +14,7 @@ import {
 import { convertTitleCaseToStage } from "../../utils/StageUtils";
 import { STORY_TRANSLATION_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER } from "../../utils/Copy";
 import usePagination from "../../utils/hooks/usePagination";
+import AddLanguageModal from "./AddLanguageModal";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -26,6 +27,8 @@ const ManageStoryTranslations = () => {
     useState(0);
   const [numTranslationsInReview, setNumTranslationsInReview] = useState(0);
   const [numTranslationsCompleted, setNumTranslationsCompleted] = useState(0);
+  const [isAddNewLanguageModalOpen, setIsAddNewLanguageModalOpen] =
+    useState(false);
 
   const query = buildStoryTranslationsQuery(
     0,
@@ -57,62 +60,76 @@ const ManageStoryTranslations = () => {
   });
 
   return (
-    <Box textAlign="center">
-      <Flex padding="35px 35px 10px 35px">
-        <Statistic header="IN TRANSLATION" num={numTranslationsInTranslation} />
-        <Statistic header="IN REVIEW" num={numTranslationsInReview} />
-        <Statistic header="COMPLETED" num={numTranslationsCompleted} />
-        <Link
-          border="1px solid"
-          borderColor="gray.200"
-          borderRadius="10px"
-          href="/#/import-story"
-          margin="10px"
-          textDecoration="none"
-          _hover={{ textDecoration: "none" }}
-        >
-          <Box color="blue.500" height="150px" paddingTop="35px" width="200px">
-            <Icon
-              as={MdLogout}
-              height={10}
-              marginBottom="10px"
-              transform="rotate(270deg)"
-              width={10}
-            />
-            <Heading size="sm" textTransform="uppercase">
-              IMPORT STORY
-            </Heading>
+    <>
+      <Box textAlign="center">
+        <Flex padding="35px 35px 10px 35px">
+          <Statistic
+            header="IN TRANSLATION"
+            num={numTranslationsInTranslation}
+          />
+          <Statistic header="IN REVIEW" num={numTranslationsInReview} />
+          <Statistic header="COMPLETED" num={numTranslationsCompleted} />
+          <Box
+            border="1px solid"
+            borderColor="gray.200"
+            borderRadius="10px"
+            margin="10px"
+            textDecoration="none"
+            _hover={{ cursor: "pointer", textDecoration: "none" }}
+            onClick={() => setIsAddNewLanguageModalOpen(true)}
+          >
+            <Box
+              color="blue.500"
+              height="150px"
+              paddingTop="35px"
+              width="200px"
+            >
+              <Icon
+                as={MdLibraryAdd}
+                height={10}
+                marginBottom="10px"
+                transform="rotate(270deg)"
+                width={10}
+              />
+              <Heading size="sm" textTransform="uppercase">
+                LANGUAGE
+              </Heading>
+            </Box>
           </Box>
-        </Link>
-      </Flex>
-      <Flex>
-        <Heading float="left" margin="20px 30px" size="lg">
-          Manage Story Translations
-        </Heading>
-      </Flex>
-      <TableFilter
-        language={language}
-        setLanguage={setLanguage}
-        level={level}
-        setLevel={setLevel}
-        stage={stage}
-        setStage={setStage}
-        searchText={searchText}
-        setSearchText={setSearchText}
-        searchBarPlaceholder={
-          STORY_TRANSLATION_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER
-        }
-        useLanguage
-        useLevel
-        useStage
+        </Flex>
+        <Flex>
+          <Heading float="left" margin="20px 30px" size="lg">
+            Manage Story Translations
+          </Heading>
+        </Flex>
+        <TableFilter
+          language={language}
+          setLanguage={setLanguage}
+          level={level}
+          setLevel={setLevel}
+          stage={stage}
+          setStage={setStage}
+          searchText={searchText}
+          setSearchText={setSearchText}
+          searchBarPlaceholder={
+            STORY_TRANSLATION_TABLE_FILTER_SEARCH_BAR_PLACEHOLDER
+          }
+          useLanguage
+          useLevel
+          useStage
+        />
+        <StoryTranslationsTable
+          loading={loading}
+          storyTranslationSlice={pageResults}
+          paginator={paginator}
+          filters={[setLanguage, setLevel, setStage, setSearchText]}
+        />
+      </Box>
+      <AddLanguageModal
+        isOpen={isAddNewLanguageModalOpen}
+        onClose={() => setIsAddNewLanguageModalOpen(false)}
       />
-      <StoryTranslationsTable
-        loading={loading}
-        storyTranslationSlice={pageResults}
-        paginator={paginator}
-        filters={[setLanguage, setLevel, setStage, setSearchText]}
-      />
-    </Box>
+    </>
   );
 };
 

--- a/frontend/src/constants/Languages.ts
+++ b/frontend/src/constants/Languages.ts
@@ -1,0 +1,5 @@
+/* eslint-disable import/prefer-default-export */
+export const scriptDirectionOptions = [
+  { value: "Left-to-right" },
+  { value: "Right-to-left" },
+];

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -133,3 +133,10 @@ export const USER_PROFILE_PAGE_SAVE_CHANGES_BUTTON = "I'm sure, save changes";
 
 export const GRADED_TEST_ASSIGN_LEVEL_TOOL_TIP_COPY =
   "The results of the test cannot be altered.";
+
+export const ADD_LANGUAGE_SUCCESS_HEADING = "New Language Added";
+
+export const ADD_LANGUAGE_SUCCESS_CONFIRMATION =
+  "The new language was successfully added.";
+
+export const CONFIRM_OK = "Okay";


### PR DESCRIPTION
## Notion ticket link

https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=0bce90b6883443fdbc6ae18c0e945e63

## Implementation description

- added AddLanguageModal
- converted the import story button on the manage story translation page to an add language button

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as angela
2. click the big phat language button
3. observe an intuitive and functional flow
4. confirm adding the language. do not refresh, immediately click the phat button again
5. observe the cleared modal. add another language just for fun
6. try messing around with modals as usual

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- happiness, staying hydrated
- hows it look on different screen sizes?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
