### PR TITLE
Make sign up form shorter

### DIFF
--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -70,7 +70,7 @@ const LoginForm = ({
     <Flex direction="column">
       {isSignup && (
         <Flex direction="column">
-          <FormControl isRequired marginTop="30px">
+          <FormControl isRequired marginTop="15px">
             <FormLabel htmlFor="first-name">First name</FormLabel>
             <Input
               id="first-name"
@@ -81,7 +81,7 @@ const LoginForm = ({
               placeholder="Enter first name"
             />
           </FormControl>
-          <FormControl isRequired marginTop="30px">
+          <FormControl isRequired marginTop="15px">
             <FormLabel htmlFor="last-name">Last name</FormLabel>
             <Input
               id="last-name"
@@ -94,7 +94,7 @@ const LoginForm = ({
           </FormControl>
         </Flex>
       )}
-      <FormControl isRequired={isSignup} marginTop="30px">
+      <FormControl isRequired={isSignup} marginTop="15px">
         <FormLabel htmlFor="email" color={invalidLogin ? "red" : "black"}>
           Email Address
         </FormLabel>
@@ -112,11 +112,11 @@ const LoginForm = ({
           <InfoAlert
             message={SIGN_UP_INVALID_EMAIL_ALERT}
             colour="orange.50"
-            height="55px"
+            height="40px"
           />
         )}
       </FormControl>
-      <FormControl isRequired={isSignup} marginTop="30px">
+      <FormControl isRequired={isSignup} marginTop="15px">
         <FormLabel htmlFor="password" color={invalidLogin ? "red" : "black"}>
           {isSignup ? "Create Password" : "Password"}
         </FormLabel>
@@ -153,7 +153,7 @@ const LoginForm = ({
         )}
       </FormControl>
       {isSignup && (
-        <FormControl isRequired marginTop="30px">
+        <FormControl isRequired marginTop="15px">
           <FormLabel>
             <Checkbox
               defaultChecked={agreeToTerms}

--- a/frontend/src/components/auth/LoginImage.tsx
+++ b/frontend/src/components/auth/LoginImage.tsx
@@ -5,7 +5,7 @@ import LoginBackgroundImage from "../../assets/login-background-image.png";
 
 const LoginImage = () => {
   return (
-    <Box background="gray.100" width="40vw" height="100vh">
+    <Box background="gray.100" width="40vw" minHeight="100vh">
       <Flex direction="column" height="100%">
         <Flex margin="40px">
           <Image width="80px" src={Logo} alt="PlanetRead logo" />


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket](https://www.notion.so/uwblueprintexecs/a658c933d18c48d4b43fd99bda2bd3b4?v=ba22ac93d09040ff8219c60ac7caabdb&p=2e15fddc0d9e4db9a3f17025fd5e3871)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Change margins of fields in signup page

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to sign up page, see if the form is short enough

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- :3

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
