### PR TITLE
Do not disable dropdowns on TableFilter

### DIFF
--- a/frontend/src/components/admin/TableFilter.tsx
+++ b/frontend/src/components/admin/TableFilter.tsx
@@ -12,12 +12,10 @@ import {
   InputGroup,
   InputLeftElement,
   Stack,
-  Tooltip,
 } from "@chakra-ui/react";
 import DatePicker from "react-datepicker";
 import { levelOptions } from "../../constants/Levels";
 import { stageOptions } from "../../constants/Stage";
-import { FILTER_TOOL_TIP_COPY } from "../../utils/Copy";
 import DropdownIndicator from "../utils/DropdownIndicator";
 import { colourStyles } from "../../theme/components/Select";
 import { getLanguagesQuery } from "../../APIClients/queries/LanguageQueries";
@@ -107,66 +105,45 @@ const TableFilter = ({
         margin="20px auto 10px"
       >
         {useLanguage && setLanguage && (
-          <Tooltip
-            hasArrow
-            label={FILTER_TOOL_TIP_COPY}
-            isDisabled={language == null}
-          >
-            <Box flex={1}>
-              <Select
-                isDisabled={language != null}
-                placeholder="Language"
-                options={options}
-                onChange={(option: any) => setLanguage(option?.value || "")}
-                getOptionLabel={(option: any) => `
+          <Box flex={1}>
+            <Select
+              placeholder="Language"
+              options={options}
+              onChange={(option: any) => setLanguage(option?.value || "")}
+              getOptionLabel={(option: any) => `
                 ${option.value || ""}
               `}
-                value={language ? { value: language } : null}
-                styles={colourStyles}
-                components={{ DropdownIndicator }}
-              />
-            </Box>
-          </Tooltip>
+              value={language ? { value: language } : null}
+              styles={colourStyles}
+              components={{ DropdownIndicator }}
+            />
+          </Box>
         )}
         {useLevel && setLevel && (
-          <Tooltip
-            hasArrow
-            label={FILTER_TOOL_TIP_COPY}
-            isDisabled={level == null}
-          >
-            <Box flex={1} margin="0 15px">
-              <Select
-                placeholder="Level"
-                options={levelOptions}
-                onChange={(option: any) => setLevel(option?.value || "")}
-                getOptionLabel={(option: any) => `Level ${option.value}`}
-                value={level ? { value: level } : null}
-                styles={colourStyles}
-                components={{ DropdownIndicator }}
-                isDisabled={level != null}
-              />
-            </Box>
-          </Tooltip>
+          <Box flex={1} margin="0 15px">
+            <Select
+              placeholder="Level"
+              options={levelOptions}
+              onChange={(option: any) => setLevel(option?.value || "")}
+              getOptionLabel={(option: any) => `Level ${option.value}`}
+              value={level ? { value: level } : null}
+              styles={colourStyles}
+              components={{ DropdownIndicator }}
+            />
+          </Box>
         )}
         {useStage && setStage && (
-          <Tooltip
-            hasArrow
-            label={FILTER_TOOL_TIP_COPY}
-            isDisabled={stage == null}
-          >
-            <Box flex={1} margin="0 15px">
-              <Select
-                placeholder="Progress"
-                options={stageOptions}
-                onChange={(option: any) => setStage(option?.value || "")}
-                getOptionLabel={(option: any) => `${option.value}`}
-                value={stage ? { value: stage } : null}
-                styles={colourStyles}
-                components={{ DropdownIndicator }}
-                isDisabled={stage != null}
-              />
-            </Box>
-          </Tooltip>
+          <Box flex={1} margin="0 15px">
+            <Select
+              placeholder="Progress"
+              options={stageOptions}
+              onChange={(option: any) => setStage(option?.value || "")}
+              getOptionLabel={(option: any) => `${option.value}`}
+              value={stage ? { value: stage } : null}
+              styles={colourStyles}
+              components={{ DropdownIndicator }}
+            />
+          </Box>
         )}
         {useDate && setStartDate && setEndDate && (
           <Box

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -39,9 +39,6 @@ export const REVIEW_PAGE_RETURN_TO_TRANSLATOR_CONFIRMATION =
 export const REVIEW_PAGE_SUBMIT_TRANSLATION_CONFIRMATION =
   "By clicking this button, your review session will end and the story translation will be officially submitted to PlanetRead.";
 
-export const FILTER_TOOL_TIP_COPY =
-  "This category already has a filter applied.";
-
 export const MANAGE_STORY_TRANSLATIONS_TABLE_DELETE_TRANSLATION_CONFIRMATION =
   "By removing this story translation, all its data will no longer be viewable on the platform. This action cannot be undone.";
 


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Do not disable dropdowns on TableFilter](https://www.notion.so/uwblueprintexecs/Do-not-disable-dropdowns-on-TableFilter-baa371befec9425895a8c86b3dcfd6dc)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- remove check to disable dropdown when value is set and corresponding tooltip

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as admin
2. Play around with filters on `Manage Story Translations` tab
3. Verify that when an option is selected, dropdown no longer becomes disabled; when a new value is selected, it replaces the old value
4. Repeat for `Manage Stories`, `Manage Translators`, `Manage Reviewers`

![filter disable](https://user-images.githubusercontent.com/32009013/152491183-a57d514a-1bed-4d30-8d9c-4932619f0731.gif)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- are there any other dropdowns that need to be modified?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
