### PR TITLE
Hide ‘Return to translator’ and self-removal link on review platform …

### DIFF
--- a/frontend/src/components/pages/ReviewPage.tsx
+++ b/frontend/src/components/pages/ReviewPage.tsx
@@ -247,8 +247,8 @@ const ReviewPage = () => {
                 fontSize={fontSize}
               />
             </Flex>
-            <Flex>
-              {+authenticatedUser!.id === reviewerId && (
+            {+authenticatedUser!.id === reviewerId && (
+              <Flex>
                 <Text
                   as="u"
                   margin="5px 20px 0 0"
@@ -257,32 +257,32 @@ const ReviewPage = () => {
                 >
                   Remove myself from translation
                 </Text>
-              )}
-              <Tooltip
-                hasArrow
-                label={REVIEW_PAGE_TOOL_TIP_COPY}
-                isDisabled={!isDisabled}
-              >
-                <Box>
-                  <Button
-                    colorScheme="blue"
-                    size="secondary"
-                    margin="0 10px 0"
-                    width="250px"
-                    disabled={isDisabled}
-                    onClick={
-                      numApprovedLines === translatedStoryLines.length
-                        ? openSubmitTranslationModal
-                        : openReturnToTranslatorModal
-                    }
-                  >
-                    {numApprovedLines === translatedStoryLines.length
-                      ? "FINISH TRANSLATION"
-                      : "RETURN TO TRANSLATOR"}
-                  </Button>
-                </Box>
-              </Tooltip>
-            </Flex>
+                <Tooltip
+                  hasArrow
+                  label={REVIEW_PAGE_TOOL_TIP_COPY}
+                  isDisabled={!isDisabled}
+                >
+                  <Box>
+                    <Button
+                      colorScheme="blue"
+                      size="secondary"
+                      margin="0 10px 0"
+                      width="250px"
+                      disabled={isDisabled}
+                      onClick={
+                        numApprovedLines === translatedStoryLines.length
+                          ? openSubmitTranslationModal
+                          : openReturnToTranslatorModal
+                      }
+                    >
+                      {numApprovedLines === translatedStoryLines.length
+                        ? "FINISH TRANSLATION"
+                        : "RETURN TO TRANSLATOR"}
+                    </Button>
+                  </Box>
+                </Tooltip>
+              </Flex>
+            )}
           </Flex>
         </Flex>
         {(+authenticatedUser!.id === translatorId ||


### PR DESCRIPTION
…for Admin

## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Hide ‘Return to translator’ and self-removal link on review platform for Admin](https://www.notion.so/uwblueprintexecs/Hide-Return-to-translator-and-self-removal-link-on-review-platform-for-Admin-390eb014cd4e4bb1bf568e2dae607f1a)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Hide ‘Return to translator’ and self-removal link if user is not reviewer

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Angela
2. Go to a story translation where not reviewer
3. Observe that ‘Return to translator’ and self-removal link are hidden
4. Click on Angela Merkel's name in the Manage Story Translations table or go to http://localhost:3000/#/user/6
5. Assign her as a reviewer on a translation
6. Go to the translation where reviewer
7. Observe that ‘Return to translator’ and self-removal link are shown

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
