### PR TITLE
Notify user if entered language is not titlecase

### DIFF
--- a/frontend/src/components/admin/AddLanguageModal.tsx
+++ b/frontend/src/components/admin/AddLanguageModal.tsx
@@ -114,6 +114,18 @@ const AddLanguageModal = ({ isOpen, onClose }: AddLanguageModalProps) => {
       .map((lang) => lang.toLowerCase())
       .indexOf(language.toLowerCase()) !== -1;
 
+  const languageNotTitlecase = language.match(/\b[a-z]/) !== null;
+
+  const getFocuBorderColor = () => {
+    if (languageAlreadyExists) {
+      return "red.100";
+    }
+    if (languageNotTitlecase) {
+      return "orange.100";
+    }
+    return "";
+  };
+
   return (
     <>
       <Modal
@@ -144,6 +156,11 @@ const AddLanguageModal = ({ isOpen, onClose }: AddLanguageModalProps) => {
                 <Text marginBottom="3px">
                   Please enter the name of the new language.
                 </Text>
+                {languageNotTitlecase && (
+                  <Text marginBottom="3px" color="orange.100">
+                    Note: Did you mean to make this language title-case?
+                  </Text>
+                )}
                 {languageAlreadyExists && (
                   <Text marginBottom="3px" color="red.100">
                     This language already exists.
@@ -153,7 +170,7 @@ const AddLanguageModal = ({ isOpen, onClose }: AddLanguageModalProps) => {
                   id="new-language"
                   isInvalid={languageAlreadyExists}
                   errorBorderColor="red.100"
-                  focusBorderColor={languageAlreadyExists ? "red.100" : ""}
+                  focusBorderColor={getFocuBorderColor()}
                   type="text"
                   value={language}
                   onChange={(event) => setLanguage(event.target.value)}


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Notify admin that new language does not appear to be titlecase](https://www.notion.so/uwblueprintexecs/Notify-admin-that-new-language-does-not-appear-to-be-titlecase-fead049902df41518df8fdd8c82891f4)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Display warning if language entered is not title case
- Currently messages stack for not titlecase and language already exists

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Enter a language in the addlanguagemodal that isn't titlecase
2. Verify alert message is shown

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Whether regex is desired for determining titlecase
- Whether alerts should stack or language already exists message should be prioritized

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
