### PR TITLE
Use "In Review" as default filter for reviewers with story translations in review

### DIFF
--- a/frontend/src/components/homepage/MyWorkFilter.tsx
+++ b/frontend/src/components/homepage/MyWorkFilter.tsx
@@ -8,16 +8,20 @@ export type StoriesFilterFn = (story: StoryCardProps) => boolean;
 
 export type MyWorkFilterProps = {
   setFilter: Dispatch<SetStateAction<StoriesFilterFn | null>>;
+  isDefaultInReview: boolean;
 };
 
-const MyWorkFilter = ({ setFilter }: MyWorkFilterProps) => {
+const MyWorkFilter = ({ setFilter, isDefaultInReview }: MyWorkFilterProps) => {
   const generateFilterFn = (stage: string) => {
     return (story: StoryCardProps) => story?.stage === stage;
   };
 
   useEffect(() => {
-    // default to show stories in translation
-    setFilter(() => generateFilterFn("TRANSLATE"));
+    if (isDefaultInReview) {
+      setFilter(() => generateFilterFn("REVIEW"));
+    } else {
+      setFilter(() => generateFilterFn("TRANSLATE"));
+    }
   }, []);
 
   const handleStageChange = (stage: string) => {
@@ -41,7 +45,7 @@ const MyWorkFilter = ({ setFilter }: MyWorkFilterProps) => {
           name="Level"
           options={["In Translation", "In Review", "Completed"]}
           onChange={handleStageChange}
-          defaultValue="In Translation"
+          defaultValue={isDefaultInReview ? "In Review" : "In Translation"}
         />
       </Box>
     </Flex>

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -146,13 +146,22 @@ const HomePage = () => {
     },
   });
 
+  const isDefaultInReview =
+    stories &&
+    stories.filter(
+      (s) => s.reviewerId === +authenticatedUser!!.id && s.stage === "REVIEW",
+    ).length > 0;
+
   return (
     <Box>
       <Header />
       <Divider />
       <Flex direction="row">
-        {pageOption === HomepageOption.MyStories ? (
-          <MyWorkFilter setFilter={setStoriesFilter} />
+        {pageOption === HomepageOption.MyStories && stories ? (
+          <MyWorkFilter
+            setFilter={setStoriesFilter}
+            isDefaultInReview={!!isDefaultInReview}
+          />
         ) : (
           <Filter
             approvedLanguagesTranslation={approvedLanguagesTranslation}


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=248d523e745d4bdebfc6409293b60ad3

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- accept isDefaultInReview param on MyStoriesFilter
- check if user is review and has story in review platform

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. reseed db
2. login as dwight and observe default IN TRANSLATION
3. move one of dwight's own stories to translation
4. observe default is still IN TRANSLATION
5. login as carl and move great gatsby to review (dwight is already reviewer)
6. login as dwight and observe default IN REVIEW
7. click between homepage tabs and observe behaviour

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does it work
- sleeping well

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
