### PR TITLE
Show translator and reviewer role in profile

### DIFF
--- a/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
+++ b/frontend/src/components/userProfile/AssignedStoryTranslationsTable.tsx
@@ -126,6 +126,12 @@ const AssignedStoryTranslationsTable = ({
   };
 
   const getRole = (translation: StoryTranslation) => {
+    if (
+      userId === translation.translatorId &&
+      userId === translation.reviewerId
+    ) {
+      return "Translator, Reviewer";
+    }
     if (userId === translation.translatorId) {
       return "Translator";
     }


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->



<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- in user profile's assigned story translations table, show both translator and reviewer role if user is translating and reviewing the story

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test
1. Login as admin; upgrade Dwight D Eisenhower to be able to review Level 4 English (UK) translations
2. Login as Dwight; confirm Dwight is currently a translator on Pride and Prejudice English(UK)
3. Navigate to Browse Stories tab, select Reviewer, English(UK), Level 4; click Review on Pride and Prejudice; Confirm that you were successfully assigned as reviewer
4. View Dwight's user profile; verify that the table shows `Translator, Reviewer`

![image](https://user-images.githubusercontent.com/32009013/154513663-f6d76a3e-8657-4d9a-8907-f7bbce07db00.png)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- any other places where changes are necessary?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
