### PR TITLE
Update the no stories copy on Homepage

### DIFF
--- a/frontend/src/components/homepage/StoryList.tsx
+++ b/frontend/src/components/homepage/StoryList.tsx
@@ -23,7 +23,7 @@ const LoadingCard = () => {
   );
 };
 
-const NoStoriesFoundCard = () => {
+const NoStoriesFoundCardCheckAccess = () => {
   return (
     <Flex
       alignItems="center"
@@ -34,6 +34,25 @@ const NoStoriesFoundCard = () => {
     >
       <Text>No Stories Found</Text>
       <Text>Please check access permissions.</Text>
+    </Flex>
+  );
+};
+
+const NoStoriesFoundCard = () => {
+  return (
+    <Flex
+      alignItems="center"
+      border="2px solid black"
+      flexDirection="column"
+      margin="10px 0px 10px 0px"
+      padding="20px"
+    >
+      <Text>No Stories Found</Text>
+      <Text>
+        You may be seeing no stories if you are a translator or reviewer on an
+        active story translation for this language. <br />
+        Please complete that story translation before signing up for more.
+      </Text>
     </Flex>
   );
 };
@@ -52,8 +71,12 @@ const StoryList = ({
     return <LoadingCard />;
   }
 
-  if (stories.length === 0) {
+  if (stories.length === 0 && !displayMyStories && !displayMyTests) {
     return <NoStoriesFoundCard />;
+  }
+
+  if (stories.length === 0) {
+    return <NoStoriesFoundCardCheckAccess />;
   }
 
   const storyCards = stories.map(


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Update the no stories copy on Homepage](https://www.notion.so/uwblueprintexecs/Update-the-no-stories-copy-on-Homepage-2697d4ad8a8248f198c9d1624754f992)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- change text that shows up when user is browsing stories and doesn't see any pop up

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl Sagan
2. Verify that the messages shown in `My Work`/`My Tests` tabs are unchanged
3. Click on `Browse Stories` and verify that new copy shows up (Carl Sagan should have active translations in both English US and UK)

![no access text](https://user-images.githubusercontent.com/32009013/150995486-e717c0a3-06eb-4f82-985f-01e987171d63.gif)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- is the text changed for the correct scenario?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
