### PR TITLE
Display story level in StoriesTable

### DIFF
--- a/frontend/src/components/admin/StoriesTable.tsx
+++ b/frontend/src/components/admin/StoriesTable.tsx
@@ -2,6 +2,7 @@ import React, { Dispatch, SetStateAction, useState } from "react";
 import { Icon } from "@chakra-ui/icon";
 import { MdDelete } from "react-icons/md";
 import {
+  Badge,
   Link,
   Table,
   Thead,
@@ -18,6 +19,7 @@ import {
   MANAGE_STORY_TABLE_DELETE_STORY_CONFIRMATION,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
+import { getLevelVariant } from "../../utils/StatusUtils";
 import { generateSortFn } from "../../utils/Utils";
 import { Story } from "../../APIClients/queries/StoryQueries";
 import {
@@ -128,6 +130,15 @@ const StoriesTable = ({
       </Td>
       <Td>{new Date(story.dateUploaded).toLocaleDateString()}</Td>
       <Td>
+        <Badge
+          background={getLevelVariant(story.level)}
+          marginBottom="3px"
+          marginTop="3px"
+        >
+          {`Level ${story.level}`}
+        </Badge>
+      </Td>
+      <Td>
         <IconButton
           aria-label={`Delete story ${story.title}`}
           background="transparent"
@@ -160,6 +171,7 @@ const StoriesTable = ({
           <Th cursor="pointer" onClick={() => sort("date")}>{`DATE UPLOADED ${
             isAscendingDate ? "↑" : "↓"
           }`}</Th>
+          <Th>LEVEL</Th>
           <Th width="18%">ACTION</Th>
         </Tr>
       </Thead>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Display story level in StoriesTable](https://www.notion.so/uwblueprintexecs/Display-story-level-in-StoriesTable-2ff36984c5b34ffd8d325fab6c699848)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- add level badge to manage stories table

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin
2. Navigate to manage stories tab and verify level shows up

![image](https://user-images.githubusercontent.com/32009013/150551313-62c66ee1-12a4-42ea-a3e8-eadaee3f549b.png)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- did we want the level badges to show up?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
