### PR TITLE
Fix/duplicate story title

### DIFF
--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -108,9 +108,7 @@ class StoryService(IStoryService):
     def import_story(self, details, file):
         try:
             matching_story_title = (
-                db.session.query(Story)
-                .filter(Story.title == details.title)
-                .first()
+                db.session.query(Story).filter(Story.title == details.title).first()
             )
             if matching_story_title is not None:
                 raise Exception("Story title already exists")

--- a/backend/python/app/services/implementations/story_service.py
+++ b/backend/python/app/services/implementations/story_service.py
@@ -107,6 +107,14 @@ class StoryService(IStoryService):
 
     def import_story(self, details, file):
         try:
+            matching_story_title = (
+                db.session.query(Story)
+                .filter(Story.title == details.title)
+                .first()
+            )
+            if matching_story_title is not None:
+                raise Exception("Story title already exists")
+
             story_contents = self.process_story(file["path"])
             return self.create_story(details, story_contents)
 

--- a/frontend/src/components/pages/ImportStoryPage.tsx
+++ b/frontend/src/components/pages/ImportStoryPage.tsx
@@ -118,27 +118,32 @@ const ImportStoryPage = () => {
   };
 
   const submitForm = async () => {
-    if (!(storyFile && title && description && level && youtubeLink)) {
-      // eslint-disable-next-line no-alert
-      window.alert("Please fill out all required fields.");
-      return;
-    }
+    try {
+      if (!(storyFile && title && description && level && youtubeLink)) {
+        // eslint-disable-next-line no-alert
+        window.alert("Please fill out all required fields.");
+        return;
+      }
 
-    const result = await importStory({
-      variables: {
-        storyFile,
-        storyDetails: {
-          title,
-          description,
-          youtubeLink,
-          level,
-          translatedLanguages: excludedLanguages,
+      const result = await importStory({
+        variables: {
+          storyFile,
+          storyDetails: {
+            title,
+            description,
+            youtubeLink,
+            level,
+            translatedLanguages: excludedLanguages,
+          },
         },
-      },
-    });
-    if (result.data) {
-      const storyId = result.data.importStory.story.id;
-      history.push(`/story/${storyId}`);
+      });
+      if (result.data) {
+        const storyId = result.data.importStory.story.id;
+        history.push(`/story/${storyId}`);
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-alert
+      window.alert(error ?? "Error occurred, please try again.");
     }
   };
 


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Throw error if import story has duplicate story name](https://www.notion.so/uwblueprintexecs/Throw-error-if-import-story-has-duplicate-story-name-f49a1a5e653b4b689c62a564395e427d)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- In `import_story` service, if any stories have matching titles, raise exception

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Login as Angela
2. Go to import a story or http://localhost:3000/#/import-story
3. Fill out form and set title to existing story, e.g. East of Eden
4. Click on import story
5. Observe error in console: `[GraphQL error]: Message: Story title already exists, Location: [object Object], Path: importStory`
6. Set title to new story, e.g. South of Eden
7. Click on import story
8. Observe successful import

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does it work?
- Does implementation make sense?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
