### PR TITLE
Fixed signup

### DIFF
--- a/backend/python/app/services/implementations/auth_service.py
+++ b/backend/python/app/services/implementations/auth_service.py
@@ -69,7 +69,7 @@ class AuthService(IAuthService):
                 CreateUserWithGoogleDTO(
                     first_name=google_user["firstName"],
                     last_name=google_user["lastName"],
-                    role_id="User",
+                    role="User",
                     email=google_user["email"],
                     auth_id=auth_id,
                     on_firebase=on_firebase,

--- a/frontend/src/APIClients/BaseGQLClient.ts
+++ b/frontend/src/APIClients/BaseGQLClient.ts
@@ -70,7 +70,8 @@ const accessTokenInjectionLink = new ApolloLink(
 );
 
 const refreshDirectionalLink = new RetryLink().split(
-  (operation) => ["Refresh", "Login"].includes(operation.operationName),
+  (operation) =>
+    ["Refresh", "Login", "SignUp"].includes(operation.operationName),
   authFromLocalLink.concat(httpLink),
   accessTokenInjectionLink.concat(httpLink),
 );

--- a/frontend/src/APIClients/BaseGQLClient.ts
+++ b/frontend/src/APIClients/BaseGQLClient.ts
@@ -71,7 +71,9 @@ const accessTokenInjectionLink = new ApolloLink(
 
 const refreshDirectionalLink = new RetryLink().split(
   (operation) =>
-    ["Refresh", "Login", "SignUp"].includes(operation.operationName),
+    ["Refresh", "Login", "SignUp", "LoginWithGoogle"].includes(
+      operation.operationName,
+    ),
   authFromLocalLink.concat(httpLink),
   accessTokenInjectionLink.concat(httpLink),
 );


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/User-sign-up-is-broken-c012f711e5064df6bac19ed3e9176f2c

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

okay so there were a few issues with the signup flow:
1. on the frontend, the `refreshToken` field wasn't fetched
2. on the frontend, SignUp was triggering the `accessTokenFromInjectionLink`, which refreshes the page since there is no access token in local storage (took me wayyyy too long to find this)
3. on the backend, `dispatch_request` was calling the `create_user` function in user_service twice (which led to an `EMAIL_EXISTS` error, also took me way too long to resolve this)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Try signing up with a new email
2. Verify that you get logged and redirected to `/complete-profile`
3. Logout and try signing in again, verify that it works

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does signup work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
