### PR TITLE
Allow admin to update level on story

### DIFF
--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -196,15 +196,18 @@ class UpdateStory(graphene.Mutation):
     class Arguments:
         story_id = graphene.Int(required=True)
         title = graphene.String(required=True)
+        level = graphene.Int(required=True)
         description = graphene.String(required=True)
         youtube_link = graphene.String(required=True)
 
     ok = graphene.Boolean()
 
     @require_authorization_by_role_gql({"Admin"})
-    def mutate(root, info, story_id, title, description, youtube_link):
+    def mutate(root, info, story_id, title, level, description, youtube_link):
         try:
-            services["story"].update_story(story_id, title, description, youtube_link)
+            services["story"].update_story(
+                story_id, title, level, description, youtube_link
+            )
             return UpdateStory(ok=True)
         except Exception as e:
             error_message = getattr(e, "message", None)

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -594,10 +594,11 @@ class StoryService(IStoryService):
             )
             raise error
 
-    def update_story(self, story_id, title, description, youtube_link):
+    def update_story(self, story_id, title, level, description, youtube_link):
         try:
             story = Story.query.get(story_id)
             story.title = title
+            story.level = level
             story.description = description
             story.youtube_link = youtube_link
             db.session.commit()

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -142,10 +142,11 @@ class IStoryService(ABC):
         pass
 
     @abstractmethod
