### PR TITLE
Fix Prod Email Password Reset

### DIFF
--- a/backend/python/app/graphql/__init__.py
+++ b/backend/python/app/graphql/__init__.py
@@ -38,7 +38,7 @@ def init_app(app):
             "client_id": os.getenv("EMAIL_CLIENT_ID"),
             "client_secret": os.getenv("EMAIL_CLIENT_SECRET"),
         },
-        "planetread@uwblueprint.org",  # must replace
-        "Planet Read",  # must replace
+        os.getenv("EMAIL_USER"),
+        "Add My Language",
     )
     services["auth"] = AuthService(current_app.logger, services["user"], email_service)


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Ticket Name](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- set sender email via environment variable `EMAIL_USER`
- change email display name to `Add My Language`
![image](https://user-images.githubusercontent.com/32009013/167515596-8a9edfde-94de-4b81-853e-f5ef5102222c.png)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Test password reset in prod
2. Does it work?

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- i haven't added the value in the vault yet!

## Checklist

- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] For backend changes, I have run the appropriate linters: `docker exec -it planet-read_py-backend_1 /bin/bash -c "black . && isort --profile black ."` and I have generated new migrations: `flask db migrate -m "<your message>"`
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
