### PR TITLE
Allow use of enter key on login/signup page

### DIFF
--- a/frontend/src/components/auth/LoginComponent.tsx
+++ b/frontend/src/components/auth/LoginComponent.tsx
@@ -67,17 +67,7 @@ const LoginComponent = ({
     window.addEventListener("keyup", (event) => {
       const submitButton = document.getElementById("submit-login-form");
       if (event.key === "Enter" && submitButton !== null) {
-        if (
-          email !== "" &&
-          password !== "" &&
-          (!isSignup ||
-            (firstName !== "" &&
-              lastName !== "" &&
-              agreeToTerms &&
-              checkValidPassword()))
-        ) {
-          submitButton.click();
-        }
+        submitButton.click();
       }
     });
   }, []);
@@ -123,13 +113,13 @@ const LoginComponent = ({
           width="100%"
           colorScheme="blue"
           isDisabled={
-            isSignup &&
-            (firstName === "" ||
-              lastName === "" ||
-              email === "" ||
-              password === "" ||
-              !agreeToTerms ||
-              !checkValidPassword())
+            email === "" ||
+            password === "" ||
+            (isSignup &&
+              (firstName === "" ||
+                lastName === "" ||
+                !agreeToTerms ||
+                !checkValidPassword()))
           }
           isLoading={isLoading}
           loadingText={isSignup ? "Registering account" : "Signing in"}

--- a/frontend/src/components/auth/LoginComponent.tsx
+++ b/frontend/src/components/auth/LoginComponent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   GoogleLogin,
   GoogleLoginResponse,
@@ -62,6 +62,26 @@ const LoginComponent = ({
     }
     return false;
   };
+
+  useEffect(() => {
+    window.addEventListener("keyup", (event) => {
+      if (event.key === "Enter") {
+        if (
+          isSignup &&
+          firstName !== "" &&
+          lastName !== "" &&
+          email !== "" &&
+          password !== "" &&
+          agreeToTerms &&
+          checkValidPassword()
+        ) {
+          onSignUpClick();
+        } else if (!isSignup) {
+          onLogInClick();
+        }
+      }
+    });
+  }, []);
 
   return (
     <Flex>

--- a/frontend/src/components/auth/LoginComponent.tsx
+++ b/frontend/src/components/auth/LoginComponent.tsx
@@ -68,13 +68,13 @@ const LoginComponent = ({
       const submitButton = document.getElementById("submit-login-form");
       if (event.key === "Enter" && submitButton !== null) {
         if (
-          !isSignup ||
-          (firstName !== "" &&
-            lastName !== "" &&
-            email !== "" &&
-            password !== "" &&
-            agreeToTerms &&
-            checkValidPassword())
+          email !== "" &&
+          password !== "" &&
+          (!isSignup ||
+            (firstName !== "" &&
+              lastName !== "" &&
+              agreeToTerms &&
+              checkValidPassword()))
         ) {
           submitButton.click();
         }

--- a/frontend/src/components/auth/LoginComponent.tsx
+++ b/frontend/src/components/auth/LoginComponent.tsx
@@ -65,19 +65,18 @@ const LoginComponent = ({
 
   useEffect(() => {
     window.addEventListener("keyup", (event) => {
-      if (event.key === "Enter") {
+      const submitButton = document.getElementById("submit-login-form");
+      if (event.key === "Enter" && submitButton !== null) {
         if (
-          isSignup &&
-          firstName !== "" &&
-          lastName !== "" &&
-          email !== "" &&
-          password !== "" &&
-          agreeToTerms &&
-          checkValidPassword()
+          !isSignup ||
+          (firstName !== "" &&
+            lastName !== "" &&
+            email !== "" &&
+            password !== "" &&
+            agreeToTerms &&
+            checkValidPassword())
         ) {
-          onSignUpClick();
-        } else if (!isSignup) {
-          onLogInClick();
+          submitButton.click();
         }
       }
     });
@@ -119,6 +118,7 @@ const LoginComponent = ({
           checkValidPassword={checkValidPassword}
         />
         <Button
+          id="submit-login-form"
           marginTop={isSignup ? "0px" : "40px"}
           width="100%"
           colorScheme="blue"


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Allow use of enter key on login/signup page](https://www.notion.so/uwblueprintexecs/Allow-use-of-enter-key-on-login-signup-page-3f42426584f348dc863d534cb5a742ac)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added enter key event listener
- Calls same function as login/signup button on click
- I enabled when button is (i.e. pressing enter does nothing when the corresponding button is disabled)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to login page
2. Enter login information
3. Press enter
4. Observe login
5. Go to signup page
6. Press enter
7. Observe that nothing happens when button is disabled
8. Enter signup information
9. Press enter
10. Observe signup
11. Please also test different combinations of entering information and pressing enter

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work as expected?
- Is the code ok?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
