### PR TITLE
Fix reset password refresh in BaseGQLClient

### DIFF
--- a/frontend/src/APIClients/BaseGQLClient.ts
+++ b/frontend/src/APIClients/BaseGQLClient.ts
@@ -71,7 +71,7 @@ const accessTokenInjectionLink = new ApolloLink(
 
 const refreshDirectionalLink = new RetryLink().split(
   (operation) =>
-    ["Refresh", "Login", "SignUp", "LoginWithGoogle"].includes(
+    ["Refresh", "ResetPassword", "Login", "SignUp", "LoginWithGoogle"].includes(
       operation.operationName,
     ),
   authFromLocalLink.concat(httpLink),


### PR DESCRIPTION
## Notion ticket link

https://www.notion.so/uwblueprintexecs/Make-forget-password-work-716319eac5ca4a9a8a0b0a91b5087449

## Implementation description

- currently on main branch, the reset password feature just refreshes the page. this is due to the basegqlclient throwing out the  request, like in #331 
- this is the last of all the auth mutations to not be considered in the basegqlclient

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. go to signup
2. input an email 
3. hit the forget password link
4. observe alert
5. check email, observe the reset password email from firebase

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- happiness
- staying hydrated
- does it work

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
