### PR TITLE
Prevent stage change until content changes are saved

### DIFF
--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -19,6 +19,7 @@ import deepCopy from "../../utils/DeepCopyUtils";
 import Header from "../navigation/Header";
 import CommentsPanel from "../review/CommentsPanel";
 import {
+  CHANGES_NOT_YET_SAVED_ALERT,
   TRANSLATION_PAGE_TOOL_TIP_COPY,
   TRANSLATION_PAGE_BUTTON_MESSAGE,
   TRANSLATION_PAGE_SEND_FOR_REVIEW_CONFIRMATION,
@@ -63,6 +64,7 @@ const TranslationPage = () => {
     Map<number, StoryLine>
   >(new Map());
   const [numTranslatedLines, setNumTranslatedLines] = useState(0);
+  const [changesSaved, setChangesSaved] = useState<Boolean>(true);
   // UndoRedo
   const [versionHistoryStack, setVersionHistoryStack] = useState<
     Array<StoryLine[]>
@@ -90,6 +92,8 @@ const TranslationPage = () => {
     newContent: string,
     lineIndex: number,
   ) => {
+    setChangesSaved(false);
+
     const updatedContentArray = [...translatedStoryLines];
     snapSnapShotLineIndexes((val: Set<number>) => new Set(val.add(lineIndex)));
     if (
@@ -291,15 +295,19 @@ const TranslationPage = () => {
             />
             <Tooltip
               hasArrow
-              label={TRANSLATION_PAGE_TOOL_TIP_COPY}
-              isDisabled={editable}
+              label={
+                !changesSaved
+                  ? CHANGES_NOT_YET_SAVED_ALERT
+                  : TRANSLATION_PAGE_TOOL_TIP_COPY
+              }
+              disabled={editable && changesSaved}
             >
               <Box>
                 <Button
                   colorScheme="blue"
                   size="secondary"
                   margin="0 10px 0"
-                  disabled={!editable}
+                  disabled={!editable || !changesSaved}
                   onClick={onSendForReviewClick}
                 >
                   {editable ? "SEND FOR REVIEW" : "IN REVIEW"}
@@ -323,6 +331,7 @@ const TranslationPage = () => {
       <Autosave
         storylines={Array.from(changedStoryLines.values())}
         onSuccess={clearUnsavedChangesMap}
+        setChangesSaved={setChangesSaved}
       />
       {sendForReview && (
         <ConfirmationModal

--- a/frontend/src/components/translation/Autosave.tsx
+++ b/frontend/src/components/translation/Autosave.tsx
@@ -15,10 +15,15 @@ export type StoryLine = {
 type AutosaveProps = {
   storylines: StoryLine[];
   onSuccess: () => void;
+  setChangesSaved: (saved: boolean) => void;
 };
 
 // Inspiration from https://www.synthace.com/autosave-with-react-hooks/
-const Autosave = ({ storylines, onSuccess }: AutosaveProps) => {
+const Autosave = ({
+  storylines,
+  onSuccess,
+  setChangesSaved,
+}: AutosaveProps) => {
   const handleError = (errorMessage: string) => {
     // eslint-disable-next-line no-alert
     alert(errorMessage);
@@ -33,7 +38,6 @@ const Autosave = ({ storylines, onSuccess }: AutosaveProps) => {
       if (linesToUpdate.length === 0) {
         return;
       }
-
       const storyTranslationContents = linesToUpdate.map((line: StoryLine) => {
         return {
           id: line.storyTranslationContentId,
@@ -50,6 +54,7 @@ const Autosave = ({ storylines, onSuccess }: AutosaveProps) => {
           handleError("Unable to save translation");
         } else {
           onSuccess();
+          setChangesSaved(true);
         }
       } catch (err) {
         if (typeof err === "string") {
@@ -57,6 +62,7 @@ const Autosave = ({ storylines, onSuccess }: AutosaveProps) => {
         } else {
           handleError("Error occurred, please try again.");
         }
+        setChangesSaved(true);
       }
     }, 1000),
     [],

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -148,3 +148,6 @@ export const USER_WANTS_REVIEWER =
 
 export const SIGN_UP_INVALID_PASSWORD_ALERT =
   "Password must be at least 8 characters long and contain one letter and one number.";
+
+export const CHANGES_NOT_YET_SAVED_ALERT =
+  "Your changes have not yet been saved. Please wait before submitting...";


### PR DESCRIPTION

## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Prevent stage change until content changes are saved](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Add new state variable `changesSaved` to TranslationPage
- Button to submit story translation is disabled if this state is `false`
- State gets changed back to `true` once AutoSave calls `onSuccess()`
- Add tooltip message to warn user that their progress has not been saved 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to a storu translation
2. Change the story translation content
3. Observe that the button is disabled until the progress bar says 'Progress Saved'
4. Also see if the tooltip message appears when hovering over the button

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- why is the world unjust

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
