### PR TITLE
Allow user to start story test with intention to review

### DIFF
--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -56,13 +56,14 @@ class CreateStoryTranslationTest(graphene.Mutation):
         user_id = graphene.ID(required=True)
         level = graphene.Int(required=True)
         language = graphene.String(required=True)
+        wants_reviewer = graphene.Boolean(required=True)
 
     story = graphene.Field(lambda: CreateStoryTranslationResponseDTO)
 
-    def mutate(root, info, user_id, level, language):
+    def mutate(root, info, user_id, level, language, wants_reviewer):
         try:
             new_story_translation = services["story"].create_translation_test(
-                user_id, level, language
+                user_id, level, language, wants_reviewer
             )
             return CreateStoryTranslation(story=new_story_translation)
         except Exception as e:

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -227,14 +227,14 @@ class StoryService(IStoryService):
             db.session.add(new_story_translation)
             db.session.commit()
         except Exception as error:
-            self.logger.error("Could not create story translation test.", str(error))
+            self.logger.error(str(error))
             raise error
         try:
             self._insert_empty_story_translation_contents(db, new_story_translation)
         except Exception as error:
             db.session.delete(new_story_translation)
             db.session.commit()
-            self.logger.error("Could not create story translation test.", str(error))
+            self.logger.error(str(error))
             raise error
         return new_story_translation
 

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -55,12 +55,14 @@ class IStoryService(ABC):
         pass
 
     @abstractmethod
