### PR TITLE
Hide comment panel if admin viewing story translation

### DIFF
--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -244,15 +244,18 @@ const ReviewPage = () => {
             </Tooltip>
           </Flex>
         </Flex>
-        <CommentsPanel
-          storyTranslationContentId={storyTranslationContentId}
-          commentLine={commentLine}
-          storyTranslationId={storyTranslationId}
-          translatorId={translatorId}
-          translatorName={translatorName}
-          reviewerName={reviewerName}
-          setCommentLine={setCommentLine}
-        />
+        {(+authenticatedUser!.id === translatorId ||
+          +authenticatedUser!.id === reviewerId) && (
+          <CommentsPanel
+            storyTranslationContentId={storyTranslationContentId}
+            commentLine={commentLine}
+            storyTranslationId={storyTranslationId}
+            translatorId={translatorId}
+            translatorName={translatorName}
+            reviewerName={reviewerName}
+            setCommentLine={setCommentLine}
+          />
+        )}
         {returnToTranslator && (
           <ConfirmationModal
             confirmation={returnToTranslator}


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Hide comment panel if admin viewing story translation](https://www.notion.so/uwblueprintexecs/Hide-comment-panel-if-admin-viewing-story-translation-7e6ea619ce584f9a9419ef2b90cfa8ec)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added requirement that user is translator or reviewer to view comments

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Angela
2. View some translations where Angela is not a translator or reviewer
3. Observe no comments panel
4. View some translations where Angela is a translator (e.g. East of Eden German Level 4)
5. Observe comments panel
6. View some translations where Angela is a reviewer (use mysql `update story_translations set reviewer_id=6 where id=3` and look at War and Peace German Level 1)
7. Observe comments panel

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
