### PR TITLE
Validate language params on backend

### DIFF
--- a/backend/python/app/services/implementations/user_service.py
+++ b/backend/python/app/services/implementations/user_service.py
@@ -187,6 +187,15 @@ class UserService(IUserService):
                     firebase_user = firebase_admin.auth.create_user(uid=user.auth_id)
                 auth_id = user.auth_id
 
+            existing_languages = language_service.get_languages()
+
+            for lang in {
+                **(user.approved_languages_translation or {}),
+                **(user.approved_languages_review or {}),
+            }:
+                if lang not in existing_languages:
+                    raise Exception("{lang} is not a valid language".format(lang=lang))
+
             mysql_user = {
                 "first_name": user.first_name,
                 "last_name": user.last_name,
@@ -312,6 +321,14 @@ class UserService(IUserService):
 
             if not old_user:
                 raise Exception("user_id {user_id} not found".format(user_id=user_id))
+
+            existing_languages = language_service.get_languages()
+            for lang in {
+                **(user.approved_languages_translation or {}),
+                **(user.approved_languages_review or {}),
+            }:
+                if lang not in existing_languages:
+                    raise Exception("{lang} is not a valid language".format(lang=lang))
 
             User.query.filter_by(id=user_id).update(
                 {

--- a/backend/python/app/tests/helpers/story_translation_helpers.py
+++ b/backend/python/app/tests/helpers/story_translation_helpers.py
@@ -107,8 +107,8 @@ def create_translator(db):
             email="carl.sagan@uwblueprint.org",
             auth_id="secret",
             role="User",
-            approved_languages_translation={"ENGLISH_US": 4, "ENGLISH_UK": 4},
-            approved_languages_review={"ENGLISH_US": 4, "ENGLISH_UK": 4},
+            approved_languages_translation={"English (US)": 4, "English (UK)": 4},
+            approved_languages_review={"English (US)": 4, "English (UK)": 4},
         ),
     )
 
@@ -122,8 +122,8 @@ def create_reviewer(db):
             email="dwight.d.eisenhower@uwblueprint.org",
             auth_id="anothersecret",
             role="User",
-            approved_languages_translation={"ENGLISH_US": 4, "ENGLISH_UK": 4},
-            approved_languages_review={"ENGLISH_US": 4, "ENGLISH_UK": 4},
+            approved_languages_translation={"English (US)": 4, "English (UK)": 4},
+            approved_languages_review={"English (US)": 4, "English (UK)": 4},
         ),
     )
 
@@ -137,8 +137,8 @@ def create_admin(db):
             email="planetread+angelamerkel@uwblueprint.org",
             auth_id="thirdsecret",
             role="Admin",
-            approved_languages_translation={"GERMAN": 4},
-            approved_languages_review={"GERMAN": 4},
+            approved_languages_translation={"German": 4},
+            approved_languages_review={"German": 4},
         ),
     )
 
