### PR TITLE
Allow admins to comment on translations

### DIFF
--- a/backend/python/app/graphql/mutations/comment_mutation.py
+++ b/backend/python/app/graphql/mutations/comment_mutation.py
@@ -23,8 +23,9 @@ class CreateComment(graphene.Mutation):
     @require_authorization_by_role_gql({"User", "Admin"})
     def mutate(root, info, comment_data):
         user_id = get_user_id_from_request()
+        is_admin = services["user"].get_user_by_id(user_id).role == "Admin"
         comment_response = services["comment"].create_comment(
-            comment=comment_data, user_id=user_id
+            comment=comment_data, user_id=user_id, is_admin=is_admin
         )
         ok = True
         return CreateComment(ok=ok, comment=comment_response)

--- a/backend/python/app/services/implementations/comment_service.py
+++ b/backend/python/app/services/implementations/comment_service.py
@@ -18,7 +18,7 @@ class CommentService(ICommentService):
     def __init__(self, logger=current_app.logger):
         self.logger = logger
 
-    def create_comment(self, comment, user_id):
+    def create_comment(self, comment, user_id, is_admin=False):
         try:
             new_comment = CommentAll(**comment)
             new_comment.user_id = user_id
@@ -44,11 +44,13 @@ class CommentService(ICommentService):
         except Exception as error:
             self.logger.error(str(error))
             raise error
-        if story_translation_stage == "PUBLISH" and (is_translator or is_reviewer):
+        if story_translation_stage == "PUBLISH" and (
+            is_translator or is_reviewer or is_admin
+        ):
             raise Exception(
                 "Comments cannot be left after the story has been published."
             )
-        elif is_translator or is_reviewer:
+        elif is_translator or is_reviewer or is_admin:
             try:
                 new_comment.time = datetime.utcnow()
                 new_comment.resolved = False

