### PR TITLE
Allow same user to be translator and reviewer on story translation

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -566,7 +566,6 @@ class StoryService(IStoryService):
             and user.approved_languages_review[story_translation["language"]]
             >= story_translation["level"]
             and not story_translation["reviewer_id"]
-            and user.id != story_translation["translator_id"]
         ):
             story_translation = StoryTranslation.query.get(story_translation["id"])
             story_translation.reviewer_id = user.id

--- a/frontend/src/components/homepage/StoryCard.tsx
+++ b/frontend/src/components/homepage/StoryCard.tsx
@@ -48,6 +48,8 @@ const StoryCard = ({
   isMyStory,
   isMyTest,
   translatorId,
+  reviewerId,
+  stage,
 }: StoryCardProps) => {
   const { authenticatedUser } = useContext(AuthContext);
   const history = useHistory();
@@ -57,6 +59,7 @@ const StoryCard = ({
     alert(errorMessage);
   };
   const isTranslator = +authenticatedUser!!.id === translatorId;
+  const isReviewer = +authenticatedUser!!.id === reviewerId;
 
   const [assignUserAsReviewer] = useMutation<{
     assignUserAsReviewer: AssignReviewerResponse;
@@ -119,7 +122,10 @@ const StoryCard = ({
   };
 
   const openTranslation = () => {
-    const storyTranslationUrlBase = isTranslator ? "translation" : "review";
+    const storyTranslationUrlBase =
+      (isTranslator && !isReviewer) || (isTranslator && stage === "TRANSLATE")
+        ? "translation"
+        : "review";
     history.push(
       `/${storyTranslationUrlBase}/${storyId}/${storyTranslationId}`,
     );
@@ -177,11 +183,10 @@ const StoryCard = ({
               background={getLevelVariant(level)}
             >{`Level ${level}`}</Badge>
             <Badge variant="language">{`${language}`}</Badge>
-            {isMyStory && (
-              <Badge variant="role">
-                {isTranslator ? "Translator" : "Reviewer"}
-              </Badge>
+            {isMyStory && isTranslator && (
+              <Badge variant="role">Translator</Badge>
             )}
+            {isMyStory && isReviewer && <Badge variant="role">Reviewer</Badge>}
             {isMyTest && <Badge variant="role">Test Book</Badge>}
           </Flex>
         </Flex>

--- a/frontend/src/components/homepage/StoryList.tsx
+++ b/frontend/src/components/homepage/StoryList.tsx
@@ -90,6 +90,7 @@ const StoryList = ({
       language,
       translatorId,
       reviewerId,
+      stage,
     }: StoryCardProps) => (
       <StoryCard
         key={createCardId(storyId, storyTranslationId)}
@@ -104,6 +105,7 @@ const StoryList = ({
         isMyTest={displayMyTests}
         translatorId={translatorId}
         reviewerId={reviewerId}
+        stage={stage}
       />
     ),
   );


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Allow same user to be translator and reviewer on story translation](https://www.notion.so/uwblueprintexecs/Allow-same-user-to-be-translator-and-reviewer-on-story-translation-4b689c63d2ff4ef48159882114e71abc)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- remove check in backend preventing user from being assigned as reviewer if they are translator
- update frontend story card to reflect changes

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test
1. Login as admin; upgrade Dwight D Eisenhower to be able to review Level 4 English (UK) translations
2. Login as Dwight; confirm Dwight is currently a translator on `Pride and Prejudice` English(UK)
3. Navigate to `Browse Stories`  tab, select Reviewer, English(UK), Level 4; click `Review` on `Pride and Prejudice`
4. Confirm that you were successfully assigned as reviewer
5. Navigate back to `My Stories` tab; confirm that `Pride and Prejudice` now shows up with a `Translator` and `Reviewer` badge, and that it is currently `In Translation`
6. Click on `View Translation` -> confirm that the translation platform appears; do some normal translator actions to confirm they still work as expected
7. Click on `Send for Review`
8. Navigate back to `My Stories` tab; confirm that `Pride and Prejudice` now shows up under `In Review`
9. Click on `View Translation` -> confirm that the review platform appears; do some normal reviewer actions to confirm they still work as expected

![image](https://user-images.githubusercontent.com/32009013/152575917-9f52d26a-8f44-4f60-95f5-aaa0d5b4bb4e.png)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- are there any other places we would need to modify now that we are enabling translators to also be reviewers of the same story?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
