### PR TITLE
Admin/sort translations

### DIFF
--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -64,10 +64,10 @@ def resolve_export_story_translation(root, info, id):
 
 @require_authorization_by_role_gql({"Admin"})
 def resolve_story_translations(
-    root, info, language, level, stage, story_title, story_id
+    root, info, language, level, stage, story_title, story_id, last_activity_ascending
 ):
     return services["story"].get_story_translations(
-        language, level, stage, story_title, story_id
+        language, level, stage, story_title, story_id, last_activity_ascending
     )
 
 

--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -67,7 +67,7 @@ def resolve_story_translations(
     root, info, language, level, stage, story_title, story_id, last_activity_ascending
 ):
     return services["story"].get_story_translations(
-        language, level, stage, story_title, story_id, True
+        language, level, stage, story_title, story_id, last_activity_ascending=last_activity_ascending
     )
 
 

--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -67,7 +67,12 @@ def resolve_story_translations(
     root, info, language, level, stage, story_title, story_id, last_activity_ascending
 ):
     return services["story"].get_story_translations(
-        language, level, stage, story_title, story_id, last_activity_ascending=last_activity_ascending
+        language,
+        level,
+        stage,
+        story_title,
+        story_id,
+        last_activity_ascending=last_activity_ascending,
     )
 
 

--- a/backend/python/app/graphql/queries/story_query.py
+++ b/backend/python/app/graphql/queries/story_query.py
@@ -67,7 +67,7 @@ def resolve_story_translations(
     root, info, language, level, stage, story_title, story_id, last_activity_ascending
 ):
     return services["story"].get_story_translations(
-        language, level, stage, story_title, story_id, last_activity_ascending
+        language, level, stage, story_title, story_id, True
     )
 
 

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -120,6 +120,7 @@ class Query(graphene.ObjectType):
         stage=graphene.String(),
         story_title=graphene.String(),
         story_id=graphene.Int(),
+        last_activity_ascending=graphene.Boolean(),
     )
     story_translation_tests = graphene.Field(
         graphene.List(StoryTranslationTestResponseDTO),

--- a/backend/python/app/graphql/schema.py
+++ b/backend/python/app/graphql/schema.py
@@ -227,10 +227,18 @@ class Query(graphene.ObjectType):
         stage=None,
         story_title=None,
         story_id=None,
+        last_activity_ascending=None,
         **kwargs
     ):
         return resolve_story_translations(
-            root, info, language, level, stage, story_title, story_id
+            root,
+            info,
+            language,
+            level,
+            stage,
+            story_title,
+            story_id,
+            last_activity_ascending,
         )
 
     def resolve_story_translation_tests(

--- a/backend/python/app/models/story_translation_all.py
+++ b/backend/python/app/models/story_translation_all.py
@@ -41,12 +41,8 @@ class StoryTranslationAll(db.Model):
         return formatted
 
     @hybrid_property
-    def get_last_activity(self):
+    def last_activity(self):
         return func.greatest(
-            func.coalesce(
-                self.translator_last_activity, 0
-            ),
-            func.coalesce(
-                self.reviewer_last_activity, 0
-            ),
+            func.coalesce(self.translator_last_activity, 0),
+            func.coalesce(self.reviewer_last_activity, 0),
         )

--- a/backend/python/app/models/story_translation_all.py
+++ b/backend/python/app/models/story_translation_all.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Boolean, DateTime, Float, inspect
+from sqlalchemy import Boolean, DateTime, Float, func, inspect
 from sqlalchemy.dialects.mysql import TEXT
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm.properties import ColumnProperty
 
 from . import db
@@ -38,3 +39,14 @@ class StoryTranslationAll(db.Model):
             elif include_relationships:
                 formatted[field] = [obj.to_dict() for obj in attr]
         return formatted
+
+    @hybrid_property
+    def get_last_activity(self):
+        return func.greatest(
+            func.coalesce(
+                self.translator_last_activity, 0
+            ),
+            func.coalesce(
+                self.reviewer_last_activity, 0
+            ),
+        )

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -295,6 +295,7 @@ class StoryService(IStoryService):
         role_filter=None,
         last_activity_ascending=None,
     ):
