### PR TITLE
Configure backend for uwsgi  deployment

### DIFF
--- a/backend/python/Dockerfile
+++ b/backend/python/Dockerfile
@@ -8,4 +8,4 @@ COPY . /app
 WORKDIR /app
 
 EXPOSE 5000
-CMD ["python", "server.py"]
+CMD ["python", "wsgi.py"]

--- a/backend/python/aml.ini
+++ b/backend/python/aml.ini
@@ -1,0 +1,11 @@
+[uwsgi]
+module = wsgi
+
+master = true
+processes = 5
+
+socket = aml.sock
+chmod-socket = 660
+vacuum = true
+
+die-on-term = true

--- a/backend/python/server.py
+++ b/backend/python/server.py
@@ -5,9 +5,6 @@ from dotenv import load_dotenv
 # note: VS Code's Python extension might falsely report an unresolved import
 from app import create_app
 
-if __name__ == "__main__":
-    load_dotenv()
-    config_name = os.getenv("FLASK_CONFIG") or "development"
-    port = int(os.getenv("PORT", 5000))
-    app = create_app(config_name)
-    app.run(host="0.0.0.0", port=port)
+load_dotenv()
+config_name = os.getenv("FLASK_CONFIG") or "development"
+application = create_app(config_name)

--- a/backend/python/wsgi.py
+++ b/backend/python/wsgi.py
@@ -1,0 +1,11 @@
+import os
+
+from dotenv import load_dotenv
+
+# note: VS Code's Python extension might falsely report an unresolved import
+from server import application
+
+if __name__ == "__main__":
+    load_dotenv()
+    port = int(os.getenv("PORT", 5000))
+    application.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
THIS HAS NO CIRCLE CI CODE TO ACTUALLY DO ANY DEPLOYMENT STEPS

## Implementation description

- rename `server.py` to `wsgi.py` (uwsgi expects `wsgi.py` as the entry point) 
- reuse `server.py` to invoke `create_app`. annoyingly uwsgi needs to see `application` imported in `wsgi.py` so we need to invoke `create_app` elsewhere 
- added `aml.ini` file for starting up the uwsgi server through systemctl (systemctl stuff doesnt need to be committed as its configured on machine. tho, it looks like this)
```
[Unit]
Description=uWSGI instance to serve planet-read
After=network.target

[Service]
User=bp-amluser
Group=www #this is nginx's user on the droplet
WorkingDirectory=/home/bp-amluser/planet-read/backend/python # will be modified
Environment="PATH=/home/bp-amluser/planet-read/planet-read/bin" # will be modified
ExecStart=/home/bp-amluser/planet-read/planet-read/bin/uwsgi --ini planet-read.ini # will be modified
# insert all the environment variables here

[Install]
WantedBy=multi-user.target
```

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test
Dev environment
- `docker-compose down --volumes`
- `docker-compose up`
- poke around and make sure nothing is broken

Production
- you cant lol. gotta trust me on this one 😎 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does this make sense 
- 

## Some open questions you may be curious about
- How will we apply the migrations every time we have new code? insert test data?
  - @Puepis how did you run the migrations?
  - insert test data: *TBD* lol i cant figure it out
- Do we need to restart systemctl every time we have new code? 
  - yes :( 
- Hang on, arent we pushing to /aml but the running code is from /planetread?
  - I will manually reroute the sockets after this pr is merged and a release is made
  - will also rename everything to `aml` - client has multiple things running on the machine and "planet-read" is not a descriptive project name
- How are you getting environment variables into the app?
  - manually setting them in `/etc/systemd/system/planet-read.service`

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
