### PR TITLE
Add loading indicator to login/signup page

### DIFF
--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -19,6 +19,7 @@ const Login = () => {
   const [isSignup, setIsSignup] = useState(false);
   const [agreeToTerms, setAgreeToTerms] = useState(false);
   const [invalidLogin, setInvalidLogin] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const [signup] = useMutation<{ signup: AuthenticatedUser }>(SIGNUP);
   const [login] = useMutation<{ login: AuthenticatedUser }>(LOGIN);
@@ -31,6 +32,7 @@ const Login = () => {
       setIsSignup(false);
     } else {
       try {
+        setIsLoading(true);
         const user: AuthenticatedUser = await authAPIClient.login(
           email,
           password,
@@ -41,6 +43,7 @@ const Login = () => {
         setInvalidLogin(true);
       }
     }
+    setIsLoading(false);
   };
 
   const onGoogleLoginSuccess = async (tokenId: string) => {
@@ -61,6 +64,7 @@ const Login = () => {
     setInvalidLogin(false);
     if (isSignup) {
       if (validateEmail(email)) {
+        setIsLoading(true);
         const user: AuthenticatedUser = await authAPIClient.signup(
           firstName,
           lastName,
@@ -76,6 +80,7 @@ const Login = () => {
     } else {
       setIsSignup(true);
     }
+    setIsLoading(false);
   };
 
   const onAgreeToTermsClick = async () => {
@@ -107,6 +112,7 @@ const Login = () => {
 
   return (
     <LoginComponent
+      isLoading={isLoading}
       isSignup={isSignup}
       invalidLogin={invalidLogin}
       firstName={firstName}

--- a/frontend/src/components/auth/LoginComponent.tsx
+++ b/frontend/src/components/auth/LoginComponent.tsx
@@ -18,6 +18,7 @@ type GoogleErrorResponse = {
 };
 
 type LoginComponentProps = {
+  isLoading: boolean;
   isSignup: boolean;
   invalidLogin: boolean;
   firstName: string;
@@ -37,6 +38,7 @@ type LoginComponentProps = {
 };
 
 const LoginComponent = ({
+  isLoading,
   isSignup,
   invalidLogin,
   firstName,
@@ -84,11 +86,7 @@ const LoginComponent = ({
           onAgreeToTermsClick={onAgreeToTermsClick}
         />
         <Button
-          marginTop={isSignup ? "20px" : "40px"}
-          width="100%"
           colorScheme="blue"
-          onClick={isSignup ? onSignUpClick : onLogInClick}
-          textTransform="none"
           isDisabled={
             isSignup &&
             (firstName === "" ||
@@ -97,6 +95,12 @@ const LoginComponent = ({
               password === "" ||
               !agreeToTerms)
           }
+          isLoading={isLoading}
+          loadingText={isSignup ? "Registering account" : "Signing in"}
+          marginTop={isSignup ? "20px" : "40px"}
+          onClick={isSignup ? onSignUpClick : onLogInClick}
+          textTransform="none"
+          width="100%"
         >
           {isSignup ? "Register account" : "Sign in"}
         </Button>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add loading indicator to login/signup page](https://www.notion.so/uwblueprintexecs/Add-loading-indicator-to-login-signup-page-8dddffb6a5e24badae26961ae1fff1ca)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Set `isLoading` to true on sign in/register account button when request is made
- Reset `isLoading` to false after request is finished

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl
2. Observe loading button and redirect as usual
3. Login as non-existent user
4. Observe loading button that switches back to normal button after error returns
5. Sign up with valid password
6. Observe loading button and redirect as usual
7. Sign up with invalid password (e.g. "a")
8. Observe loading button that switches back to normal button after error returns

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does is work?
- Does it look ok?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