+        raise Exception(last_activity_ascending)
         try:
             filters = [
                 StoryTranslation.is_test == False,
@@ -360,7 +361,7 @@ class StoryService(IStoryService):
                             func.coalesce(
                                 StoryTranslationAll.reviewer_last_activity, 0
                             ),
-                        ).asc()
+                        ).desc()
                         if last_activity_ascending
                         else func.greatest(
                             func.coalesce(

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import docx
 from docx.enum.style import WD_STYLE_TYPE
 from flask import current_app
-from sqlalchemy import func, or_
+from sqlalchemy import or_
 from sqlalchemy.orm import aliased
 from werkzeug.utils import secure_filename
 
@@ -353,23 +353,9 @@ class StoryService(IStoryService):
                     Story.id
                     if last_activity_ascending is None
                     else (
-                        func.greatest(
-                            func.coalesce(
-                                StoryTranslationAll.translator_last_activity, 0
-                            ),
-                            func.coalesce(
-                                StoryTranslationAll.reviewer_last_activity, 0
-                            ),
-                        ).asc()
+                        StoryTranslationAll.get_last_activity.asc()
                         if last_activity_ascending
-                        else func.greatest(
-                            func.coalesce(
-                                StoryTranslationAll.translator_last_activity, 0
-                            ),
-                            func.coalesce(
-                                StoryTranslationAll.reviewer_last_activity, 0
-                            ),
-                        ).desc()
+                        else StoryTranslationAll.get_last_activity.desc()
                     )
                 )
                 .all()

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -295,7 +295,6 @@ class StoryService(IStoryService):
         role_filter=None,
         last_activity_ascending=None,
     ):
