### PR TITLE
Alert user when signing up with a password shorter than 6 characters

### DIFF
--- a/frontend/src/components/auth/LoginComponent.tsx
+++ b/frontend/src/components/auth/LoginComponent.tsx
@@ -89,6 +89,7 @@ const LoginComponent = ({
           colorScheme="blue"
           onClick={isSignup ? onSignUpClick : onLogInClick}
           textTransform="none"
+          isDisabled={isSignup && password.length < 6}
         >
           {isSignup ? "Register account" : "Sign in"}
         </Button>

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -13,6 +13,9 @@ import {
 } from "@chakra-ui/react";
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
 
+import InfoAlert from "../utils/InfoAlert";
+import { SIGN_UP_ALERT_PASSWORD_LESS_THAN_6_CHARACTERS } from "../../utils/Copy";
+
 type LoginFormProps = {
   isSignup: boolean;
   invalidLogin: boolean;
@@ -100,7 +103,7 @@ const LoginForm = ({
         <FormLabel htmlFor="password" color={invalidLogin ? "red" : "black"}>
           {isSignup ? "Create Password" : "Password"}
         </FormLabel>
-        <InputGroup size="md">
+        <InputGroup size="md" paddingBottom="5px">
           <Input
             id="password"
             type={showPassword ? "text" : "password"}
@@ -119,6 +122,15 @@ const LoginForm = ({
             />
           </InputRightElement>
         </InputGroup>
+        {password.length > 0 && password.length < 6 ? (
+          <InfoAlert
+            message={SIGN_UP_ALERT_PASSWORD_LESS_THAN_6_CHARACTERS}
+            colour="orange.50"
+            height="20px"
+          />
+        ) : (
+          <Flex height="24px" />
+        )}
         {invalidLogin && (
           <FormHelperText id="password-helper-text" color="red">
             Invalid login, please try again.

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -14,7 +14,7 @@ import {
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa";
 
 import InfoAlert from "../utils/InfoAlert";
-import { SIGN_UP_ALERT_PASSWORD_LESS_THAN_6_CHARACTERS } from "../../utils/Copy";
+import { SIGN_UP_PASSWORD_LESS_THAN_6_CHAR_ALERT } from "../../utils/Copy";
 
 type LoginFormProps = {
   isSignup: boolean;
@@ -124,7 +124,7 @@ const LoginForm = ({
         </InputGroup>
         {password.length > 0 && password.length < 6 ? (
           <InfoAlert
-            message={SIGN_UP_ALERT_PASSWORD_LESS_THAN_6_CHARACTERS}
+            message={SIGN_UP_PASSWORD_LESS_THAN_6_CHAR_ALERT}
             colour="orange.50"
             height="20px"
           />

--- a/frontend/src/components/utils/InfoAlert.tsx
+++ b/frontend/src/components/utils/InfoAlert.tsx
@@ -5,9 +5,14 @@ import { MdInfoOutline } from "react-icons/md";
 export type AlertProps = {
   message: string;
   colour?: string;
+  height?: string;
 };
 
-const InfoAlert = ({ message, colour = "gray.200" }: AlertProps) => {
+const InfoAlert = ({
+  message,
+  colour = "gray.200",
+  height = "50px",
+}: AlertProps) => {
   return (
     <Alert
       status="info"
@@ -16,7 +21,7 @@ const InfoAlert = ({ message, colour = "gray.200" }: AlertProps) => {
       justifyContent="center"
       textColor="black"
       opacity="60%"
-      height="50px"
+      height={height}
     >
       <AlertIcon as={MdInfoOutline} color="black" />
       {message}

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -146,5 +146,5 @@ export const CONFIRM_OK = "Okay";
 export const USER_WANTS_REVIEWER =
   "This user is requesting to be evaluated for the reviewer role";
 
-export const SIGN_UP_ALERT_PASSWORD_LESS_THAN_6_CHARACTERS =
-  "For security, please consider a longer password.";
+export const SIGN_UP_PASSWORD_LESS_THAN_6_CHAR_ALERT =
+  "Please enter a password at least 6 characters long.";

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -145,3 +145,6 @@ export const CONFIRM_OK = "Okay";
 
 export const USER_WANTS_REVIEWER =
   "This user is requesting to be evaluated for the reviewer role";
+
+export const SIGN_UP_ALERT_PASSWORD_LESS_THAN_6_CHARACTERS =
+  "For security, please consider a longer password.";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Alert user when signing up with a password shorter than 6 characters](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=c44b6c02042243bc92705ce42c54cf89)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- On signup page, alert user when their password is less than 6 characters

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to sign up page, type in password shorter than 6 characters 
2. Confirm that the alert pops up
3. Type a password longer than 6 characters. Confirm that the alert disappears

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->


## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
