### PR TITLE
Allow users to quit story translations

### DIFF
--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -235,14 +235,14 @@ class UpdateStoryTranslationStage(graphene.Mutation):
 
 class SoftDeleteStoryTranslation(graphene.Mutation):
     class Arguments:
-        id = graphene.Int(required=True)
+        story_translation_id = graphene.Int(required=True)
 
     ok = graphene.Boolean()
 
     @require_authorization_as_story_user_by_role(as_translator=True)
-    def mutate(root, info, id):
+    def mutate(root, info, story_translation_id):
         try:
-            services["story"].soft_delete_story_translation(id)
+            services["story"].soft_delete_story_translation(story_translation_id)
             return SoftDeleteStoryTranslation(ok=True)
         except Exception as e:
             error_message = getattr(e, "message", None)

--- a/backend/python/app/graphql/mutations/story_mutation.py
+++ b/backend/python/app/graphql/mutations/story_mutation.py
@@ -101,7 +101,7 @@ class RemoveReviewerFromStoryTranslation(graphene.Mutation):
 
     ok = graphene.Boolean()
 
-    @require_authorization_by_role_gql({"Admin"})
+    @require_authorization_as_story_user_by_role(as_translator=False)
     def mutate(root, info, story_translation_id):
         try:
             story_translation = services["story"].get_story_translation(
@@ -239,7 +239,7 @@ class SoftDeleteStoryTranslation(graphene.Mutation):
 
     ok = graphene.Boolean()
 
-    @require_authorization_by_role_gql({"Admin"})
+    @require_authorization_as_story_user_by_role(as_translator=True)
     def mutate(root, info, id):
         try:
             services["story"].soft_delete_story_translation(id)

--- a/backend/python/app/middlewares/auth.py
+++ b/backend/python/app/middlewares/auth.py
@@ -1,5 +1,4 @@
 from functools import wraps
-import sys
 
 import firebase_admin.auth
 from flask import current_app, jsonify, request
@@ -199,7 +198,10 @@ def require_authorization_as_story_user_by_role(as_translator):
                         story_translation_id=kwargs["story_translation_id"],
                     )
                 )
-            elif "story_translation_content_id" in kwargs or "story_translation_contents" in kwargs:
+            elif (
+                "story_translation_content_id" in kwargs
+                or "story_translation_contents" in kwargs
+            ):
                 story_translation_content_id = None
 
                 if "story_translation_content_id" in kwargs:
@@ -235,7 +237,6 @@ def require_authorization_as_story_user_by_role(as_translator):
                         story_translation_id=kwargs["id"],
                     )
                 )
-
 
             if not authorized:
                 if as_translator:

--- a/backend/python/app/middlewares/auth.py
+++ b/backend/python/app/middlewares/auth.py
@@ -198,10 +198,7 @@ def require_authorization_as_story_user_by_role(as_translator):
                         story_translation_id=kwargs["story_translation_id"],
                     )
                 )
-            elif (
-                "story_translation_content_id" in kwargs
-                or "story_translation_contents" in kwargs
-            ):
+            else:
                 story_translation_content_id = None
 
                 if "story_translation_content_id" in kwargs:
@@ -225,18 +222,6 @@ def require_authorization_as_story_user_by_role(as_translator):
                             story_translation_content_id=story_translation_content_id,
                         )
                     )
-            elif "id" in kwargs:
-                authorized = (
-                    auth_service.is_translator(
-                        access_token,
-                        story_translation_id=kwargs["id"],
-                    )
-                    if as_translator
-                    else auth_service.is_reviewer(
-                        access_token,
-                        story_translation_id=kwargs["id"],
-                    )
-                )
 
             if not authorized:
                 if as_translator:

--- a/backend/python/app/middlewares/auth.py
+++ b/backend/python/app/middlewares/auth.py
@@ -1,4 +1,5 @@
 from functools import wraps
+import sys
 
 import firebase_admin.auth
 from flask import current_app, jsonify, request
@@ -198,7 +199,7 @@ def require_authorization_as_story_user_by_role(as_translator):
                         story_translation_id=kwargs["story_translation_id"],
                     )
                 )
-            else:
+            elif "story_translation_content_id" in kwargs or "story_translation_contents" in kwargs:
                 story_translation_content_id = None
 
                 if "story_translation_content_id" in kwargs:
@@ -222,6 +223,19 @@ def require_authorization_as_story_user_by_role(as_translator):
                             story_translation_content_id=story_translation_content_id,
                         )
                     )
+            elif "id" in kwargs:
+                authorized = (
+                    auth_service.is_translator(
+                        access_token,
+                        story_translation_id=kwargs["id"],
+                    )
+                    if as_translator
+                    else auth_service.is_reviewer(
+                        access_token,
+                        story_translation_id=kwargs["id"],
+                    )
+                )
+
 
             if not authorized:
                 if as_translator:

--- a/frontend/src/APIClients/mutations/StoryMutations.ts
+++ b/frontend/src/APIClients/mutations/StoryMutations.ts
@@ -120,8 +120,8 @@ export const UPDATE_STORY_TRANSLATION_STAGE = gql`
 export type UpdateStoryTranslationStageResponse = { ok: boolean };
 
 export const SOFT_DELETE_STORY_TRANSLATION = gql`
-  mutation SoftDeleteStoryTranslation($id: Int!) {
-    softDeleteStoryTranslation(id: $id) {
+  mutation SoftDeleteStoryTranslation($storyTranslationId: Int!) {
+    softDeleteStoryTranslation(storyTranslationId: $storyTranslationId) {
       ok
     }
   }

--- a/frontend/src/components/admin/StoryTestsTable.tsx
+++ b/frontend/src/components/admin/StoryTestsTable.tsx
@@ -72,7 +72,7 @@ const StoryTestsTable = ({
   const callSoftDeleteStoryTranslationMutation = async () => {
     await deleteStoryTranslation({
       variables: {
-        id: idToDelete,
+        storyTranslationId: idToDelete,
       },
     });
     closeModal();

--- a/frontend/src/components/admin/StoryTranslationsTable.tsx
+++ b/frontend/src/components/admin/StoryTranslationsTable.tsx
@@ -97,7 +97,7 @@ const StoryTranslationsTable = ({
   const callSoftDeleteStoryTranslationMutation = async () => {
     await deleteStoryTranslation({
       variables: {
-        id: idToDelete,
+        storyTranslationId: idToDelete,
       },
     });
     closeModal();

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -166,6 +166,13 @@ const ReviewPage = () => {
     removeReviewerFromStoryTranslation: UnassignReviewerResponse;
   }>(UNASSIGN_REVIEWER);
   const onRemoveFromTranslationConfirmationClick = async (): Promise<void> => {
+    const storyTranslationData = {
+      id: storyTranslationId,
+      stage: "TRANSLATE",
+    };
+    await updateStoryTranslationStage({
+      variables: { storyTranslationData },
+    });
     await removeReviewer({
       variables: {
         storyTranslationId,

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -185,7 +185,7 @@ const TranslationPage = () => {
   const onRemoveFromTranslationConfirmationClick = async () => {
     await deleteStoryTranslation({
       variables: {
-        id: storyTranslationId,
+        storyTranslationId,
       },
     });
     onRemoveFromTranslationClick();

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -11,6 +11,8 @@ import Autosave, { StoryLine } from "../translation/Autosave";
 import { convertStatusTitleCase } from "../../utils/StatusUtils";
 import { GET_STORY_AND_TRANSLATION_CONTENTS } from "../../APIClients/queries/StoryQueries";
 import {
+  SOFT_DELETE_STORY_TRANSLATION,
+  SoftDeleteStoryTranslationResponse,
   UPDATE_STORY_TRANSLATION_STAGE,
   UpdateStoryTranslationStageResponse,
 } from "../../APIClients/mutations/StoryMutations";
@@ -23,6 +25,8 @@ import {
   TRANSLATION_PAGE_TOOL_TIP_COPY,
   TRANSLATION_PAGE_BUTTON_MESSAGE,
   TRANSLATION_PAGE_SEND_FOR_REVIEW_CONFIRMATION,
+  TRANSLATION_PAGE_REMOVE_FROM_TRANSLATION_BUTTON_MESSAGE,
+  TRANSLATION_PAGE_REMOVE_FROM_TRANSLATION_CONFIRMATION,
 } from "../../utils/Copy";
 import ConfirmationModal from "../utils/ConfirmationModal";
 
@@ -170,6 +174,25 @@ const TranslationPage = () => {
     }
   };
 
+  const [removeFromTranslation, setRemoveFromTranslation] = useState(false);
+  const onRemoveFromTranslationClick = async () => {
+    setRemoveFromTranslation(!removeFromTranslation);
+  };
+
+  const [deleteStoryTranslation] = useMutation<{
+    response: SoftDeleteStoryTranslationResponse;
+  }>(SOFT_DELETE_STORY_TRANSLATION);
+  const onRemoveFromTranslationConfirmationClick = async () => {
+    console.log(storyTranslationId);
+    await deleteStoryTranslation({
+      variables: {
+        id: storyTranslationId,
+      },
+    });
+    onRemoveFromTranslationClick();
+    history.push("/");
+  };
+
   const { loading } = useQuery(
     GET_STORY_AND_TRANSLATION_CONTENTS(storyId, storyTranslationId),
     {
@@ -293,27 +316,37 @@ const TranslationPage = () => {
               type="Translation"
               fontSize={fontSize}
             />
-            <Tooltip
-              hasArrow
-              label={
-                !changesSaved
-                  ? CHANGES_NOT_YET_SAVED_ALERT
-                  : TRANSLATION_PAGE_TOOL_TIP_COPY
-              }
-              disabled={editable && changesSaved}
-            >
-              <Box>
-                <Button
-                  colorScheme="blue"
-                  size="secondary"
-                  margin="0 10px 0"
-                  disabled={!editable || !changesSaved}
-                  onClick={onSendForReviewClick}
-                >
-                  {editable ? "SEND FOR REVIEW" : "IN REVIEW"}
-                </Button>
-              </Box>
-            </Tooltip>
+            <Flex>
+              <Text
+                as="u"
+                margin="5px 20px 0 0"
+                onClick={onRemoveFromTranslationClick}
+                variant="link"
+              >
+                Remove myself from translation
+              </Text>
+              <Tooltip
+                hasArrow
+                label={
+                  !changesSaved
+                    ? CHANGES_NOT_YET_SAVED_ALERT
+                    : TRANSLATION_PAGE_TOOL_TIP_COPY
+                }
+                disabled={editable && changesSaved}
+              >
+                <Box>
+                  <Button
+                    colorScheme="blue"
+                    size="secondary"
+                    margin="0 10px 0"
+                    disabled={!editable || !changesSaved}
+                    onClick={onSendForReviewClick}
+                  >
+                    {editable ? "SEND FOR REVIEW" : "IN REVIEW"}
+                  </Button>
+                </Box>
+              </Tooltip>
+            </Flex>
           </Flex>
         </Flex>
         {!isTest && (
@@ -340,6 +373,19 @@ const TranslationPage = () => {
           onConfirmationClick={onSendForReviewConfirmationClick}
           confirmationMessage={TRANSLATION_PAGE_SEND_FOR_REVIEW_CONFIRMATION}
           buttonMessage={TRANSLATION_PAGE_BUTTON_MESSAGE}
+        />
+      )}
+      {removeFromTranslation && (
+        <ConfirmationModal
+          buttonMessage={
+            TRANSLATION_PAGE_REMOVE_FROM_TRANSLATION_BUTTON_MESSAGE
+          }
+          confirmation={removeFromTranslation}
+          confirmationMessage={
+            TRANSLATION_PAGE_REMOVE_FROM_TRANSLATION_CONFIRMATION
+          }
+          onClose={onRemoveFromTranslationClick}
+          onConfirmationClick={onRemoveFromTranslationConfirmationClick}
         />
       )}
     </Flex>

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -183,7 +183,6 @@ const TranslationPage = () => {
     response: SoftDeleteStoryTranslationResponse;
   }>(SOFT_DELETE_STORY_TRANSLATION);
   const onRemoveFromTranslationConfirmationClick = async () => {
-    console.log(storyTranslationId);
     await deleteStoryTranslation({
       variables: {
         id: storyTranslationId,

--- a/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
+++ b/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
@@ -224,7 +224,7 @@ const AssignedStoryTranslationsTable = ({
   const unassignTranslator = async (storyTranslationId: number) => {
     await deleteStoryTranslation({
       variables: {
-        id: storyTranslationId,
+        storyTranslationId,
       },
     });
     return null;

--- a/frontend/src/utils/Copy.ts
+++ b/frontend/src/utils/Copy.ts
@@ -151,3 +151,9 @@ export const SIGN_UP_INVALID_PASSWORD_ALERT =
 
 export const CHANGES_NOT_YET_SAVED_ALERT =
   "Your changes have not yet been saved. Please wait before submitting...";
+
+export const TRANSLATION_PAGE_REMOVE_FROM_TRANSLATION_BUTTON_MESSAGE =
+  "I'm sure, remove";
+
+export const TRANSLATION_PAGE_REMOVE_FROM_TRANSLATION_CONFIRMATION =
+  "Are you sure you want to remove yourself from this story translation? You will lose access to contributing to this story translation.";


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Allow users to quit story translations](https://www.notion.so/uwblueprintexecs/Allow-users-to-quit-story-translations-ea6058975b8040c796df52af571dd8d0)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added Remove myself from translation link to translation and review pages
- On translation page, call `SOFT_DELETE_STORY_TRANSLATION` to remove translator from translation
- On review page, call `UPDATE_STORY_TRANSLATION_STAGE` and `UNASSIGN_REVIEWER` to move story translation to in translation and remove reviewer from translation
- Added confirmation modals
- Modified authorization requirements on story mutations
- Modified `require_authorization_as_story_user_by_role` function in `auth.py` to work with `id` in `kwargs`

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Carl
2. View To Kill a Mockingbird
3. Click Remove myself from translation link
4. Confirm modal
5. Observe redirect to homepage and translation deletion
6. View The Great Gatsby
7. Send for review
8. Login as Dwight
9. View The Great Gatsby
10. Click Remove myself from translation link
11. Confirm modal
12. Observe redirect to homepage and translation removal
13. Login as Carl
14. View The Great Gatsby
15. Observe that it is in translation

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?
- Does the implementation make sense (please double check changes in `auth.py`)?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