--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -284,13 +284,15 @@ const ReviewPage = () => {
           </Flex>
         </Flex>
         {(+authenticatedUser!.id === translatorId ||
-          +authenticatedUser!.id === reviewerId) && (
+          +authenticatedUser!.id === reviewerId ||
+          isAdmin) && (
           <CommentsPanel
             storyTranslationContentId={storyTranslationContentId}
             commentLine={commentLine}
             storyTranslationId={storyTranslationId}
             translatorId={translatorId}
             translatorName={translatorName}
+            reviewerId={reviewerId}
             reviewerName={reviewerName}
             setCommentLine={setCommentLine}
           />

--- a/frontend/src/components/pages/TranslationPage.tsx
+++ b/frontend/src/components/pages/TranslationPage.tsx
@@ -54,6 +54,7 @@ const TranslationPage = () => {
     [],
   );
   const [translatorId, setTranslatorId] = useState(-1);
+  const [reviewerId, setReviewerId] = useState<number | null>(-1);
   const [title, setTitle] = useState<string>("");
   const [language, setLanguage] = useState<string>("");
   const [stage, setStage] = useState<string>("");
@@ -198,6 +199,7 @@ const TranslationPage = () => {
       fetchPolicy: "cache-and-network",
       onCompleted: (data) => {
         setTranslatorId(data.storyTranslationById.translatorId);
+        setReviewerId(data.storyTranslationById.reviewerId);
         const storyContent = data.storyById.contents;
         const translatedContent = data.storyTranslationById.translationContents;
         setStage(data.storyTranslationById.stage);
@@ -355,6 +357,7 @@ const TranslationPage = () => {
             storyTranslationId={storyTranslationId}
             translatorId={translatorId}
             translatorName={translatorName}
+            reviewerId={reviewerId}
             reviewerName={reviewerName}
             setCommentLine={setCommentLine}
           />

--- a/frontend/src/components/review/CommentThread.tsx
+++ b/frontend/src/components/review/CommentThread.tsx
@@ -11,18 +11,20 @@ import {
 export type CommentThreadProps = {
   comments: CommentResponse[];
   commentsIdx: number;
-  reviewerName: string;
   setComments: (comments: CommentResponse[]) => void;
   updateCommentsAsResolved: (index: number) => void;
   updateThreadHeadMap: (cmts: CommentResponse[]) => void;
   threadHeadMap: boolean[];
   translatorId: number;
   translatorName: string;
+  reviewerId: number | null;
+  reviewerName: string;
 };
 
 const CommentThread = ({
   comments,
   commentsIdx,
+  reviewerId,
   reviewerName,
   setComments,
   updateCommentsAsResolved,
@@ -94,6 +96,16 @@ const CommentThread = ({
     }
   };
 
+  const getCommentAuthor = (userId: number) => {
+    if (translatorId === userId) {
+      return translatorName;
+    }
+    if (reviewerId === userId) {
+      return reviewerName;
+    }
+    return "Admin";
+  };
+
   return (
     <>
       <ExistingComment
@@ -102,9 +114,7 @@ const CommentThread = ({
         isFirstReply={false}
         isThreadHead
         resolveExistingComment={resolveExistingComment}
-        userName={
-          translatorId === comment.userId ? translatorName : reviewerName
-        }
+        userName={getCommentAuthor(comment.userId)}
       />
       {
         // eslint-disable-next-line func-names
@@ -115,11 +125,7 @@ const CommentThread = ({
               isFirstReply={i === 0}
               isThreadHead={false}
               key={threadReply.id}
-              userName={
-                translatorId === threadReply.userId
-                  ? translatorName
-                  : reviewerName
-              }
+              userName={getCommentAuthor(threadReply.userId)}
             />
           );
         })

--- a/frontend/src/components/review/CommentsPanel.tsx
+++ b/frontend/src/components/review/CommentsPanel.tsx
@@ -12,6 +12,7 @@ export type CommentPanelProps = {
   storyTranslationId: number;
   translatorId: number;
   translatorName: string;
+  reviewerId: number | null;
   reviewerName: string;
   commentLine: number;
   setCommentLine: (line: number) => void;
@@ -21,6 +22,7 @@ export type CommentPanelProps = {
 const CommentsPanel = ({
   storyTranslationId,
   translatorId,
+  reviewerId,
   translatorName,
   reviewerName,
   commentLine,
@@ -122,13 +124,14 @@ const CommentsPanel = ({
                   comments={comments}
                   commentsIdx={i}
                   key={comment.id}
-                  reviewerName={reviewerName}
                   setComments={setComments}
                   updateCommentsAsResolved={updateCommentsAsResolved}
                   updateThreadHeadMap={updateThreadHeadMap}
                   threadHeadMap={threadHeadMap}
                   translatorId={translatorId}
                   translatorName={translatorName}
+                  reviewerId={reviewerId}
+                  reviewerName={reviewerName}
                 />
               );
             }

--- a/frontend/src/components/review/WIPComment.tsx
+++ b/frontend/src/components/review/WIPComment.tsx
@@ -67,7 +67,10 @@ const WIPComment = ({
       }
     }
   };
-  const name = `${authenticatedUser!!.firstName}
+  const isAdmin = authenticatedUser!!.role === "Admin";
+  const name = isAdmin
+    ? "Admin"
+    : `${authenticatedUser!!.firstName}
                 ${authenticatedUser!!.lastName}`;
   return (
     <Flex


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

https://www.notion.so/uwblueprintexecs/Allow-admins-to-comment-on-story-translations-efd4db5222ba4985a9aa71e7e08dd657

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- modified `comment_service.py` to allow admins to create a comment
- modified `ReviewPage.tsx` to display comments panel
- made some changes to display "Admin" as the name if user is neither translator nor reviewer

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. login as admin
2. click on any story translation in the table
3. comment on any line, verify that name shows "Admin"
4. comment a reply
5. refresh to verify that name still shows "Admin"
6. sanity check: login as translator or reviewer and verify that commenting still works


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- does the name show up correctly?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