-    def create_translation_test(self, user_id, level, language):
+    def create_translation_test(self, user_id, level, language, wants_reviewer):
         """Create a new StoryTranslation object that is_test=True
 
         :param user_id: ID target translator_id
         :param level: int Story test level
         :param language: String target test language
+        :param wants_reviewer: Boolean indicating if user wants to be
+                               assigned level for review
         :return: dictionary of StoryTranslation object
         :rtype: dictionary
         :raises Exception: if story fields are invalid

--- a/backend/python/app/tests/services/test_story_service.py
+++ b/backend/python/app/tests/services/test_story_service.py
@@ -197,7 +197,7 @@ def test_create_translation_test(app, db, services):
     db.session.commit()
 
     story_translation_resp = services["story"].create_translation_test(
-        translator_obj.id, 2, "ENGLISH"
+        translator_obj.id, 2, "ENGLISH", False
     )
     story_translation_obj = StoryTranslation.query.get(story_translation_resp.id)
     assert story_translation_resp == story_translation_obj
@@ -272,10 +272,10 @@ def test_get_story_translation_tests(app, db, services):
 
     # Create story translation tests
     first_story_translation_resp = services["story"].create_translation_test(
-        first_translator_obj.id, 2, "ENGLISH"
+        first_translator_obj.id, 2, "ENGLISH", False
     )
     second_story_translation_resp = services["story"].create_translation_test(
-        second_translator_obj.id, 2, "ENGLISH"
+        second_translator_obj.id, 2, "ENGLISH", False
     )
 
     # Test for admin

--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -148,11 +148,17 @@ export const UPDATE_STORY = gql`
 export type UpdateStoryResponse = { ok: boolean };
 
 export const CREATE_TRANSLATION_TEST = gql`
-  mutation UpdateStory($userId: ID!, $level: Int!, $language: String!) {
+  mutation UpdateStory(
+    $userId: ID!
+    $level: Int!
+    $language: String!
+    $wantsReviewer: Boolean!
+  ) {
     createStoryTranslationTest(
       userId: $userId
       level: $level
       language: $language
+      wantsReviewer: $wantsReviewer
     ) {
       story {
         id

--- a/frontend/src/components/onboarding/AssignTestGradeModal.tsx
+++ b/frontend/src/components/onboarding/AssignTestGradeModal.tsx
@@ -32,6 +32,7 @@ import {
   ASSIGN_USER_LEVEL_BUTTON,
   VIEW_FAILED_GRADE_ALERT,
   GRADED_TEST_ASSIGN_LEVEL_TOOL_TIP_COPY,
+  USER_WANTS_REVIEWER,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
 import DropdownIndicator from "../utils/DropdownIndicator";
@@ -50,11 +51,13 @@ export type AssignTestGradeModalProps = {
   defaultTranslatorLevel?: number | null;
   defaultReviewerLevel?: number | null;
   defaultTestFeedback?: string;
+  wantsReviewer?: boolean;
 };
 
 export type TestResult = {
   translate: number | null;
   review?: number | null;
+  wants_reviewer: boolean | null;
 };
 
 const AssignTestGradeModal = ({
@@ -69,6 +72,7 @@ const AssignTestGradeModal = ({
   defaultTranslatorLevel = null,
   defaultReviewerLevel = null,
   defaultTestFeedback = "",
+  wantsReviewer = false,
 }: AssignTestGradeModalProps) => {
   const [assignReviewerLevel, setAssignReviewerLevel] =
     useState<boolean>(false);
@@ -87,6 +91,7 @@ const AssignTestGradeModal = ({
   const assignTestLevel = async () => {
     const testResult: TestResult = {
       translate: translatorLevel,
+      wants_reviewer: wantsReviewer,
     };
     if (assignReviewerLevel) testResult.review = reviewerLevel;
     const result = await finishGradingStoryTranslation({
@@ -228,7 +233,12 @@ const AssignTestGradeModal = ({
             </Heading>
           </ModalHeader>
           <ModalBody paddingBottom="36px">
-            <Heading as="h4" paddingBottom="24px" size="md">
+            {wantsReviewer && (
+              <Flex marginRight="28px" justifyContent="flex-end">
+                <InfoAlert message={USER_WANTS_REVIEWER} colour="orange.50" />
+              </Flex>
+            )}
+            <Heading as="h4" paddingBottom="24px" size="md" paddingTop="24px">
               Basic Test Information
             </Heading>
 

--- a/frontend/src/components/pages/StoryTestGradingPage.tsx
+++ b/frontend/src/components/pages/StoryTestGradingPage.tsx
@@ -55,6 +55,7 @@ const StoryTestGradingPage = () => {
   const [level, setLevel] = useState<number>(0);
   const [language, setLanguage] = useState<string>("");
   const [stage, setStage] = useState<string>("");
+  const [wantsReviewer, setWantsReviewer] = useState(false);
 
   const [failUser, setFailUser] = useState(false);
   const [assignGrade, setAssignGrade] = useState(false);
@@ -119,6 +120,9 @@ const StoryTestGradingPage = () => {
           );
           setDefaultReviewerLevel(
             JSON.parse(data.storyTranslationById.testResult).review,
+          );
+          setWantsReviewer(
+            JSON.parse(data.storyTranslationById.testResult).wants_reviewer,
           );
         }
         setDefaultTestFeedback(data.storyTranslationById.testFeedback);
@@ -255,6 +259,7 @@ const StoryTestGradingPage = () => {
           defaultTranslatorLevel={defaultTranslatorLevel}
           defaultReviewerLevel={defaultReviewerLevel}
           defaultTestFeedback={defaultTestFeedback}
+          wantsReviewer={wantsReviewer}
         />
       </Flex>
     </Flex>

--- a/frontend/src/components/pages/StoryTestGradingPage.tsx
+++ b/frontend/src/components/pages/StoryTestGradingPage.tsx
@@ -115,15 +115,21 @@ const StoryTestGradingPage = () => {
         setTitle(data.storyById.title);
         setNumApprovedLines(data.storyTranslationById.numApprovedLines);
         if (JSON.parse(data.storyTranslationById.testResult)) {
-          setDefaultTranslatorLevel(
-            JSON.parse(data.storyTranslationById.testResult).translate,
-          );
-          setDefaultReviewerLevel(
-            JSON.parse(data.storyTranslationById.testResult).review,
-          );
-          setWantsReviewer(
-            JSON.parse(data.storyTranslationById.testResult).wants_reviewer,
-          );
+          if (JSON.parse(data.storyTranslationById.testResult).translate) {
+            setDefaultTranslatorLevel(
+              JSON.parse(data.storyTranslationById.testResult).translate,
+            );
+          }
+          if (JSON.parse(data.storyTranslationById.testResult).review) {
+            setDefaultReviewerLevel(
+              JSON.parse(data.storyTranslationById.testResult).review,
+            );
+          }
+          if (JSON.parse(data.storyTranslationById.testResult).wants_reviewer) {
+            setWantsReviewer(
+              JSON.parse(data.storyTranslationById.testResult).wants_reviewer,
+            );
+          }
         }
         setDefaultTestFeedback(data.storyTranslationById.testFeedback);
 

--- a/frontend/src/components/userProfile/ApprovedLanguagesTable.tsx
+++ b/frontend/src/components/userProfile/ApprovedLanguagesTable.tsx
@@ -69,6 +69,7 @@ const ApprovedLanguagesTable = ({
   const [confirmDemoteLevel, setConfirmDemoteLevel] = useState(false);
   const [confirmLevelUp, setConfirmLevelUp] = useState(false);
   const [alertNewTest, setAlertNewTest] = useState(false);
+  const [wantsReviewer, setWantsReviewer] = useState(false);
   const [testLevel, setTestLevel] = useState(0);
   const [testLanguage, setTestLanguage] = useState("");
   const [languageToRemove, setLanguageToRemove] = useState("");
@@ -193,10 +194,15 @@ const ApprovedLanguagesTable = ({
     setRemoveLanguage(false);
   };
 
-  const openLevelUpModal = (level: number, language: string) => {
+  const openLevelUpModal = (
+    level: number,
+    language: string,
+    review_language: boolean,
+  ) => {
     setTestLevel(level);
     setTestLanguage(language);
     setConfirmLevelUp(true);
+    setWantsReviewer(review_language);
   };
 
   const closeLevelUpModal = () => {
@@ -217,13 +223,18 @@ const ApprovedLanguagesTable = ({
     closeAddNewLanguageModal(false);
   };
 
-  const onUserAddNewLanguage = async (newLanguage: string) => {
+  const onUserAddNewLanguage = async (
+    newLanguage: string,
+    requestReviewer: boolean,
+  ) => {
+    // eslint-disable-next-line
     try {
       await createTranslationTest({
         variables: {
           userId,
           level: 2,
           language: newLanguage,
+          wantsReviewer: requestReviewer,
         },
       });
       closeAddNewLanguageModal(false);
@@ -252,6 +263,7 @@ const ApprovedLanguagesTable = ({
           userId,
           level: testLevel,
           language: testLanguage,
+          wantsReviewer,
         },
       });
       closeLevelUpModal();

--- a/frontend/src/components/userProfile/ApprovedLanguagesTable.tsx
+++ b/frontend/src/components/userProfile/ApprovedLanguagesTable.tsx
@@ -227,7 +227,6 @@ const ApprovedLanguagesTable = ({
     newLanguage: string,
     requestReviewer: boolean,
   ) => {
-    // eslint-disable-next-line
     try {
       await createTranslationTest({
         variables: {

--- a/frontend/src/components/userProfile/ApprovedLanguagesTable.tsx
+++ b/frontend/src/components/userProfile/ApprovedLanguagesTable.tsx
@@ -197,12 +197,12 @@ const ApprovedLanguagesTable = ({
   const openLevelUpModal = (
     level: number,
     language: string,
-    review_language: boolean,
+    reviewLanguage: boolean,
   ) => {
     setTestLevel(level);
     setTestLanguage(language);
     setConfirmLevelUp(true);
-    setWantsReviewer(review_language);
+    setWantsReviewer(reviewLanguage);
   };
 
   const closeLevelUpModal = () => {

--- a/frontend/src/components/userProfile/ApprovedLanguagesTableComponent.tsx
+++ b/frontend/src/components/userProfile/ApprovedLanguagesTableComponent.tsx
@@ -37,7 +37,11 @@ type ApprovedLanguage = {
 
 export type ApprovedLanguagesTableComponentProps = {
   addNewLanguage: () => void;
-  levelUpOnClick: (level: number, language: string) => void;
+  levelUpOnClick: (
+    level: number,
+    language: string,
+    review_language: boolean,
+  ) => void;
   removeLanguageOnClick: (isTranslate: boolean, language: string) => void;
   onSliderValueChange: (
     isTranslate: boolean,
@@ -184,6 +188,7 @@ const ApprovedLanguagesTableComponent = ({
                   levelUpOnClick(
                     approvedLanguage.level + 1,
                     approvedLanguage.language,
+                    approvedLanguage.role === "Reviewer",
                   )
                 }
               >

--- a/frontend/src/components/userProfile/ApprovedLanguagesTableComponent.tsx
+++ b/frontend/src/components/userProfile/ApprovedLanguagesTableComponent.tsx
@@ -40,7 +40,7 @@ export type ApprovedLanguagesTableComponentProps = {
   levelUpOnClick: (
     level: number,
     language: string,
-    review_language: boolean,
+    reviewLanguage: boolean,
   ) => void;
   removeLanguageOnClick: (isTranslate: boolean, language: string) => void;
   onSliderValueChange: (

--- a/frontend/src/components/userProfile/UserNewLanguageModal.tsx
+++ b/frontend/src/components/userProfile/UserNewLanguageModal.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@apollo/client";
 import Select from "react-select";
 import {
   Button,
+  Checkbox,
   Flex,
   Heading,
   Modal,
@@ -20,7 +21,7 @@ import DropdownIndicator from "../utils/DropdownIndicator";
 import { getLanguagesQuery } from "../../APIClients/queries/LanguageQueries";
 
 export type UserNewLanguageModalProps = {
-  onSubmit: (newLanguage: string) => void;
+  onSubmit: (newLanguage: string, wantsReviewer: boolean) => void;
   approvedLanguagesTranslation: ApprovedLanguagesMap | undefined;
   isOpen: boolean;
   onClose: () => void;
@@ -34,6 +35,8 @@ const UserNewLanguageModal = ({
 }: UserNewLanguageModalProps) => {
   const [newLanguage, setNewLanguage] = useState<string>("");
   const [languageOptions, setLanguageOptions] = useState<string[]>([]);
+  const [wantsReviewer, setWantsReviewer] = useState<boolean>(false);
+
   useQuery(getLanguagesQuery.string, {
     fetchPolicy: "cache-and-network",
     onCompleted: (data) => {
@@ -75,7 +78,7 @@ const UserNewLanguageModal = ({
             Please select a new language that you would like to take the story
             translation test in.
           </Text>
-          <Flex marginBottom="200px">
+          <Flex marginBottom="20px">
             <Select
               components={{ DropdownIndicator }}
               getOptionLabel={(option: any) => option.value}
@@ -84,6 +87,16 @@ const UserNewLanguageModal = ({
               placeholder="Select language"
               styles={colourStyles}
             />
+          </Flex>
+          <Flex marginBottom="180px">
+            <Checkbox
+              isChecked={wantsReviewer}
+              size="md"
+              width="100%"
+              onChange={() => setWantsReviewer(!wantsReviewer)}
+            >
+              <Text>I want to become a reviewer in this language</Text>
+            </Checkbox>
           </Flex>
           <Tooltip
             hasArrow
@@ -95,7 +108,7 @@ const UserNewLanguageModal = ({
               <Button
                 colorScheme="blue"
                 disabled={newLanguage === ""}
-                onClick={() => onSubmit(newLanguage)}
+                onClick={() => onSubmit(newLanguage, wantsReviewer)}
               >
                 ADD TEST
               </Button>

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -142,3 +142,6 @@ export const ADD_LANGUAGE_SUCCESS_CONFIRMATION =
   "The new language was successfully added.";
 
 export const CONFIRM_OK = "Okay";
+
+export const USER_WANTS_REVIEWER =
+  "This user is requesting to be evaluated for the reviewer role";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket Name](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=2a59105407934e1aae7d18fdf93ac775)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Add option for user to check wants review when leveling up or adding a new language 
- Notify admin of user intention to be assigned language for review 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Level up a review language, this should create a new story test 
2. add new language, click the I want to be assigned as reviewer option 
3. Go to admin page, confirm that for both of these tests there is an alert indicating that the user would like to be assigned a language for review

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->


## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [ x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
