### PR TITLE
Fix/redirect complete profile

### DIFF
--- a/frontend/src/components/homepage/WelcomeModal.tsx
+++ b/frontend/src/components/homepage/WelcomeModal.tsx
@@ -41,7 +41,7 @@ const WelcomeModal = ({
 
   const handleClose = () => {
     onClose();
-    window.location.href = `#/?welcome=true&tab=2`;
+    window.location.href = `#/?tab=2`;
   };
 
   return (

--- a/frontend/src/components/homepage/WelcomeModal.tsx
+++ b/frontend/src/components/homepage/WelcomeModal.tsx
@@ -38,6 +38,12 @@ const WelcomeModal = ({
   readonly = false,
 }: WelcomeModalProps) => {
   const [isAgreed, setIsAgreed] = useState(false);
+
+  const handleClose = () => {
+    onClose();
+    window.location.href = `#/?welcome=true&tab=2`;
+  };
+
   return (
     <Modal
       isCentered
@@ -78,7 +84,7 @@ const WelcomeModal = ({
               <Button
                 colorScheme="blue"
                 isDisabled={!isAgreed}
-                onClick={onClose}
+                onClick={handleClose}
               >
                 Let&apos;s Get Started
               </Button>

--- a/frontend/src/components/pages/CompleteProfilePage.tsx
+++ b/frontend/src/components/pages/CompleteProfilePage.tsx
@@ -54,7 +54,7 @@ const CompleteProfilePage = () => {
           resume,
         },
       });
-      window.location.href = `#/?welcome=true`;
+      window.location.href = `#/?welcome=true&tab=2`;
     } catch (err) {
       // eslint-disable-next-line no-alert
       window.alert(err);


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Redirect user to ‘My Test’ after complete-profile](https://www.notion.so/uwblueprintexecs/Redirect-user-to-My-Test-after-complete-profile-9b9ae1b8da804b539fabf79840750042)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Redirects to `#/?welcome=true&tab=2` after profile completion
- Redirects to `#/?tab=2` after welcome modal is closed (for some reason url parameters are reset after modal is closed)

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Sign up or go directly to http://localhost:3000/#/complete-profile
2. Fill out information and submit for review
3. Observe redirect to http://localhost:3000/#/?welcome=true&tab=2 with welcome modal and tests tab open in background
4. Agree to terms and conditions and click get started
5. Observe redirect to http://localhost:3000/#/?tab=2 with tests tab open

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?
- Is code ok? Please see implementation description

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
