### PR TITLE
Make left column sticky on UserProfile

### DIFF
--- a/frontend/src/components/pages/CompleteProfilePage.tsx
+++ b/frontend/src/components/pages/CompleteProfilePage.tsx
@@ -63,7 +63,7 @@ const CompleteProfilePage = () => {
   return (
     <Flex direction="column" height="100vh">
       <Header />
-      <Flex direction="row" flex={1} margin="40px" marginLeft="90px">
+      <Flex direction="row" flex={1} margin="40px 90px">
         <UserProfileForm
           fullName={name}
           email={email}

--- a/frontend/src/components/pages/UserProfilePage.tsx
+++ b/frontend/src/components/pages/UserProfilePage.tsx
@@ -249,9 +249,18 @@ const UserProfilePage = () => {
 
   return (
     <Flex direction="column" height="100vh">
-      <Header />
-      <Flex direction="row" flex={1}>
-        <Flex sx={filterStyle} maxWidth="400px">
+      <Box backgroundColor="white" position="fixed" width="100%" zIndex="1000">
+        <Header />
+      </Box>
+      <Box paddingTop="64px">
+        <Flex
+          backgroundColor="white"
+          height="100%"
+          position="fixed"
+          sx={filterStyle}
+          width="400px"
+          zIndex="100"
+        >
           <Heading size="lg">{fullName}</Heading>
           <Heading size="sm" marginTop="36px">
             Role(s)
@@ -277,7 +286,7 @@ const UserProfilePage = () => {
             </>
           )}
         </Flex>
-        <Flex direction="column" margin="40px" flex={1}>
+        <Flex direction="column" margin="40px 40px 40px 440px">
           {/* TODO: use different state for email & fullname since currently the sidebar also gets modified */}
           {!isAdmin && (
             <Box>
@@ -405,7 +414,7 @@ const UserProfilePage = () => {
             </>
           )}
         </Flex>
-      </Flex>
+      </Box>
       {confirmDeleteUser && (
         <ConfirmationModal
           confirmation={confirmDeleteUser}

--- a/frontend/src/components/userProfile/UserProfileForm.tsx
+++ b/frontend/src/components/userProfile/UserProfileForm.tsx
@@ -203,7 +203,6 @@ const UserProfileForm = ({
           direction="column"
           height="250px"
           justify="center"
-          maxWidth="80%"
           onDragEnter={(e: any) => onDragEnter(e)}
           onDragLeave={(e: any) => onDragLeave(e)}
           onDragOver={(e: any) => onDragOver(e)}


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Make left column sticky on UserProfile](https://www.notion.so/uwblueprintexecs/Make-left-column-sticky-on-UserProfile-a6c39451a61f40d88798a2010ba91b67)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Changed styling to make navbar and sidebar stick

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl
2. Go to profile
3. Resize window and scroll around
4. Navbar and sidebar should stick
5. Login as Angela
6. Go to some profiles
7. Resize window and scroll around
8. Navbar and sidebar should stick

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it look ok?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