-    def update_story(self, story_id, title, description, youtube_link):
+    def update_story(self, story_id, title, level, description, youtube_link):
         """Update a single story
         :param story_id: id of story to be updated
         :param title: updated title
+        :param level: updated level
         :param description: updated description
         :param youtube_link: updated youtube_link
         :raises Exception: if the user is not authorized to update stories

--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -132,12 +132,14 @@ export const UPDATE_STORY = gql`
   mutation UpdateStory(
     $storyId: Int!
     $title: String!
+    $level: Int!
     $description: String!
     $youtubeLink: String!
   ) {
     updateStory(
       storyId: $storyId
       title: $title
+      level: $level
       description: $description
       youtubeLink: $youtubeLink
     ) {

--- a/frontend/src/components/pages/ManageStoryPage.tsx
+++ b/frontend/src/components/pages/ManageStoryPage.tsx
@@ -120,10 +120,10 @@ const ManageStoryPage = () => {
           youtubeLink: tempYoutubeLink,
         },
       });
-      // // Reload page so Story Translations Table shows translations with updated levels
-      // if (tempLevel !== level) {
-      //   window.location.reload();
-      // }
+      // Reload page so Story Translations Table shows translations with updated levels
+      if (tempLevel !== level) {
+        window.location.reload();
+      }
       setTitle(tempTitle);
       setLevel(tempLevel);
       setDescription(tempDescription);

--- a/frontend/src/components/pages/ManageStoryPage.tsx
+++ b/frontend/src/components/pages/ManageStoryPage.tsx
@@ -287,7 +287,8 @@ const ManageStoryPage = () => {
             isDisabled={
               title === tempTitle &&
               description === tempDescription &&
-              youtubeLink === tempYoutubeLink
+              youtubeLink === tempYoutubeLink &&
+              level === tempLevel
             }
             onClick={cancelChanges}
             variant="blueOutline"

--- a/frontend/src/components/pages/ManageStoryPage.tsx
+++ b/frontend/src/components/pages/ManageStoryPage.tsx
@@ -120,14 +120,7 @@ const ManageStoryPage = () => {
           youtubeLink: tempYoutubeLink,
         },
       });
-      // Reload page so Story Translations Table shows translations with updated levels
-      if (tempLevel !== level) {
-        window.location.reload();
-      }
-      setTitle(tempTitle);
-      setLevel(tempLevel);
-      setDescription(tempDescription);
-      setYoutubeLink(tempYoutubeLink);
+      window.location.reload();
     }
   };
 

--- a/frontend/src/components/pages/ManageStoryPage.tsx
+++ b/frontend/src/components/pages/ManageStoryPage.tsx
@@ -8,6 +8,11 @@ import {
   FormControl,
   Input,
   Heading,
+  Slider,
+  SliderFilledTrack,
+  SliderMark,
+  SliderThumb,
+  SliderTrack,
   Text,
   Textarea,
 } from "@chakra-ui/react";
@@ -44,9 +49,11 @@ const ManageStoryPage = () => {
   const { storyIdParam } = useParams<ManageStoryPageProps>();
 
   const [title, setTitle] = useState<string>("");
+  const [level, setLevel] = useState<number>(0);
   const [description, setDescription] = useState<string>("");
   const [youtubeLink, setYoutubeLink] = useState<string>("");
   const [tempTitle, setTempTitle] = useState<string>("");
+  const [tempLevel, setTempLevel] = useState<number>(0);
   const [tempDescription, setTempDescription] = useState<string>("");
   const [tempYoutubeLink, setTempYoutubeLink] = useState<string>("");
 
@@ -68,9 +75,11 @@ const ManageStoryPage = () => {
     fetchPolicy: "cache-and-network",
     onCompleted: (data: { storyById: Story; errors: any }) => {
       setTitle(data.storyById.title);
+      setLevel(data.storyById.level);
       setDescription(data.storyById.description);
       setYoutubeLink(data.storyById.youtubeLink);
       setTempTitle(data.storyById.title);
+      setTempLevel(data.storyById.level);
       setTempDescription(data.storyById.description);
       setTempYoutubeLink(data.storyById.youtubeLink);
     },
@@ -99,17 +108,24 @@ const ManageStoryPage = () => {
     if (
       title !== tempTitle ||
       description !== tempDescription ||
-      youtubeLink !== tempYoutubeLink
+      youtubeLink !== tempYoutubeLink ||
+      level !== tempLevel
     ) {
       await updateStory({
         variables: {
           storyId: storyIdParam,
           title: tempTitle,
+          level: tempLevel,
           description: tempDescription,
           youtubeLink: tempYoutubeLink,
         },
       });
+      // // Reload page so Story Translations Table shows translations with updated levels
+      // if (tempLevel !== level) {
+      //   window.location.reload();
+      // }
       setTitle(tempTitle);
+      setLevel(tempLevel);
       setDescription(tempDescription);
       setYoutubeLink(tempYoutubeLink);
     }
@@ -151,6 +167,45 @@ const ManageStoryPage = () => {
                   type="title"
                   value={tempTitle || ""}
                 />
+                <Heading size="sm" marginTop="24px" marginBottom="18px">
+                  Level
+                </Heading>
+                <Slider
+                  value={tempLevel}
+                  min={1}
+                  max={4}
+                  step={1}
+                  marginLeft="20px"
+                  size="lg"
+                  width="79%"
+                  onChange={(newLevel: number) => setTempLevel(newLevel)}
+                >
+                  <SliderTrack height="6px">
+                    <SliderFilledTrack bg="blue.500" />
+                  </SliderTrack>
+                  <SliderThumb boxShadow="0px 0px 3px black" />
+                  {[1, 2, 3, 4].map((val) => (
+                    <SliderMark
+                      key={val}
+                      value={val}
+                      height="6px"
+                      width="4px"
+                      marginTop="-3px"
+                      bg={
+                        level >= val
+                          ? "#64A1CD" // light blue
+                          : "#ECF1F4" // light gray
+                      }
+                    >
+                      <Text
+                        margin="10px 0px 0px -2px"
+                        fontWeight={level === val ? "bold" : "normal"}
+                      >
+                        {val}
+                      </Text>
+                    </SliderMark>
+                  ))}
+                </Slider>
                 <Heading size="sm" marginTop="24px" marginBottom="18px">
                   Description
                 </Heading>
@@ -201,7 +256,6 @@ const ManageStoryPage = () => {
             filters={[() => {}]}
             width="100%"
           />
-
           <Heading size="sm">Delete Story</Heading>
           <Text>
             Permanently delete this story and all story translations associated
@@ -245,7 +299,8 @@ const ManageStoryPage = () => {
             isDisabled={
               title === tempTitle &&
               description === tempDescription &&
-              youtubeLink === tempYoutubeLink
+              youtubeLink === tempYoutubeLink &&
+              level === tempLevel
             }
             onClick={callUpdateStoryMutation}
           >


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Allow admin to update level on story](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=464f9a0b9b6d4d88a6a139dfedd5a67e)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Add slider to Manage Story page to allow admin to update story level
- Update `UpdateStory` mutation to take in level parameter to update

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to Manage Story page for a story
2. Update the level, click Save Changes 
3. Ensure no errors appear 

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Is it necessary to immediately update the badges in the Story Translations table as well? 

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
