### PR TITLE
Fix broken tab links

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Add My Language is a volunteer-driven activity where people help us in making stories in their native languages."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/planet-read-logo.ico" />
     <!--

--- a/frontend/src/components/navigation/Header.tsx
+++ b/frontend/src/components/navigation/Header.tsx
@@ -62,7 +62,7 @@ const Header = ({ title, adminPageOption }: HeaderProps) => {
     AdminPageOptionToStr.map((adminPageOp: AdminPageOptionPair) => (
       <Button
         onClick={() => {
-          window.location.href = `/#/?tab=${adminPageOp.op}`;
+          window.location.href = `#/?tab=${adminPageOp.op}`;
         }}
         variant={adminPageOption === adminPageOp.op ? "headerSelect" : "header"}
       >

--- a/frontend/src/components/pages/AdminPage.tsx
+++ b/frontend/src/components/pages/AdminPage.tsx
@@ -24,7 +24,7 @@ const AdminPage = () => {
 
   const adminPageOption = getPageOptionFromURL();
   if (adminPageOption === -1) {
-    window.location.href = "/";
+    window.location.href = "#/";
   }
   const bodyComponent = (adminPgOption: AdminPageOption) => {
     switch (adminPgOption) {

--- a/frontend/src/components/pages/HomePage.tsx
+++ b/frontend/src/components/pages/HomePage.tsx
@@ -78,7 +78,7 @@ const HomePage = () => {
   useEffect(() => {
     const index = getPageOptionFromURL();
     if (index === -1) {
-      window.location.href = "/";
+      window.location.href = "#/";
     } else {
       setPageOption(index);
     }
@@ -116,7 +116,7 @@ const HomePage = () => {
     } else if (nextOption === "My Tests") {
       newIndex = 2;
     }
-    window.location.href = `/#/?tab=${newIndex}`;
+    window.location.href = `#/?tab=${newIndex}`;
   };
 
   const query = buildHomePageStoriesQuery(
@@ -228,7 +228,7 @@ const HomePage = () => {
         isOpen={welcomeModalToggle}
         onClose={() => {
           setWelcomeModalToggle(false);
-          window.location.href = "/";
+          window.location.href = "#/";
         }}
       />
     </Box>

--- a/frontend/src/components/pages/ManageStoryPage.tsx
+++ b/frontend/src/components/pages/ManageStoryPage.tsx
@@ -131,7 +131,7 @@ const ManageStoryPage = () => {
           id: parseInt(storyIdParam, 10),
         },
       });
-      window.location.href = "/#/?tab=1";
+      window.location.href = "#/?tab=1";
     } catch (error) {
       // eslint-disable-next-line no-alert
       window.alert(`Error occurred, please try again. Error: ${error}`);


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- fixes some tab links that were broken on prod->previously for tabs they would redirect the user to https://www.planetread.org/#/?tab=0 rather than https://www.planetread.org/aml_platform/#/?tab=0

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Go to [the prod site](https://www.planetread.org/aml_platform)
2. Login as admin; click around on the tabs and verify that they redirect you as expected
3. Login as a regular user; click around on the tabs and verify that they redirect you as expected

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- any other places to change?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
