### PR TITLE
Replace most console.logs with window.alerts

### DIFF
--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -38,8 +38,6 @@ export const GET_STORIES = (
   queryParams +=
     startDate != null ? `startDate: "${startDate.toISOString()}", ` : "";
   queryParams += endDate != null ? `endDate: "${endDate.toISOString()}", ` : "";
-  // eslint-disable-next-line no-console
-  console.log(queryParams);
 
   return gql`
       query GetStories {

--- a/frontend/src/components/auth/ResetPassword.tsx
+++ b/frontend/src/components/auth/ResetPassword.tsx
@@ -49,8 +49,6 @@ const ResetPassword = ({ email }: ResetPasswordProps) => {
       if (typeof err === "string") {
         handleErrorOnReset(err);
       } else {
-        // eslint-disable-next-line no-console
-        console.log(err);
         handleErrorOnReset("Error occurred, please try again.");
       }
     }

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -75,8 +75,6 @@ const StoryCard = ({
       if (typeof err === "string") {
         handleError(err);
       } else {
-        // eslint-disable-next-line no-console
-        console.log(err);
         handleError("Error occurred, please try again.");
       }
     }
@@ -106,8 +104,6 @@ const StoryCard = ({
       if (typeof err === "string") {
         handleError(err);
       } else {
-        // eslint-disable-next-line no-console
-        console.log(err);
         handleError("Error occurred, please try again.");
       }
     }

--- a/frontend/src/components/pages/ImportStoryPage.tsx
+++ b/frontend/src/components/pages/ImportStoryPage.tsx
@@ -103,8 +103,8 @@ const ImportStoryPage = () => {
       ) {
         setStoryFile(newStoryFile);
       } else {
-        // eslint-disable-next-line no-console
-        console.log("Incorrect file type");
+        // eslint-disable-next-line no-alert
+        window.alert("Incorrect file type");
       }
     } else if (e.dataTransfer.files && e.dataTransfer.files.length === 1) {
       const newStoryFile = e.dataTransfer.files[0];

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -63,8 +63,6 @@ const WIPComment = ({
       if (typeof err === "string") {
         handleError(err);
       } else {
-        // eslint-disable-next-line no-console
-        console.log(err);
         handleError("Error occurred, please try again.");
       }
     }

--- a/frontend/src/components/translation/Autosave.tsx
+++ b/frontend/src/components/translation/Autosave.tsx
@@ -55,8 +55,6 @@ const Autosave = ({ storylines, onSuccess }: AutosaveProps) => {
         if (typeof err === "string") {
           handleError(err);
         } else {
-          // eslint-disable-next-line no-console
-          console.log(err);
           handleError("Error occurred, please try again.");
         }
       }


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket](https://www.notion.so/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=17ad2628b86d4452b659530ac032cb66)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

-  Remove` console.log()` where appropriate 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. If possible, try to recreate the errors and see if the window pops up

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->


## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
