### PR TITLE
Hide 'remove myself from translation' if admin viewing platform

### DIFF
--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -248,14 +248,16 @@ const ReviewPage = () => {
               />
             </Flex>
             <Flex>
-              <Text
-                as="u"
-                margin="5px 20px 0 0"
-                onClick={onRemoveFromTranslationClick}
-                variant="link"
-              >
-                Remove myself from translation
-              </Text>
+              {+authenticatedUser!.id === reviewerId && (
+                <Text
+                  as="u"
+                  margin="5px 20px 0 0"
+                  onClick={onRemoveFromTranslationClick}
+                  variant="link"
+                >
+                  Remove myself from translation
+                </Text>
+              )}
               <Tooltip
                 hasArrow
                 label={REVIEW_PAGE_TOOL_TIP_COPY}


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Hide “remove myself from translation” if admin viewing platform](https://www.notion.so/uwblueprintexecs/Hide-remove-myself-from-translation-if-admin-viewing-platform-9070ed5859ea4b84b5750486c2162246)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Hid “remove myself from translation” on review page if user is not the reviewer

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Angela Merkel
2. Go to a translation
3. Observe that “remove myself from translation” link is not there

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
