### PR TITLE
Allow admin to approve translator language when user approved for reviewer

### DIFF
--- a/frontend/src/components/userProfile/AdminNewLanguageModal.tsx
+++ b/frontend/src/components/userProfile/AdminNewLanguageModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useQuery } from "@apollo/client";
 import Select from "react-select";
 import {
@@ -49,8 +49,10 @@ const AdminNewLanguageModal = ({
   const [role, setRole] = useState<string | null>(null);
   const [language, setLanguage] = useState<string | null>(null);
   const [level, setLevel] = useState<number | null>(null);
-  const [languageOptions, setLanguageOptions] = useState<string[]>([]);
-
+  const [languageOptions, setLanguageOptions] = useState<{ value: string }[]>(
+    [],
+  );
+  const [allLanguageOptions, setAllLanguageOptions] = useState<string[]>([]);
   const currentApprovedLanguages = new Set(
     Object.keys(
       role === "Translator"
@@ -62,17 +64,19 @@ const AdminNewLanguageModal = ({
   useQuery(getLanguagesQuery.string, {
     fetchPolicy: "cache-and-network",
     onCompleted: (data) => {
-      setLanguageOptions(
-        data.languages.filter(
-          (lang: string) => !currentApprovedLanguages.has(lang),
-        ),
-      );
+      setAllLanguageOptions(data.languages);
     },
   });
 
-  const newLanguageOptions = languageOptions.map((lang) => {
-    return { value: lang };
-  });
+  useEffect(() => {
+    setLanguageOptions(
+      allLanguageOptions
+        .filter((lang) => !currentApprovedLanguages.has(lang))
+        .map((lang) => {
+          return { value: lang };
+        }),
+    );
+  }, [role]);
 
   const disabledStyle = useStyleConfig("Disabled");
   const isLanguageSelectDisabled = role == null;
@@ -136,7 +140,7 @@ const AdminNewLanguageModal = ({
               >
                 <Select
                   placeholder="Select language"
-                  options={newLanguageOptions}
+                  options={languageOptions}
                   onChange={(option: any) => setLanguage(option.value)}
                   getOptionLabel={(option: any) => option.value}
                   value={language ? { value: language } : null}


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Allow admin to approve translator language when user approved for reviewer](https://www.notion.so/uwblueprintexecs/Allow-admin-to-approve-translator-language-when-user-approved-for-reviewer-314504622d2e4a1bbb7231126c6b6a9d)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- added a hook to update language options when role is changed

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as angela
2. Go to a reviewer
3. Add a new language that the user is not approved for, add as reviewer
4. Check that you can add the same language for translation, and check that other languages that they are already approved for do NOT show up
5. Try the other way around 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
