### PR TITLE
Redirect user to login page after resetting password in firebase defa…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: |
             set -x
             echo "Build images"
-            docker-compose build frontend 
+            docker-compose build frontend
             docker-compose build py-backend
 
   test:
@@ -66,6 +66,8 @@ jobs:
             touch .env.production
             REACT_APP_BACKEND_URL=`echo ${REACT_APP_BACKEND_URL_BASE64} | base64 --decode`
             echo "REACT_APP_BACKEND_URL=$REACT_APP_BACKEND_URL" > .env.production
+            REACT_APP_URL=`echo ${REACT_APP_URL_BASE64} | base64 --decode`
+            echo "REACT_APP_URL=$REACT_APP_URL" > .env.production
             yarn install --frozen-lockfile
             yarn build
       - run:

--- a/backend/python/app/services/implementations/auth_service.py
+++ b/backend/python/app/services/implementations/auth_service.py
@@ -1,3 +1,5 @@
+import os
+
 import firebase_admin.auth
 
 from ...models import db
@@ -111,19 +113,25 @@ class AuthService(IAuthService):
     def reset_password(self, email):
         if not self.email_service:
             error_message = """
-                Attempted to call reset_password but this instance of AuthService 
+                Attempted to call reset_password but this instance of AuthService
                 does not have an EmailService instance
                 """
             self.logger.error(error_message)
             raise Exception(error_message)
 
         try:
-            reset_link = firebase_admin.auth.generate_password_reset_link(email)
+            action_code_settings = firebase_admin.auth.ActionCodeSettings(
+                url=os.getenv("PASSWORD_RESET_REDIRECT"),
+                handle_code_in_app=False,
+            )
+            reset_link = firebase_admin.auth.generate_password_reset_link(
+                email, action_code_settings
+            )
             email_body = """
                 Hello,
                 <br><br>
-                We have received a password reset request for your account. 
-                Please click the following link to reset it. 
+                We have received a password reset request for your account.
+                Please click the following link to reset it.
                 <strong>This link is only valid for 1 hour.</strong>
                 <br><br>
                 <a href={reset_link}>Reset Password</a>
@@ -244,7 +252,7 @@ class AuthService(IAuthService):
                 )[0]
             else:
                 error_message = """
-                Neither story_translation_id nor story_translation_content_id were passed in 
+                Neither story_translation_id nor story_translation_content_id were passed in
                 """
                 self.logger.error(error_message)
                 raise Exception(error_message)

--- a/backend/python/app/services/implementations/auth_service.py
+++ b/backend/python/app/services/implementations/auth_service.py
@@ -121,7 +121,7 @@ class AuthService(IAuthService):
 
         try:
             action_code_settings = firebase_admin.auth.ActionCodeSettings(
-                url=os.getenv("PASSWORD_RESET_REDIRECT"),
+                url=os.getenv("REACT_APP_URL") + "/#/login",
                 handle_code_in_app=False,
             )
             reset_link = firebase_admin.auth.generate_password_reset_link(


### PR DESCRIPTION
…ult ui

## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Redirect user to login page after resetting password in firebase default ui](https://www.notion.so/uwblueprintexecs/Redirect-user-to-login-page-after-resetting-password-in-firebase-default-ui-6c4e2f00128647289d9eb54a9778cc80)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Redirect user after resetting password by adding a continue link with `ActionCodeSettings`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Add this line in your `.env` file: `REACT_APP_URL=http://localhost:3000`
2. Rebuild if necessary
3. Go to `http://localhost:3000/#/login`
4. Enter an email you can access (e.g. Blueprint email)
5. Click on forgot password
6. Check your email
7. Click on the reset password link
8. Enter a new password
9. Press continue
10. Observe redirect to login page

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