@@ -148,7 +148,7 @@ def _create_story_translation(db, story, translator, reviewer):
         db,
         StoryTranslationAll(
             story_id=story.id,
-            language="ENGLISH_US",
+            language="English (US)",
             stage="TRANSLATE",
             translator_id=translator.id,
             reviewer_id=reviewer.id,

--- a/backend/python/app/tests/services/test_story_service.py
+++ b/backend/python/app/tests/services/test_story_service.py
@@ -82,7 +82,7 @@ def test_create_story(app, db, services):
 
 def test_get_stories_available_for_translation(app, db, services):
     translator_obj = create_translator(db)
-    translation_language = "ENGLISH_US"
+    translation_language = "English (US)"
     translation_level = 3
 
     # create stories
@@ -160,7 +160,7 @@ def test_create_translation(app, db, services):
 
     story_translation = StoryTranslationRequestDTO(
         story_id=story_obj.id,
-        language="English",
+        language="English (UK)",
         stage="TRANSLATE",
         translator_id=translator_obj.id,
         reviewer_id=reviewer_obj.id,
@@ -197,7 +197,7 @@ def test_create_translation_test(app, db, services):
     db.session.commit()
 
     story_translation_resp = services["story"].create_translation_test(
-        translator_obj.id, 2, "ENGLISH", False
+        translator_obj.id, 2, "English (UK)", False
     )
     story_translation_obj = StoryTranslation.query.get(story_translation_resp.id)
     assert story_translation_resp == story_translation_obj
@@ -272,10 +272,10 @@ def test_get_story_translation_tests(app, db, services):
 
     # Create story translation tests
     first_story_translation_resp = services["story"].create_translation_test(
-        first_translator_obj.id, 2, "ENGLISH", False
+        first_translator_obj.id, 2, "English (UK)", False
     )
     second_story_translation_resp = services["story"].create_translation_test(
-        second_translator_obj.id, 2, "ENGLISH", False
+        second_translator_obj.id, 2, "English (UK)", False
     )
 
     # Test for admin
@@ -316,7 +316,7 @@ def test_assign_user_as_reviewer(app, db, services):
         db,
         StoryTranslationAll(
             story_id=story_obj.id,
-            language="ENGLISH_US",
+            language="English (US)",
             stage="TRANSLATE",
             translator_id=translator_obj.id,
             reviewer_id=None,
@@ -345,8 +345,8 @@ def test_assign_user_as_reviewer_not_approved_for_language(app, db, services):
             email="dwight.d.eisenhower@uwblueprint.org",
             auth_id="anothersecret",
             role="User",
-            approved_languages_translation={"ENGLISH_US": 2},
-            approved_languages_review={"ENGLISH_US": 2},
+            approved_languages_translation={"English (US)": 2},
+            approved_languages_review={"English (US)": 2},
         ),
     )
     story_obj = db_session_add_commit_obj(
@@ -362,7 +362,7 @@ def test_assign_user_as_reviewer_not_approved_for_language(app, db, services):
         db,
         StoryTranslationAll(
             story_id=story_obj.id,
-            language="ENGLISH_US",
+            language="English (US)",
             stage="TRANSLATE",
             translator_id=translator_obj.id,
             reviewer_id=None,
@@ -391,8 +391,8 @@ def test_assign_user_as_reviewer_insufficient_level_for_language(app, db, servic
             email="dwight.d.eisenhower@uwblueprint.org",
             auth_id="anothersecret",
             role="User",
-            approved_languages_translation={"ENGLISH_US": 2},
-            approved_languages_review={"ENGLISH_US": 2},
+            approved_languages_translation={"English (US)": 2},
+            approved_languages_review={"English (US)": 2},
         ),
     )
     story_obj = db_session_add_commit_obj(
@@ -408,7 +408,7 @@ def test_assign_user_as_reviewer_insufficient_level_for_language(app, db, servic
         db,
         StoryTranslationAll(
             story_id=story_obj.id,
-            language="ENGLISH_US",
+            language="English (US)",
             stage="TRANSLATE",
             translator_id=translator_obj.id,
             reviewer_id=None,
@@ -419,7 +419,7 @@ def test_assign_user_as_reviewer_insufficient_level_for_language(app, db, servic
         story_translation_obj.id
     )
 
-    assert reviewer_obj.approved_languages_review["ENGLISH_US"] < story_obj.level
+    assert reviewer_obj.approved_languages_review["English (US)"] < story_obj.level
     with pytest.raises(Exception) as e:
         services["story"].assign_user_as_reviewer(
             user=reviewer_obj, story_translation=story_translation
@@ -439,8 +439,8 @@ def test_assign_user_as_reviewer_reviewer_id_already_exists_on_translation(
             email="test@gmail.com",
             auth_id="anothersecret2",
             role="User",
-            approved_languages_translation={"ENGLISH_US": 2},
-            approved_languages_review={"ENGLISH_US": 2},
+            approved_languages_translation={"English (US)": 2},
+            approved_languages_review={"English (US)": 2},
         ),
     )
     create_story_translation_contents(db, story_translation_obj)
@@ -546,7 +546,7 @@ def test_get_story_translations_available_for_review(app, db, services):
     translator_obj = create_translator(db)
     reviewer_obj = create_reviewer(db)
 
-    translation_language = "ENGLISH_US"
+    translation_language = "English (US)"
     translation_level = 3
 
     # create stories
@@ -621,7 +621,7 @@ def test_get_story_translations_available_for_review_user_already_reviewing(
         db,
         StoryTranslationAll(
             story_id=story_2.id,
-            language="ENGLISH_US",
+            language="English (US)",
             stage="TRANSLATE",
             translator_id=translator.id,
             reviewer_id=None,
@@ -634,7 +634,7 @@ def test_get_story_translations_available_for_review_user_already_reviewing(
     assert story_translation_2.reviewer_id == None
 
     resp = services["story"].get_story_translations_available_for_review(
-        "ENGLISH_US", 4, reviewer.id
+        "English (US)", 4, reviewer.id
     )
     assert len(resp) == 0
 
@@ -651,16 +651,16 @@ def test_get_story_translations_available_for_review_translation_has_reviewer(
             email="test@gmail.com",
             auth_id="anothersecret2",
             role="User",
-            approved_languages_translation={"ENGLISH_US": 4},
-            approved_languages_review={"ENGLISH_US": 4},
+            approved_languages_translation={"English (US)": 4},
+            approved_languages_review={"English (US)": 4},
         ),
     )
 
     assert story_translation.reviewer_id != None
-    assert story_translation.language == "ENGLISH_US"
+    assert story_translation.language == "English (US)"
     assert story.level == 4
     resp = services["story"].get_story_translations_available_for_review(
-        "ENGLISH_US", 4, reviewer_2.id
+        "English (US)", 4, reviewer_2.id
     )
     assert len(resp) == 0
 


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Validate language params on backend](https://www.notion.so/uwblueprintexecs/Validate-language-params-on-backend-95459bb79283439f9f1d20e85947ab15)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Validate any mutations where languages are added or updated (stories, users) 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test


Updated mutations:
- create_translation
- create_translation_test
- create_user
- update_user_by_id

1. Test each mutation with a fake language, and then with a real one - check that it fails and then succeeds


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Are there any other mutations that need validations?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
