### PR TITLE
Bump CircleCI Node Version to 14.17.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/node:14.15.5
+      - image: cimg/node:14.17.0
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- bump node version in CircleCI to 14.17.0 (same as the Docker image version used locally) to avoid errors like [this](https://app.circleci.com/pipelines/github/uwblueprint/planet-read/2142/workflows/45701dd2-ce34-4f99-955c-5aa646807f06/jobs/3903)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

I tested by running CircleCI w SSH, and manually bumping the node vers and running `yarn install`: 
![image](https://user-images.githubusercontent.com/32009013/151305663-4c3be769-d049-42a0-ab0c-ac8113a259f7.png)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does the syntax look ok?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