-        raise Exception(last_activity_ascending)
         try:
             filters = [
                 StoryTranslation.is_test == False,
@@ -361,7 +360,7 @@ class StoryService(IStoryService):
                             func.coalesce(
                                 StoryTranslationAll.reviewer_last_activity, 0
                             ),
-                        ).desc()
+                        ).asc()
                         if last_activity_ascending
                         else func.greatest(
                             func.coalesce(

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -353,9 +353,9 @@ class StoryService(IStoryService):
                     Story.id
                     if last_activity_ascending is None
                     else (
-                        StoryTranslationAll.get_last_activity.asc()
+                        StoryTranslationAll.last_activity.asc()
                         if last_activity_ascending
-                        else StoryTranslationAll.get_last_activity.desc()
+                        else StoryTranslationAll.last_activity.desc()
                     )
                 )
                 .all()

--- a/backend/python/app/services/interfaces/story_service.py
+++ b/backend/python/app/services/interfaces/story_service.py
@@ -86,7 +86,14 @@ class IStoryService(ABC):
 
     @abstractmethod
     def get_story_translations(
-        self, language, level, stage, story_title, story_id, role_filter
+        self,
+        language,
+        level,
+        stage,
+        story_title,
+        story_id,
+        role_filter,
+        last_activity_ascending,
     ):
         """Return a list of story translations based on filters
 
@@ -97,6 +104,7 @@ class IStoryService(ABC):
         likeness and return
         :param story_id: story_id of story translation to filter by
         :param role_filter: filter to get story_translations by user_id/role
+        :param last_activity_ascending: whether or not story translations are sorted by last activity
         :return: list of StoryTranslationNode's
         :rtype: list of StoryTranslationNode's
         """

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -276,12 +276,16 @@ export const buildStoryTranslationsQuery = (
   level?: number,
   stage?: string,
   storyTitle?: string,
+  lastActivityAscending?: boolean,
 ) => {
   let queryParams = language ? `language: "${language}", ` : "";
   queryParams += level ? `level: ${level}, ` : "";
   queryParams += stage ? `stage: "${stage}", ` : "";
   queryParams += storyTitle ? `storyTitle: "${storyTitle}", ` : "";
   queryParams += storyId ? `storyId: ${storyId}, ` : "";
+  queryParams += lastActivityAscending
+    ? `lastActivityAscending: "${lastActivityAscending}", `
+    : "";
 
   return {
     fieldName: "storyTranslations",

--- a/frontend/src/APIClients/queries/StoryQueries.ts
+++ b/frontend/src/APIClients/queries/StoryQueries.ts
@@ -283,9 +283,11 @@ export const buildStoryTranslationsQuery = (
   queryParams += stage ? `stage: "${stage}", ` : "";
   queryParams += storyTitle ? `storyTitle: "${storyTitle}", ` : "";
   queryParams += storyId ? `storyId: ${storyId}, ` : "";
-  queryParams += lastActivityAscending
-    ? `lastActivityAscending: "${lastActivityAscending}", `
-    : "";
+  queryParams +=
+    typeof lastActivityAscending !== "undefined" &&
+    lastActivityAscending !== null
+      ? `lastActivityAscending: ${lastActivityAscending}, `
+      : "";
 
   return {
     fieldName: "storyTranslations",

--- a/frontend/src/components/admin/ManageStoryTranslations.tsx
+++ b/frontend/src/components/admin/ManageStoryTranslations.tsx
@@ -36,7 +36,7 @@ const ManageStoryTranslations = () => {
     parseInt(level || "", 10) || 0,
     convertTitleCaseToStage(stage || ""),
     searchText || "",
-    true, // This causes problem
+    true,
   );
 
   const { loading, pageResults, paginator } = usePagination<StoryTranslation>(

--- a/frontend/src/components/admin/ManageStoryTranslations.tsx
+++ b/frontend/src/components/admin/ManageStoryTranslations.tsx
@@ -36,6 +36,7 @@ const ManageStoryTranslations = () => {
     parseInt(level || "", 10) || 0,
     convertTitleCaseToStage(stage || ""),
     searchText || "",
+    true, // This causes problem
   );
 
   const { loading, pageResults, paginator } = usePagination<StoryTranslation>(

--- a/frontend/src/components/admin/ManageStoryTranslations.tsx
+++ b/frontend/src/components/admin/ManageStoryTranslations.tsx
@@ -29,6 +29,7 @@ const ManageStoryTranslations = () => {
   const [numTranslationsCompleted, setNumTranslationsCompleted] = useState(0);
   const [isAddNewLanguageModalOpen, setIsAddNewLanguageModalOpen] =
     useState(false);
+  const [isAscendingLastEdited, setIsAscendingLastEdited] = useState(false);
 
   const query = buildStoryTranslationsQuery(
     0,
@@ -36,7 +37,7 @@ const ManageStoryTranslations = () => {
     parseInt(level || "", 10) || 0,
     convertTitleCaseToStage(stage || ""),
     searchText || "",
-    true,
+    isAscendingLastEdited,
   );
 
   const { loading, pageResults, paginator } = usePagination<StoryTranslation>(
@@ -124,6 +125,7 @@ const ManageStoryTranslations = () => {
           storyTranslationSlice={pageResults}
           paginator={paginator}
           filters={[setLanguage, setLevel, setStage, setSearchText]}
+          setQueryIsAscendingLastEdited={setIsAscendingLastEdited}
         />
       </Box>
       <AddLanguageModal

--- a/frontend/src/components/admin/StoryTranslationsTable.tsx
+++ b/frontend/src/components/admin/StoryTranslationsTable.tsx
@@ -45,6 +45,7 @@ export type StoryTranslationsTableProps = {
   filters: { (data: string | null): void }[];
   loading: Boolean;
   width?: string;
+  setQueryIsAscendingLastEdited?: Dispatch<SetStateAction<boolean>>;
 };
 
 interface StoryTranslationFieldSortDict {
@@ -61,8 +62,9 @@ const StoryTranslationsTable = ({
   filters,
   loading,
   width = "95%",
+  setQueryIsAscendingLastEdited,
 }: StoryTranslationsTableProps) => {
-  const [isAscendingLastEdited, setIsAscendingLastEdited] = useState(true);
+  const [isAscendingLastEdited, setIsAscendingLastEdited] = useState(false);
   const [confirmDeleteTranslation, setConfirmDeleteTranslation] =
     useState(false);
   const [idToDelete, setIdToDelete] = useState(0);
@@ -149,6 +151,13 @@ const StoryTranslationsTable = ({
     setIsAscending(!isAscending);
     newStoryTranslations.sort(sortFn);
     setStoryTranslations(newStoryTranslations);
+  };
+
+  const sortQuery = () => {
+    if (setQueryIsAscendingLastEdited) {
+      setQueryIsAscendingLastEdited(!isAscendingLastEdited);
+      setIsAscendingLastEdited(!isAscendingLastEdited);
+    }
   };
 
   const tableBody = storyTranslations.map(
@@ -246,7 +255,11 @@ const StoryTranslationsTable = ({
           <Th>REVIEWER</Th>
           <Th
             cursor="pointer"
-            onClick={() => sort("lastEditedDate")}
+            onClick={
+              setQueryIsAscendingLastEdited
+                ? sortQuery
+                : () => sort("lastEditedDate")
+            }
           >{`LAST EDITED ${isAscendingLastEdited ? "↑" : "↓"}`}</Th>
           <Th>EXPORT</Th>
           <Th>ACTION</Th>


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Sort by last edited time in stories backend](https://www.notion.so/uwblueprintexecs/Sort-by-last-edited-time-in-stories-backend-58725e379bf3463e891e5fb7bece262f)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Added optional `last_activity_ascending` param to `get_story_translations` that sorts the returned story translations by the last activity time (either ascending or descending)
- Added sort function for `StoryTranslationsTable` that runs the query to sort across all story translations

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as a translator and edit some translations, and send them for review (make note of edit order)
2. Login as a reviewer and comment on some translations (make note of edit order)
3. Login as Angela and observe that Manage Story Translations table is sorted by last edited
4. Toggle the last edited sorting and observe that all translations are resorted
5. Add some filters and verify that it continues to work
6. Go to the Manage Stories page and click on a story to get to the Mange Story page
7. Make sure the last edited sorting is still working as it did before

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?
- Does the code look ok?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
